### PR TITLE
added a dependency so that dev_solr waits for dev_solr_initializer to…

### DIFF
--- a/dev-env/docker-compose-dev.yml
+++ b/dev-env/docker-compose-dev.yml
@@ -109,7 +109,8 @@ services:
     hostname: 'solr'
     image: solr:${SOLR_VERSION}
     depends_on:
-      - dev_solr_initializer
+      dev_solr_initializer:
+        condition: service_completed_successfully
     restart: on-failure
     expose:
       - '8983'


### PR DESCRIPTION
… complete

## What this PR does / why we need it:
modifies docker-compose so that dev_solr service waits for dev_solr_initializer to complete

## Which issue(s) this PR closes:

- Closes #179 

## Special notes for your reviewer:

## Suggestions on how to test this:
Call ./run-env.sh <dataverse image> to start the dataverse container.
Go to dataverse (localhost:8000) and login as dataverseAdmin.
Try to create a dataverse.  It should create the dataverse successfully.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:

## Additional documentation:
