### PR TITLE
19 - Tests coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,7 @@ jobs:
       - name: Install Dependencies
         run: npm install
 
-      - name: Test
-        run: npm run test:no-watch
-
-      - name: Check coverage
+      - name: Run tests & check coverage
         run: npm run test:coverage
 
   e2e:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Run tests & check coverage
         run: npm run test:coverage
 
+      - name: Upload coverage report to Coveralls
+        if: always()
+        uses: coverallsapp/github-action@v2.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
   e2e:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Upload coverage report to Coveralls
         if: always()
-        uses: coverallsapp/github-action@v2.0.0
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,10 @@ jobs:
 
       - name: Test
         run: npm run test:no-watch
+
+      - name: Check coverage
+        run: npm run test:coverage
+
   e2e:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Project Status: WIP – Initial development is in progress, but there has not yet been a stable, usable release suitable for the public.](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 [![Tests](https://github.com/IQSS/dataverse-frontend/actions/workflows/test.yml/badge.svg)](https://github.com/IQSS/dataverse-frontend/actions/workflows/test.yml)
+[![Unit Tests Coverage](https://coveralls.io/repos/github/IQSS/dataverse-frontend/badge.svg?branch=develop)](https://coveralls.io/github/IQSS/dataverse-frontend?branch=develop)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -55,3 +55,9 @@ Launches the prettier formatter. We recommend you to configure your IDE to run p
 
 Runs the Storybook in the development mode.  
 Open [http://localhost:6006](http://localhost:6006) to view it in your browser.
+
+## Changes in the style guide
+
+### Links
+
+We added the underline to the links to make them accessible.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "pre-commit": [
     "lint:fix",
-    "test:no-watch",
+    "test:coverage",
     "git:add"
   ],
   "eslintConfig": {

--- a/src/assets/styles/_bootstrap-customized.scss
+++ b/src/assets/styles/_bootstrap-customized.scss
@@ -7,7 +7,6 @@ $body-color: #333;
 $font-family-base: ("Helvetica Neue",helvetica,arial,sans-serif);
 
 $link-color: #3174AF;
-$link-decoration: none;
 $link-hover-color: #23527c;
 $link-hover-decoration: underline;
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,10 +3,16 @@ import { initReactI18next } from 'react-i18next'
 import I18nextBrowserLanguageDetector from 'i18next-browser-languagedetector'
 import I18NextHttpBackend from 'i18next-http-backend'
 
+declare module 'i18next' {
+  interface CustomTypeOptions {
+    returnNull: false
+  }
+}
+
 void i18next
   .use(initReactI18next)
   .use(I18nextBrowserLanguageDetector)
   .use(I18NextHttpBackend)
-  .init({ fallbackLng: 'en', supportedLngs: ['en'], ns: [] })
+  .init({ fallbackLng: 'en', supportedLngs: ['en'], ns: [], returnNull: false })
 
 export default i18next

--- a/src/sections/hello-dataverse/HelloDataverse.tsx
+++ b/src/sections/hello-dataverse/HelloDataverse.tsx
@@ -8,7 +8,7 @@ export function HelloDataverse() {
   return (
     <section className={styles.container}>
       <h2 className={styles.title}>{t('title')}</h2>
-      <img src={logo} className={styles.logo} alt={t('altImage') ?? 'logo'} />
+      <img src={logo} className={styles.logo} alt={t('altImage')} />
       <p>
         <Trans t={t} i18nKey="description" components={{ 1: <code /> }} />
       </p>

--- a/src/sections/ui/navbar/Navbar.tsx
+++ b/src/sections/ui/navbar/Navbar.tsx
@@ -10,7 +10,7 @@ export function Navbar({ brand, links }: NavbarProps) {
     <NavbarBS collapseOnSelect expand="lg" fixed="top">
       <Container>
         <NavbarBS.Brand href={brand.path}>
-          <img width="28" height="28" src={brand.logo.src} alt={brand.logo.altText ?? 'logo'} />
+          <img width="28" height="28" src={brand.logo.src} alt={brand.logo.altText} />
           {brand.title}
         </NavbarBS.Brand>
         <NavbarBS.Toggle aria-controls="responsive-navbar-nav" />

--- a/src/sections/ui/navbar/NavbarProps.ts
+++ b/src/sections/ui/navbar/NavbarProps.ts
@@ -5,7 +5,7 @@ export interface Link {
 
 interface Logo {
   src: string
-  altText: string | null
+  altText: string
 }
 
 interface Brand {

--- a/tests/sections/layout/header/Header.test.tsx
+++ b/tests/sections/layout/header/Header.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { Header } from '../../../../src/sections/layout/header/Header'
+
+describe('Header component', () => {
+  test('displays the user name when the user is logged in', () => {
+    const user = { name: 'John Doe' }
+    const { getByText } = render(<Header user={user} />)
+
+    const userNameElement = getByText('John Doe')
+    expect(userNameElement).toBeInTheDocument()
+  })
+
+  test('displays the Sign Up and Log In links when the user is not logged in', () => {
+    const { getByRole } = render(<Header />)
+
+    const signUpLinkElement = getByRole('link', { name: 'signUp' })
+    expect(signUpLinkElement).toBeInTheDocument()
+
+    const logInLinkElement = getByRole('link', { name: 'logIn' })
+    expect(logInLinkElement).toBeInTheDocument()
+  })
+})

--- a/tests/sections/layout/header/Header.test.tsx
+++ b/tests/sections/layout/header/Header.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import { Header } from '../../../../src/sections/layout/header/Header'
 
 describe('Header component', () => {

--- a/tests/sections/ui/navbar/Navbar.test.tsx
+++ b/tests/sections/ui/navbar/Navbar.test.tsx
@@ -43,17 +43,17 @@ describe('Navbar component', () => {
     expect(dropdownElement).toBeInTheDocument()
   })
 
-  test('shows the sublinks when the dropdown is clicked', () => {
-    const { getByRole } = render(<Navbar brand={brand} links={links} />)
+  test('shows the sublinks when the dropdown is clicked', async () => {
+    const { getByRole, findByRole } = render(<Navbar brand={brand} links={links} />)
 
     const dropdownElement = getByRole('button', { name: 'Dropdown' })
 
     fireEvent.click(dropdownElement)
 
-    const sublink1Element = getByRole('link', { name: 'Sublink 1' })
+    const sublink1Element = await findByRole('link', { name: 'Sublink 1' })
     expect(sublink1Element).toBeInTheDocument()
 
-    const sublink2Element = getByRole('link', { name: 'Sublink 2' })
+    const sublink2Element = await findByRole('link', { name: 'Sublink 2' })
     expect(sublink2Element).toBeInTheDocument()
   })
 })

--- a/tests/sections/ui/navbar/Navbar.test.tsx
+++ b/tests/sections/ui/navbar/Navbar.test.tsx
@@ -1,0 +1,59 @@
+import { render, fireEvent } from '@testing-library/react'
+import { Navbar } from '../../../../src/sections/ui/navbar/Navbar'
+
+const brand = {
+  logo: { src: 'logo.png', altText: 'Logo Alt Text' },
+  title: 'Brand Title',
+  path: '/home'
+}
+
+const links = [
+  { title: 'Link 1', value: '/link1' },
+  { title: 'Link 2', value: '/link2' },
+  {
+    title: 'Dropdown',
+    value: [
+      { title: 'Sublink 1', value: '/sublink1' },
+      { title: 'Sublink 2', value: '/sublink2' }
+    ]
+  }
+]
+
+describe('Navbar component', () => {
+  test('renders the brand logo and title', () => {
+    const { getByRole } = render(<Navbar brand={brand} links={[]} />)
+
+    const logoImage = getByRole('img', { name: 'Logo Alt Text' })
+    expect(logoImage).toBeInTheDocument()
+
+    const brandElement = getByRole('link', { name: 'Logo Alt Text Brand Title' })
+    expect(brandElement).toBeInTheDocument()
+  })
+
+  test('renders the navbar links', () => {
+    const { getByRole } = render(<Navbar brand={brand} links={links} />)
+
+    const link1Element = getByRole('link', { name: 'Link 1' })
+    expect(link1Element).toBeInTheDocument()
+
+    const link2Element = getByRole('link', { name: 'Link 2' })
+    expect(link2Element).toBeInTheDocument()
+
+    const dropdownElement = getByRole('button', { name: 'Dropdown' })
+    expect(dropdownElement).toBeInTheDocument()
+  })
+
+  test('shows the sublinks when the dropdown is clicked', () => {
+    const { getByRole } = render(<Navbar brand={brand} links={links} />)
+
+    const dropdownElement = getByRole('button', { name: 'Dropdown' })
+
+    fireEvent.click(dropdownElement)
+
+    const sublink1Element = getByRole('link', { name: 'Sublink 1' })
+    expect(sublink1Element).toBeInTheDocument()
+
+    const sublink2Element = getByRole('link', { name: 'Sublink 2' })
+    expect(sublink2Element).toBeInTheDocument()
+  })
+})

--- a/tests/sections/ui/navbar/nav-dropdown/NavDropdown.test.tsx
+++ b/tests/sections/ui/navbar/nav-dropdown/NavDropdown.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { NavDropdown } from '../../../../../src/sections/ui/navbar/nav-dropdown/NavDropdown'
+
+const links = [
+  { title: 'Link 1', value: '/link1' },
+  { title: 'Link 2', value: '/link2' },
+  {
+    title: 'Link 3',
+    value: [
+      { title: 'Sublink 1', value: '/sublink1' },
+      { title: 'Sublink 2', value: '/sublink2' }
+    ]
+  }
+]
+
+describe('NavDropdown component', () => {
+  test('renders the dropdown title', () => {
+    const { getByRole } = render(<NavDropdown title="Dropdown Title" links={links} />)
+
+    const titleElement = getByRole('button', { name: 'Dropdown Title' })
+    expect(titleElement).toBeInTheDocument()
+  })
+
+  test('renders the dropdown links', () => {
+    const { getByRole } = render(<NavDropdown title="Dropdown Title" links={links} />)
+
+    const dropdownTitle = getByRole('button', { name: 'Dropdown Title' })
+    fireEvent.click(dropdownTitle)
+
+    const link1Element = getByRole('link', { name: 'Link 1' })
+    expect(link1Element).toBeInTheDocument()
+
+    const link2Element = getByRole('link', { name: 'Link 2' })
+    expect(link2Element).toBeInTheDocument()
+
+    const link3Element = getByRole('button', { name: 'Link 3' })
+    expect(link3Element).toBeInTheDocument()
+
+    fireEvent.click(link3Element)
+
+    const sublink1Element = getByRole('link', { name: 'Sublink 1' })
+    expect(sublink1Element).toBeInTheDocument()
+
+    const sublink2Element = getByRole('link', { name: 'Sublink 2' })
+    expect(sublink2Element).toBeInTheDocument()
+  })
+})

--- a/tests/sections/ui/navbar/nav-dropdown/NavDropdown.test.tsx
+++ b/tests/sections/ui/navbar/nav-dropdown/NavDropdown.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { fireEvent, render } from '@testing-library/react'
 import { NavDropdown } from '../../../../../src/sections/ui/navbar/nav-dropdown/NavDropdown'
 
 const links = [

--- a/tests/sections/ui/navbar/nav-dropdown/NavDropdown.test.tsx
+++ b/tests/sections/ui/navbar/nav-dropdown/NavDropdown.test.tsx
@@ -21,27 +21,28 @@ describe('NavDropdown component', () => {
     expect(titleElement).toBeInTheDocument()
   })
 
-  test('renders the dropdown links', () => {
-    const { getByRole } = render(<NavDropdown title="Dropdown Title" links={links} />)
+  test('renders the dropdown links', async () => {
+    const { getByRole, findByRole } = render(<NavDropdown title="Dropdown Title" links={links} />)
 
     const dropdownTitle = getByRole('button', { name: 'Dropdown Title' })
+
     fireEvent.click(dropdownTitle)
 
-    const link1Element = getByRole('link', { name: 'Link 1' })
+    const link1Element = await findByRole('link', { name: 'Link 1' })
     expect(link1Element).toBeInTheDocument()
 
-    const link2Element = getByRole('link', { name: 'Link 2' })
+    const link2Element = await findByRole('link', { name: 'Link 2' })
     expect(link2Element).toBeInTheDocument()
 
-    const link3Element = getByRole('button', { name: 'Link 3' })
+    const link3Element = await findByRole('button', { name: 'Link 3' })
     expect(link3Element).toBeInTheDocument()
 
     fireEvent.click(link3Element)
 
-    const sublink1Element = getByRole('link', { name: 'Sublink 1' })
+    const sublink1Element = await findByRole('link', { name: 'Sublink 1' })
     expect(sublink1Element).toBeInTheDocument()
 
-    const sublink2Element = getByRole('link', { name: 'Sublink 2' })
+    const sublink2Element = await findByRole('link', { name: 'Sublink 2' })
     expect(sublink2Element).toBeInTheDocument()
   })
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     include: ['./tests/**/*.(test).(ts|tsx)'],
     coverage: {
       reporter: ['text', 'html'],
-      exclude: ['node_modules/', 'tests/setupTests.ts']
+      exclude: ['node_modules/', 'tests/'],
+      lines: 95,
+      functions: 95,
+      branches: 95,
+      statements: 95
     }
   }
 })

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     setupFiles: './tests/setupTests.ts',
     include: ['./tests/**/*.(test).(ts|tsx)'],
     coverage: {
-      reporter: ['text', 'html'],
+      reporter: ['lcov'],
       exclude: ['node_modules/', 'tests/'],
       lines: 95,
       functions: 95,


### PR DESCRIPTION
## What this PR does / why we need it:

This PR adds the test coverage check to the Github actions to maintain the unit tests coverage of the repo at 95%, checking it on push. It also adds the missing tests needed to reach this 95% coverage, in fact, with the new tests added we have reached 100% coverage

https://coveralls.io/github/IQSS/dataverse-frontend  

## Which issue(s) this PR closes:

- Closes https://github.com/IQSS/dataverse-frontend/issues/19

## Special notes for your reviewer:

To generate the coverage report I used [c8 with Vitest](https://vitest.dev/guide/coverage.html), because it was really easy to set up, the coverage check can be set in the `vitest.config.ts` file. It generates the report in lcov format which then can be uploaded to [Coveralls](https://coveralls.io) using the [coverallsapp Github action](https://github.com/marketplace/actions/coveralls-github-action)

For the coverage I researched other tools like [Istanbul](https://istanbul.js.org), but it doesn't support ES6 javascript. 

For uploading the coverage report I used Coveralls because it's a powerful tool, there are no major differences with other great tools such as [Codecov](https://about.codecov.io) and it's already been used in the Dataverse repo so I don't see any reason to use a different tool

## Suggestions on how to test this:

Run `npm run test:coverage` to check the coverage of the project

You can run `open coverage/lcov-report/index.html ` to see the report locally in the browser 

You can go to https://coveralls.io/github/IQSS/dataverse-frontend to see the last report upload

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

No

## Is there a release notes update needed for this change?:

Coverage check added to the repo

## Additional documentation:
