### PR TITLE
Feature/create the tables of the design system

### DIFF
--- a/src/sections/ui/assets/styles/bootstrap-customized.scss
+++ b/src/sections/ui/assets/styles/bootstrap-customized.scss
@@ -53,6 +53,9 @@ $link-hover-color: $dv-link-hover-color;
 // Badge
 @import "bootstrap/scss/badge";
 
+// Table
+@import "bootstrap/scss/tables";
+
 // Navbar
 
 $navbar-light-brand-color: $dv-brand-color;

--- a/src/sections/ui/table/Table.module.scss
+++ b/src/sections/ui/table/Table.module.scss
@@ -1,0 +1,3 @@
+.table > thead {
+  text-align: center;
+}

--- a/src/sections/ui/table/Table.tsx
+++ b/src/sections/ui/table/Table.tsx
@@ -1,9 +1,10 @@
 import { PropsWithChildren } from 'react'
 import { Table as TableBS } from 'react-bootstrap'
+import styles from './Table.module.scss'
 
 export function Table({ children }: PropsWithChildren) {
   return (
-    <TableBS striped bordered>
+    <TableBS striped bordered className={styles.table}>
       {children}
     </TableBS>
   )

--- a/src/sections/ui/table/Table.tsx
+++ b/src/sections/ui/table/Table.tsx
@@ -1,0 +1,10 @@
+import { PropsWithChildren } from 'react'
+import { Table as TableBS } from 'react-bootstrap'
+
+export function Table({ children }: PropsWithChildren) {
+  return (
+    <TableBS striped bordered>
+      {children}
+    </TableBS>
+  )
+}

--- a/src/stories/ui/table/Table.stories.tsx
+++ b/src/stories/ui/table/Table.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { Table } from '../../../sections/ui/table/Table'
+
+const meta: Meta<typeof Table> = {
+  title: 'UI/Table',
+  component: Table,
+  tags: ['autodocs']
+}
+
+export default meta
+type Story = StoryObj<typeof Table>
+
+export const Default: Story = {
+  render: () => (
+    <Table>
+      <thead>
+        <tr>
+          <th>Dataset Version</th>
+          <th>Summary</th>
+          <th>Contributors</th>
+          <th>Published On</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1.0</td>
+          <td>This is a dataset summary</td>
+          <td>Mark</td>
+          <td>April 20, 2023</td>
+        </tr>
+        <tr>
+          <td>1.1</td>
+          <td>This is a dataset summary</td>
+          <td>Jacob</td>
+          <td>May 3, 2023</td>
+        </tr>
+        <tr>
+          <td>1.2</td>
+          <td>This is a dataset summary</td>
+          <td>Frank</td>
+          <td>June 4, 2023</td>
+        </tr>
+      </tbody>
+    </Table>
+  )
+}

--- a/src/stories/ui/table/Table.stories.tsx
+++ b/src/stories/ui/table/Table.stories.tsx
@@ -1,6 +1,22 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { Table } from '../../../sections/ui/table/Table'
 
+/**
+ * ## Description
+ * A table is a UI element that displays data in a structured format, typically in rows and columns. Tables can be used
+ * to organize and present large amounts of data in a user-friendly and easily readable format.
+ *
+ * ## Usage guidelines
+ *  This table is not intended to be used for complex data manipulation. It is intended to be used for displaying data
+ *
+ * ### Dos
+ * - Use clear and concise table headings that accurately describe the data being presented
+ * - Use tables to display data that is related to each other
+ * - Use tables to display data that is not easily displayed in a list
+ *
+ * ### Don'ts
+ * - Don't use tables for layout purposes, such as aligning images or text. Use CSS instead.
+ */
 const meta: Meta<typeof Table> = {
   title: 'UI/Table',
   component: Table,

--- a/tests/sections/ui/table/Table.test.tsx
+++ b/tests/sections/ui/table/Table.test.tsx
@@ -1,0 +1,25 @@
+import { render } from '@testing-library/react'
+import { Table } from '../../../../src/sections/ui/table/Table'
+
+describe('Table', () => {
+  it('should render children', () => {
+    const { getByText } = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>Row 1, Column 1</td>
+            <td>Row 1, Column 2</td>
+          </tr>
+          <tr>
+            <td>Row 2, Column 1</td>
+            <td>Row 2, Column 2</td>
+          </tr>
+        </tbody>
+      </Table>
+    )
+    expect(getByText('Row 1, Column 1')).toBeInTheDocument()
+    expect(getByText('Row 1, Column 2')).toBeInTheDocument()
+    expect(getByText('Row 2, Column 1')).toBeInTheDocument()
+    expect(getByText('Row 2, Column 2')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:
This PR add the table element of the design system which is the Bootstrap 5 table with striped rows.

## Which issue(s) this PR closes:

- Closes #34 

## Special notes for your reviewer:
I only included the table to display data with is the one provided by Bootstrap.

There is another table being used in the Dataverse for the files management with contains filtering and search features. I think the data manipulation is out of the scope of this design system table so I didn't included here. The table for the files management could be develop in the [issue for creating the File tab of the Dataset page](https://github.com/IQSS/dataverse-frontend/issues/61) and we could decide then if it makes sense to add it to the design system.

## Suggestions on how to test this:
npm run storybook

Go to the Docs page in the Storybook for the Table element to see it rendered

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
None

## Is there a release notes update needed for this change?:
Table added to the design system

## Additional documentation:
https://docs.google.com/document/d/1OxCQO7B-yJaMWRl8EzuflcSmIaCmVSs19aoD83PjPmA/edit#heading=h.x2qrlcdwtvag