### PR TITLE
Dump Docker logs on failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,23 @@ jobs:
       - name: Run e2e tests
         run: npm run test:e2e
 
+      - name: Dump docker logs on failure
+        if: failure()
+        uses: jwalton/gh-docker-logs@v2
+        with:
+          dest: './logs'
+
+      - name: Tar logs
+        if: failure()
+        run: tar cvzf ./logs.tgz ./logs
+
+      - name: Upload logs to GitHub
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: logs.tgz
+          path: ./logs.tgz
+
   component:
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
## What this PR does / why we need it:

e2e tests have been failing for two months.

## Which issue(s) this PR closes:

- None, but related to #213

## Special notes for your reviewer:

This is what we use at https://github.com/gdcc/api-test-runner/blob/main/.github/workflows/develop.yml to dump the logs.

## Suggestions on how to test this:

Merge it. Then look at the logs