### PR TITLE
Add Beta Testing Environment deployment Github action

### DIFF
--- a/.github/workflows/deploy-beta-testing.yml
+++ b/.github/workflows/deploy-beta-testing.yml
@@ -1,0 +1,98 @@
+name: 'Deploy to Beta Testing'
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: beta-testing
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Create .npmrc
+        run: |
+          cp .npmrc.example .npmrc
+          sed -i -e 's/<YOUR_GITHUB_AUTH_TOKEN>/${{ secrets.GITHUB_TOKEN }}/g' .npmrc
+          sed -i -e 's/<YOUR_NPM_AUTH_TOKEN>/${{ secrets.NPM_AUTH_TOKEN }}/g' .npmrc
+
+      - name: Install Dependencies
+        run: npm install
+
+      - name: Build Dataverse UI Library
+        working-directory: packages/design-system
+        run: npm run build
+
+      - name: Create and populate .env file
+        env:
+          DATAVERSE_BACKEND_URL: ${{ secrets.DATAVERSE_BACKEND_URL }}
+        run: |
+          touch .env
+          echo VITE_DATAVERSE_BACKEND_URL="$DATAVERSE_BACKEND_URL" >> .env
+        shell: bash
+
+      - name: Build with base path
+        run: npm run build -- --base=/spa
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: built-site
+          path: ./dist
+
+  deploy-to-payara:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: beta-testing
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+
+      - uses: actions/download-artifact@v3
+        with:
+          name: built-site
+          path: ./dist
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v6
+
+      - name: Build war file
+        working-directory: ./deployment/payara
+        run: mvn package "-Dversion=${{ steps.branch-name.outputs.current_branch }}"
+
+      - name: Copy war file to remote instance
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.PAYARA_INSTANCE_HOST }}
+          username: ${{ secrets.PAYARA_INSTANCE_USERNAME }}
+          key: ${{ secrets.PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
+          source: './deployment/payara/target/dataverse-frontend.war'
+          target: '/home/${{ secrets.PAYARA_INSTANCE_USERNAME }}'
+          overwrite: true
+
+      - name: Execute payara war deployment remotely
+        uses: appleboy/ssh-action@v0.1.8
+        with:
+          host: ${{ secrets.PAYARA_INSTANCE_HOST }}
+          username: ${{ secrets.PAYARA_INSTANCE_USERNAME }}
+          key: ${{ secrets.PAYARA_INSTANCE_SSH_PRIVATE_KEY }}
+          script: |
+            APPLICATION_NAME=dataverse-frontend
+            APPLICATION_WAR_PATH=deployment/payara/target/$APPLICATION_NAME.war
+            ASADMIN='/usr/local/payara5/bin/asadmin --user admin'
+            DATAVERSE_FRONTEND=`$ASADMIN list-applications |grep $APPLICATION_NAME |awk '{print $1}'`
+            $ASADMIN undeploy $DATAVERSE_FRONTEND
+            $ASADMIN deploy --name $APPLICATION_NAME --contextroot /spa $APPLICATION_WAR_PATH

--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ It is important that the remote instance is correctly pre-configured, with the P
 
 A base path for the frontend application can be established on the remote server by setting the corresponding field in the workflow inputs. This mechanism prevents conflicts between the frontend application and any pre-existing deployed application running on Payara, which can potentially be a Dataverse backend. This way, only the routes with the base path included will redirect to the frontend application.
 
+#### Beta Testing Environment
+
+To make the SPA Frontend accesible and testable by people interested in the project, there is a remote beta testing environment that includes the latest changes developed both for the frontend application and the Dataverse backend application (develop branches).
+
+This environment follows the "all-in-one" solution described above, where both applications coexist on a Payara server.
+
+Environment updates are carried out automatically through GitHub actions, present both in this repository and in the Dataverse backend repository, which deploy the develop branches when any change is pushed to them.
+
+The environment is accessible through the following URLs:
+
+- SPA: http://ec2-3-210-184-82.compute-1.amazonaws.com/spa
+- JSF: http://ec2-3-210-184-82.compute-1.amazonaws.com
+
 ## Changes from the Style Guide
 
 The design system and frontend in this repo are inspired by the Dataverse Project [Style Guide](https://guides.dataverse.org/en/latest/style/index.html), but the following changes have been made, especially for accessibility.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,8 @@ Environment updates are carried out automatically through GitHub actions, presen
 
 The environment is accessible through the following URLs:
 
-- SPA: http://ec2-3-210-184-82.compute-1.amazonaws.com/spa
-- JSF: http://ec2-3-210-184-82.compute-1.amazonaws.com
+- SPA: https://beta.dataverse.org/spa
+- JSF: https://beta.dataverse.org
 
 ## Changes from the Style Guide
 


### PR DESCRIPTION
## What this PR does / why we need it:

Adds a GitHub action that is executed on any push event in the develop branch and deploys the application to the remote Beta Testing environment.

## Which issue(s) this PR closes:

- Closes #153 

## Special notes for your reviewer:

We need to create the GitHub environment in this repository with the secrets corresponding to the credentials to allow the GitHub action to access and update the Beta Testing instance.

The PR reviewer / QA should contact me to set up this environment, since I have the secrets.

If we set a DNS for the environment before merging this PR, the README URLs will need to be updated.

## Suggestions on how to test this:

You can see how the action works in my fork repository, where I have committed several times in the develop branch, causing these events to trigger the action:
https://github.com/GPortas/dataverse-frontend/actions/workflows/deploy-beta-testing.yml

These actions have updated the environment, available at the following URL:
http://ec2-3-210-184-82.compute-1.amazonaws.com/spa

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
GitHub action for automatic Beta Testing Environment deployment

## Additional documentation:
N/A