### PR TITLE
206 - Integration dataset locks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-pr97.418bf5e",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr99.c36f1db",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3589,9 +3589,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-pr97.418bf5e",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr97.418bf5e/0d604232d6f567b41328143c2d5d27513d069380",
-      "integrity": "sha512-wKRR1ORFkFSoFoCrWsCQvcm1vExIIrVN3pJbIl9Nk8lopP7zkUEB1xcAU+UVShbGktIZIa20TQMFl0ONafDiZw==",
+      "version": "2.0.0-pr99.c36f1db",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr99.c36f1db/3f49037b14e53295c39ce787cce53f20b2558ba6",
+      "integrity": "sha512-KzMVzB420eKKaOuwDEpvAB/k1RrW3Le/ZJcVtjxFk/Wvxov2Jl1npbwy4SXQWasEXaJWslohn2KRkBfBDoTHTQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-pr97.418bf5e",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr99.c36f1db",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/dataset/domain/models/Dataset.ts
+++ b/src/dataset/domain/models/Dataset.ts
@@ -264,15 +264,14 @@ export interface DatasetLock {
 }
 
 export enum DatasetLockReason {
-  INGEST = 'ingest',
-  WORKFLOW = 'workflow',
-  IN_REVIEW = 'inReview',
-  DCM_UPLOAD = 'dcmUpload',
-  GLOBUS_UPLOAD = 'globusUpload',
+  INGEST = 'Ingest',
+  WORKFLOW = 'Workflow',
+  IN_REVIEW = 'InReview',
+  DCM_UPLOAD = 'DcmUpload',
+  GLOBUS_UPLOAD = 'GlobusUpload',
   FINALIZE_PUBLICATION = 'finalizePublication',
-
-  EDIT_IN_PROGRESS = 'editInProgress',
-  FILE_VALIDATION_FAILED = 'fileValidationFailed'
+  EDIT_IN_PROGRESS = 'EditInProgress',
+  FILE_VALIDATION_FAILED = 'FileValidationFailed'
 }
 
 export interface PrivateUrl {

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -3,7 +3,8 @@ import {
   DatasetMetadataBlock as JSDatasetMetadataBlock,
   DatasetMetadataBlocks as JSDatasetMetadataBlocks,
   DatasetMetadataFields as JSDatasetMetadataFields,
-  DatasetVersionInfo as JSDatasetVersionInfo
+  DatasetVersionInfo as JSDatasetVersionInfo,
+  DatasetLock as JSDatasetLock
 } from '@iqss/dataverse-client-javascript'
 import { DatasetVersionState as JSDatasetVersionState } from '@iqss/dataverse-client-javascript/dist/datasets/domain/models/Dataset'
 import {
@@ -14,7 +15,9 @@ import {
   DatasetMetadataFields,
   DatasetVersion,
   MetadataBlockName,
-  PrivateUrl
+  PrivateUrl,
+  DatasetLock,
+  DatasetLockReason
 } from '../../domain/models/Dataset'
 
 export class JSDatasetMapper {
@@ -22,6 +25,7 @@ export class JSDatasetMapper {
     jsDataset: JSDataset,
     citation: string,
     summaryFieldsNames: string[],
+    jsDatasetLocks: JSDatasetLock[],
     requestedVersion?: string,
     privateUrl?: PrivateUrl
   ): Dataset {
@@ -45,7 +49,7 @@ export class JSDatasetMapper {
         canManageFilesPermissions: true,
         canDeleteDataset: true
       }, // TODO Connect with dataset permissions
-      [], // TODO Connect with dataset locks
+      JSDatasetMapper.toLocks(jsDatasetLocks),
       true, // TODO Connect with dataset hasValidTermsOfAccess
       true, // TODO Connect with dataset isValid
       jsDataset.versionInfo.releaseTime !== undefined &&
@@ -184,5 +188,14 @@ export class JSDatasetMapper {
     }
 
     return extraFields
+  }
+
+  static toLocks(jsDatasetLocks: JSDatasetLock[]): DatasetLock[] {
+    return jsDatasetLocks.map((jsDatasetLock) => {
+      return {
+        id: 0,
+        reason: jsDatasetLock.lockType as unknown as DatasetLockReason
+      }
+    })
   }
 }

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -193,7 +193,7 @@ export class JSDatasetMapper {
   static toLocks(jsDatasetLocks: JSDatasetLock[]): DatasetLock[] {
     return jsDatasetLocks.map((jsDatasetLock) => {
       return {
-        id: 0,
+        userPersistentId: jsDatasetLock.userId,
         reason: jsDatasetLock.lockType as unknown as DatasetLockReason
       }
     })

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -7,7 +7,9 @@ import {
   Dataset as JSDataset,
   getPrivateUrlDataset,
   getPrivateUrlDatasetCitation,
-  ReadError
+  ReadError,
+  getDatasetLocks,
+  DatasetLock as JSDatasetLock
 } from '@iqss/dataverse-client-javascript'
 import { JSDatasetMapper } from '../mappers/JSDatasetMapper'
 
@@ -23,11 +25,24 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
         Promise.all([
           jsDataset,
           getDatasetSummaryFieldNames.execute(),
-          getDatasetCitation.execute(jsDataset.id, this.versionToVersionId(version))
+          getDatasetCitation.execute(jsDataset.id, this.versionToVersionId(version)),
+          getDatasetLocks.execute(jsDataset.id)
         ])
       )
-      .then(([jsDataset, summaryFieldsNames, citation]: [JSDataset, string[], string]) =>
-        JSDatasetMapper.toDataset(jsDataset, citation, summaryFieldsNames, requestedVersion)
+      .then(
+        ([jsDataset, summaryFieldsNames, citation, jsDatasetLocks]: [
+          JSDataset,
+          string[],
+          string,
+          JSDatasetLock[]
+        ]) =>
+          JSDatasetMapper.toDataset(
+            jsDataset,
+            citation,
+            summaryFieldsNames,
+            jsDatasetLocks,
+            requestedVersion
+          )
       )
       .catch((error: ReadError) => {
         if (!version) {
@@ -42,9 +57,9 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       getPrivateUrlDataset.execute(privateUrlToken),
       getDatasetSummaryFieldNames.execute(),
       getPrivateUrlDatasetCitation.execute(privateUrlToken)
-    ])
+    ]) // TODO - Add getDatasetLocks.execute(privateUrlToken) when it is available in js-dataverse
       .then(([jsDataset, summaryFieldsNames, citation]: [JSDataset, string[], string]) =>
-        JSDatasetMapper.toDataset(jsDataset, citation, summaryFieldsNames, undefined)
+        JSDatasetMapper.toDataset(jsDataset, citation, summaryFieldsNames, [])
       )
       .catch((error: ReadError) => {
         throw new Error(error.message)

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -4,13 +4,16 @@ import { EditDatasetPermissionsMenu } from './EditDatasetPermissionsMenu'
 import { DeleteDatasetButton } from './DeleteDatasetButton'
 import { DeaccessionDatasetButton } from './DeaccessionDatasetButton'
 import { useTranslation } from 'react-i18next'
+import { useSession } from '../../../session/SessionContext'
 
 interface EditDatasetMenuProps {
   dataset: Dataset
 }
 
 export function EditDatasetMenu({ dataset }: EditDatasetMenuProps) {
-  if (!dataset.permissions.canUpdateDataset) {
+  const { user } = useSession()
+
+  if (!user || !dataset.permissions.canUpdateDataset) {
     return <></>
   }
 
@@ -21,7 +24,7 @@ export function EditDatasetMenu({ dataset }: EditDatasetMenuProps) {
       title={t('datasetActionButtons.editDataset.title')}
       asButtonGroup
       variant="secondary"
-      disabled={dataset.isLockedFromEdits}>
+      disabled={dataset.checkIsLockedFromEdits(user.persistentId)}>
       <DropdownButtonItem disabled={!dataset.hasValidTermsOfAccess}>
         {t('datasetActionButtons.editDataset.filesUpload')}
       </DropdownButtonItem>

--- a/src/sections/dataset/dataset-action-buttons/publish-dataset-menu/PublishDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/publish-dataset-menu/PublishDatasetMenu.tsx
@@ -2,15 +2,18 @@ import { Dataset, DatasetPublishingStatus } from '../../../../dataset/domain/mod
 import { DropdownButton, DropdownButtonItem } from '@iqss/dataverse-design-system'
 import { ChangeCurationStatusMenu } from './ChangeCurationStatusMenu'
 import { useTranslation } from 'react-i18next'
+import { useSession } from '../../../session/SessionContext'
 
 interface PublishDatasetMenuProps {
   dataset: Dataset
 }
 
 export function PublishDatasetMenu({ dataset }: PublishDatasetMenuProps) {
+  const { user } = useSession()
   if (
     !dataset.version.isLatest ||
     dataset.version.publishingStatus !== DatasetPublishingStatus.DRAFT ||
+    !user ||
     !dataset.permissions.canPublishDataset
   ) {
     return <></>
@@ -24,7 +27,9 @@ export function PublishDatasetMenu({ dataset }: PublishDatasetMenuProps) {
       asButtonGroup
       variant="secondary"
       disabled={
-        dataset.isLockedFromPublishing || !dataset.hasValidTermsOfAccess || !dataset.isValid
+        dataset.checkIsLockedFromPublishing(user.persistentId) ||
+        !dataset.hasValidTermsOfAccess ||
+        !dataset.isValid
       }>
       <DropdownButtonItem>{t('datasetActionButtons.publish.publish')}</DropdownButtonItem>
       {dataset.version.isInReview && (

--- a/src/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.tsx
+++ b/src/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.tsx
@@ -1,17 +1,20 @@
 import { Dataset, DatasetPublishingStatus } from '../../../../dataset/domain/models/Dataset'
 import { Button } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
+import { useSession } from '../../../session/SessionContext'
 
 interface SubmitForReviewButtonProps {
   dataset: Dataset
 }
 
 export function SubmitForReviewButton({ dataset }: SubmitForReviewButtonProps) {
+  const { user } = useSession()
   if (
     !dataset.version.isLatest ||
     dataset.version.publishingStatus !== DatasetPublishingStatus.DRAFT ||
     dataset.isLockedInWorkflow ||
     dataset.permissions.canPublishDataset ||
+    !user ||
     !dataset.permissions.canUpdateDataset
   ) {
     return <></>
@@ -22,7 +25,9 @@ export function SubmitForReviewButton({ dataset }: SubmitForReviewButtonProps) {
     <Button
       variant="secondary"
       disabled={
-        dataset.isLockedFromPublishing || !dataset.hasValidTermsOfAccess || !dataset.isValid
+        dataset.checkIsLockedFromPublishing(user.persistentId) ||
+        !dataset.hasValidTermsOfAccess ||
+        !dataset.isValid
       }>
       {dataset.version.isInReview
         ? t('datasetActionButtons.submitForReview.disabled')

--- a/src/sections/dataset/dataset-files/dataset-upload-files-button/DatasetUploadFilesButton.tsx
+++ b/src/sections/dataset/dataset-files/dataset-upload-files-button/DatasetUploadFilesButton.tsx
@@ -21,7 +21,7 @@ export function DatasetUploadFilesButton() {
     <Button
       onClick={handleClick}
       icon={<PlusLg className={styles.icon} />}
-      disabled={dataset.isLockedFromEdits}>
+      disabled={dataset.checkIsLockedFromEdits(user.persistentId)}>
       {t('datasetActionButtons.uploadFiles')}
     </Button>
   )

--- a/src/sections/dataset/dataset-files/file-criteria-form/FileCriteriaForm.tsx
+++ b/src/sections/dataset/dataset-files/file-criteria-form/FileCriteriaForm.tsx
@@ -18,31 +18,36 @@ export function FileCriteriaForm({
   onCriteriaChange,
   filesCountInfo
 }: FileCriteriaInputsProps) {
-  if (!filesCountInfo || filesCountInfo.total < MINIMUM_FILES_TO_SHOW_CRITERIA_INPUTS) {
-    return <></>
-  }
+  const showFileCriteriaInputs =
+    filesCountInfo && filesCountInfo.total >= MINIMUM_FILES_TO_SHOW_CRITERIA_INPUTS
   return (
-    <Form>
-      <Row>
-        <Col md={5}>
-          <FileCriteriaSearchText criteria={criteria} onCriteriaChange={onCriteriaChange} />
-        </Col>
-        <Col className={styles['upload-files-container']}>
-          <DatasetUploadFilesButton />
-        </Col>
-      </Row>
-      <Row className={styles['criteria-section']}>
-        <Col>
-          <FileCriteriaFilters
-            criteria={criteria}
-            onCriteriaChange={onCriteriaChange}
-            filesCountInfo={filesCountInfo}
-          />
-        </Col>
-        <Col className={styles['sort-container']}>
-          <FileCriteriaSortBy criteria={criteria} onCriteriaChange={onCriteriaChange} />
-        </Col>
-      </Row>
-    </Form>
+    <div className={styles['criteria-section']}>
+      <Form>
+        <Row>
+          {showFileCriteriaInputs && (
+            <Col md={5}>
+              <FileCriteriaSearchText criteria={criteria} onCriteriaChange={onCriteriaChange} />
+            </Col>
+          )}
+          <Col className={styles['upload-files-container']}>
+            <DatasetUploadFilesButton />
+          </Col>
+        </Row>
+        {showFileCriteriaInputs && (
+          <Row>
+            <Col>
+              <FileCriteriaFilters
+                criteria={criteria}
+                onCriteriaChange={onCriteriaChange}
+                filesCountInfo={filesCountInfo}
+              />
+            </Col>
+            <Col className={styles['sort-container']}>
+              <FileCriteriaSortBy criteria={criteria} onCriteriaChange={onCriteriaChange} />
+            </Col>
+          </Row>
+        )}
+      </Form>
+    </div>
   )
 }

--- a/src/sections/dataset/dataset-files/files-table/file-actions/edit-files-menu/EditFilesMenu.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-actions/edit-files-menu/EditFilesMenu.tsx
@@ -30,7 +30,7 @@ export function EditFilesMenu({ files, fileSelection }: EditFilesMenuProps) {
       variant="secondary"
       id="edit-files-menu"
       title={t('actions.editFilesMenu.title')}
-      disabled={dataset.isLockedFromEdits || !dataset.hasValidTermsOfAccess}
+      disabled={dataset.checkIsLockedFromEdits(user.persistentId) || !dataset.hasValidTermsOfAccess}
       icon={<PencilFill className={styles.icon} />}>
       <EditFilesOptions files={files} fileSelection={fileSelection} />
     </DropdownButton>

--- a/src/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/file-options-menu/FileOptionsMenu.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/file-options-menu/FileOptionsMenu.tsx
@@ -24,7 +24,7 @@ export function FileOptionsMenu({ file }: { file: File }) {
         <Tooltip placement="top" overlay={<span>{t('actions.optionsMenu.title')}</span>}>
           <Button
             id={`file-options-file-${file.id}`}
-            disabled={dataset.isLockedFromEdits}
+            disabled={dataset.checkIsLockedFromEdits(user.persistentId)}
             variant="secondary"
             icon={
               <ThreeDotsVertical
@@ -47,7 +47,7 @@ export function FileOptionsMenu({ file }: { file: File }) {
       <DropdownButton
         id={`file-options-file-${file.id}`}
         title=""
-        disabled={dataset.isLockedFromEdits}
+        disabled={dataset.checkIsLockedFromEdits(user.persistentId)}
         asButtonGroup
         variant="secondary"
         icon={<ThreeDotsVertical aria-label={t('actions.optionsMenu.title')} />}>

--- a/src/users/domain/models/User.ts
+++ b/src/users/domain/models/User.ts
@@ -1,3 +1,4 @@
 export interface User {
   name: string
+  persistentId: string
 }

--- a/src/users/infrastructure/repositories/UserJSDataverseRepository.ts
+++ b/src/users/infrastructure/repositories/UserJSDataverseRepository.ts
@@ -11,7 +11,10 @@ export class UserJSDataverseRepository implements UserRepository {
     return getCurrentAuthenticatedUser
       .execute()
       .then((authenticatedUser: AuthenticatedUser) => {
-        return { name: authenticatedUser.displayName }
+        return {
+          name: authenticatedUser.displayName,
+          persistentId: authenticatedUser.persistentUserId
+        }
       })
       .catch((error: ReadError) => {
         throw new Error(error.message)

--- a/tests/component/dataset/domain/models/DatasetMother.ts
+++ b/tests/component/dataset/domain/models/DatasetMother.ts
@@ -404,7 +404,7 @@ export class DatasetMother {
             datasetContact: [
               {
                 datasetContactName: 'Admin, Dataverse',
-                datasetContactEmail: ''
+                datasetContactEmail: 'admin@dataverse.org'
               }
             ],
             dsDescription: [

--- a/tests/component/dataset/domain/models/DatasetMother.ts
+++ b/tests/component/dataset/domain/models/DatasetMother.ts
@@ -166,7 +166,7 @@ export class DatasetPermissionsMother {
 export class DatasetLockMother {
   static create(props?: Partial<DatasetLock>): DatasetLock {
     return {
-      id: faker.datatype.number(),
+      userPersistentId: faker.internet.userName(),
       reason: faker.helpers.arrayElement(Object.values(DatasetLockReason)),
       ...props
     }

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -1,11 +1,16 @@
 import chai from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 import { JSDatasetMapper } from '../../../../../src/dataset/infrastructure/mappers/JSDatasetMapper'
-import { DatasetVersionState } from '@iqss/dataverse-client-javascript'
+import {
+  DatasetLockType,
+  DatasetVersionState,
+  DatasetLock as JSDatasetLock
+} from '@iqss/dataverse-client-javascript'
 import {
   CitationMetadataBlock,
   DatasetMetadataBlock
 } from '@iqss/dataverse-client-javascript/dist/datasets/domain/models/Dataset'
+import { DatasetLockReason } from '../../../../../src/dataset/domain/models/Dataset'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -51,6 +56,13 @@ const jsDataset = {
 const citation =
   'Finch, Fiona, 2023, "Darwin\'s Finches", <a href="https://doi.org/10.5072/FK2/B4B2MJ" target="_blank">https://doi.org/10.5072/FK2/B4B2MJ</a>, Root, DRAFT VERSION'
 const datasetSummaryFields = ['dsDescription', 'subject', 'keyword', 'publication', 'notesText']
+const jsDatasetLocks: JSDatasetLock[] = [
+  {
+    lockType: DatasetLockType.IN_REVIEW,
+    userId: 'dataverseAdmin',
+    datasetPersistentId: 'doi:10.5072/FK2/B4B2MJ'
+  }
+]
 const expectedDataset = {
   persistentId: 'doi:10.5072/FK2/B4B2MJ',
   version: {
@@ -116,7 +128,12 @@ const expectedDataset = {
     canManageFilesPermissions: true,
     canDeleteDataset: true
   },
-  locks: [],
+  locks: [
+    {
+      userPersistentId: 'dataverseAdmin',
+      reason: DatasetLockReason.IN_REVIEW
+    }
+  ],
   hasValidTermsOfAccess: true,
   isValid: true,
   isReleased: false,
@@ -176,7 +193,12 @@ const expectedDatasetAlternateVersion = {
     uri: 'http://creativecommons.org/publicdomain/zero/1.0',
     iconUri: 'https://licensebuttons.net/p/zero/1.0/88x31.png'
   },
-  locks: [],
+  locks: [
+    {
+      userPersistentId: 'dataverseAdmin',
+      reason: DatasetLockReason.IN_REVIEW
+    }
+  ],
   metadataBlocks: [
     {
       name: 'citation',
@@ -208,7 +230,12 @@ const expectedDatasetAlternateVersion = {
 }
 describe('JS Dataset Mapper', () => {
   it('maps jsDataset model to the domain Dataset model', () => {
-    const mapped = JSDatasetMapper.toDataset(jsDataset, citation, datasetSummaryFields)
+    const mapped = JSDatasetMapper.toDataset(
+      jsDataset,
+      citation,
+      datasetSummaryFields,
+      jsDatasetLocks
+    )
     expect(expectedDataset).to.deep.equal(mapped)
   })
   it('maps jsDataset model to the domain Dataset model for alternate version', () => {
@@ -216,6 +243,7 @@ describe('JS Dataset Mapper', () => {
       jsDataset,
       citation,
       datasetSummaryFields,
+      jsDatasetLocks,
       '4.0'
     )
 
@@ -255,7 +283,8 @@ describe('JS Dataset Mapper', () => {
       JSDatasetMapper.toDataset(
         jsDatasetWithAlternativePersistentId,
         citation,
-        datasetSummaryFields
+        datasetSummaryFields,
+        jsDatasetLocks
       )
     )
   })
@@ -290,7 +319,12 @@ describe('JS Dataset Mapper', () => {
     }
 
     expect(expectedDatasetWithCitationDate).to.deep.equal(
-      JSDatasetMapper.toDataset(jsDatasetWithCitationDate, citation, datasetSummaryFields)
+      JSDatasetMapper.toDataset(
+        jsDatasetWithCitationDate,
+        citation,
+        datasetSummaryFields,
+        jsDatasetLocks
+      )
     )
   })
 
@@ -323,7 +357,12 @@ describe('JS Dataset Mapper', () => {
       ]
     }
     expect(expectedDatasetWithPublicationDate).to.deep.equal(
-      JSDatasetMapper.toDataset(jsDatasetWithPublicationDate, citation, datasetSummaryFields)
+      JSDatasetMapper.toDataset(
+        jsDatasetWithPublicationDate,
+        citation,
+        datasetSummaryFields,
+        jsDatasetLocks
+      )
     )
   })
 })

--- a/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
@@ -16,7 +16,7 @@ describe('EditDatasetMenu', () => {
       isReleased: true
     })
 
-    cy.customMount(<EditDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<EditDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Edit Dataset' }).should('exist').should('be.enabled').click()
 
@@ -30,13 +30,27 @@ describe('EditDatasetMenu', () => {
     cy.findByRole('button', { name: 'Deaccession Dataset' }).should('exist')
   })
 
+  it('does not render if the user is not authenticated', () => {
+    const dataset = DatasetMother.create({
+      permissions: DatasetPermissionsMother.createWithAllAllowed(),
+      locks: [],
+      hasValidTermsOfAccess: true,
+      version: DatasetVersionMother.createReleasedWithLatestVersionIsADraft(),
+      isReleased: true
+    })
+
+    cy.customMount(<EditDatasetMenu dataset={dataset} />)
+
+    cy.findByRole('button', { name: 'Edit Dataset' }).should('not.exist')
+  })
+
   it('does not render the EditDatasetMenu if the user does not have update dataset permissions', () => {
     const dataset = DatasetMother.create({
       permissions: DatasetPermissionsMother.createWithUpdateDatasetNotAllowed(),
       locks: []
     })
 
-    cy.customMount(<EditDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<EditDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Edit Dataset' }).should('not.exist')
   })
@@ -47,7 +61,7 @@ describe('EditDatasetMenu', () => {
       locks: [DatasetLockMother.createLockedInEditInProgress()]
     })
 
-    cy.customMount(<EditDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<EditDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Edit Dataset' }).should('exist').should('be.disabled')
   })
@@ -59,7 +73,7 @@ describe('EditDatasetMenu', () => {
       hasValidTermsOfAccess: true
     })
 
-    cy.customMount(<EditDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<EditDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Edit Dataset' }).click()
     cy.findByRole('button', { name: 'Files (Upload)' })
@@ -77,7 +91,7 @@ describe('EditDatasetMenu', () => {
       hasValidTermsOfAccess: false
     })
 
-    cy.customMount(<EditDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<EditDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Edit Dataset' }).click()
     cy.findByRole('button', { name: 'Files (Upload)' })

--- a/tests/component/sections/dataset/dataset-action-buttons/publish-dataset-menu/PublishDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/publish-dataset-menu/PublishDatasetMenu.spec.tsx
@@ -5,7 +5,6 @@ import {
   DatasetPermissionsMother,
   DatasetVersionMother
 } from '../../../../dataset/domain/models/DatasetMother'
-import { DatasetLockReason } from '../../../../../../src/dataset/domain/models/Dataset'
 import { SettingRepository } from '../../../../../../src/settings/domain/repositories/SettingRepository'
 import { SettingMother } from '../../../../settings/domain/models/SettingMother'
 import { SettingsProvider } from '../../../../../../src/sections/settings/SettingsProvider'
@@ -20,7 +19,7 @@ describe('PublishDatasetMenu', () => {
       isValid: true
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' })
       .should('exist')
@@ -44,7 +43,7 @@ describe('PublishDatasetMenu', () => {
       .stub()
       .resolves(SettingMother.createExternalStatusesAllowed(['Author Contacted', 'Privacy Review']))
 
-    cy.customMount(
+    cy.mountAuthenticated(
       <SettingsProvider repository={settingRepository}>
         <PublishDatasetMenu dataset={dataset} />
       </SettingsProvider>
@@ -55,6 +54,20 @@ describe('PublishDatasetMenu', () => {
     cy.findByRole('button', { name: 'Change Curation Status' }).should('exist')
   })
 
+  it('does not render if the user is not authenticated', () => {
+    const dataset = DatasetMother.create({
+      version: DatasetVersionMother.createDraftAsLatestVersion(),
+      permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
+      locks: [],
+      hasValidTermsOfAccess: true,
+      isValid: true
+    })
+
+    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+
+    cy.findByRole('button', { name: 'Publish Dataset' }).should('not.exist')
+  })
+
   it('does not render the PublishDatasetMenu if publishing is not allowed', () => {
     const dataset = DatasetMother.create({
       version: DatasetVersionMother.createDraftAsLatestVersion(),
@@ -62,7 +75,7 @@ describe('PublishDatasetMenu', () => {
       locks: []
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('not.exist')
   })
@@ -74,7 +87,7 @@ describe('PublishDatasetMenu', () => {
       locks: []
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('not.exist')
   })
@@ -86,7 +99,7 @@ describe('PublishDatasetMenu', () => {
       locks: []
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('not.exist')
   })
@@ -100,7 +113,7 @@ describe('PublishDatasetMenu', () => {
       isValid: true
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('be.enabled')
   })
@@ -109,17 +122,12 @@ describe('PublishDatasetMenu', () => {
     const dataset = DatasetMother.create({
       version: DatasetVersionMother.createDraftAsLatestVersion(),
       permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-      locks: [
-        {
-          id: 1,
-          reason: DatasetLockReason.EDIT_IN_PROGRESS
-        }
-      ],
+      locks: [DatasetLockMother.createLockedInEditInProgress()],
       hasValidTermsOfAccess: true,
       isValid: true
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('be.disabled')
   })
@@ -133,7 +141,7 @@ describe('PublishDatasetMenu', () => {
       isValid: true
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('be.disabled')
   })
@@ -147,7 +155,7 @@ describe('PublishDatasetMenu', () => {
       isValid: false
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' }).should('be.disabled')
   })
@@ -161,7 +169,7 @@ describe('PublishDatasetMenu', () => {
       isValid: true
     })
 
-    cy.customMount(<PublishDatasetMenu dataset={dataset} />)
+    cy.mountAuthenticated(<PublishDatasetMenu dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Publish Dataset' })
       .should('exist')

--- a/tests/component/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.spec.tsx
@@ -5,7 +5,6 @@ import {
   DatasetPermissionsMother,
   DatasetVersionMother
 } from '../../../../dataset/domain/models/DatasetMother'
-import { DatasetLockReason } from '../../../../../../src/dataset/domain/models/Dataset'
 
 describe('SubmitForReviewButton', () => {
   it('renders the SubmitForReviewButton if is dataset latest version and it is a draft and the dataset is not locked in workflow and the user has dataset update permissions and the user do not have publish dataset permissions', () => {
@@ -20,9 +19,26 @@ describe('SubmitForReviewButton', () => {
       isValid: true
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('exist').should('be.enabled')
+  })
+
+  it('does not render if the user is not authenticated', () => {
+    const dataset = DatasetMother.create({
+      version: DatasetVersionMother.createDraftAsLatestVersion(),
+      permissions: DatasetPermissionsMother.create({
+        canUpdateDataset: true,
+        canPublishDataset: false
+      }),
+      locks: [],
+      hasValidTermsOfAccess: true,
+      isValid: true
+    })
+
+    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+
+    cy.findByRole('button', { name: 'Submit for Review' }).should('not.exist')
   })
 
   it('does not render the SubmitForReviewButton if is not dataset latest version', () => {
@@ -35,7 +51,7 @@ describe('SubmitForReviewButton', () => {
       locks: [DatasetLockMother.createLockedInWorkflow()]
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('not.exist')
   })
@@ -50,7 +66,7 @@ describe('SubmitForReviewButton', () => {
       locks: [DatasetLockMother.createLockedInWorkflow()]
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('not.exist')
   })
@@ -65,7 +81,7 @@ describe('SubmitForReviewButton', () => {
       locks: [DatasetLockMother.createLockedInWorkflow()]
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('not.exist')
   })
@@ -80,7 +96,7 @@ describe('SubmitForReviewButton', () => {
       locks: []
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('not.exist')
   })
@@ -95,7 +111,7 @@ describe('SubmitForReviewButton', () => {
       locks: []
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('not.exist')
   })
@@ -107,17 +123,12 @@ describe('SubmitForReviewButton', () => {
         canUpdateDataset: true,
         canPublishDataset: false
       }),
-      locks: [
-        {
-          id: 1,
-          reason: DatasetLockReason.EDIT_IN_PROGRESS
-        }
-      ],
+      locks: [DatasetLockMother.createLockedInEditInProgress()],
       hasValidTermsOfAccess: true,
       isValid: true
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('be.disabled')
   })
@@ -134,7 +145,7 @@ describe('SubmitForReviewButton', () => {
       isValid: true
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('be.disabled')
   })
@@ -151,7 +162,7 @@ describe('SubmitForReviewButton', () => {
       isValid: false
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submit for Review' }).should('be.disabled')
   })
@@ -166,7 +177,7 @@ describe('SubmitForReviewButton', () => {
       locks: [DatasetLockMother.createLockedInReview()]
     })
 
-    cy.customMount(<SubmitForReviewButton dataset={dataset} />)
+    cy.mountAuthenticated(<SubmitForReviewButton dataset={dataset} />)
 
     cy.findByRole('button', { name: 'Submitted for Review' }).should('be.disabled')
   })

--- a/tests/component/users/domain/models/UserMother.ts
+++ b/tests/component/users/domain/models/UserMother.ts
@@ -3,7 +3,8 @@ import { User } from '../../../../../src/users/domain/models/User'
 export class UserMother {
   static create(): User {
     return {
-      name: 'James D. Potts'
+      name: 'James D. Potts',
+      persistentId: 'jamesPotts'
     }
   }
 }

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -196,7 +196,7 @@ describe('Dataset JSDataverse Repository', () => {
       })
   })
 
-  it('gets the dataset when is locked', async () => {
+  it('gets the dataset by persistentId when is locked', async () => {
     const datasetResponse = await DatasetHelper.create()
     await DatasetHelper.lock(datasetResponse.id, DatasetLockReason.FINALIZE_PUBLICATION)
 

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -209,7 +209,7 @@ describe('Dataset JSDataverse Repository', () => {
       expect(dataset.getTitle()).to.deep.equal(datasetExpected.title)
       expect(dataset.locks).to.deep.equal([
         {
-          id: 0,
+          userPersistentId: 'dataverseAdmin',
           reason: DatasetLockReason.FINALIZE_PUBLICATION
         }
       ])

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -3,6 +3,7 @@ import chaiAsPromised from 'chai-as-promised'
 import { DatasetJSDataverseRepository } from '../../../../src/dataset/infrastructure/repositories/DatasetJSDataverseRepository'
 import { TestsUtils } from '../../shared/TestsUtils'
 import {
+  DatasetLockReason,
   DatasetPublishingStatus,
   DatasetVersion
 } from '../../../../src/dataset/domain/models/Dataset'
@@ -80,7 +81,8 @@ const datasetData = (persistentId: string, versionId: number) => {
       latestVersionStatus: 'draft',
       isLatest: true,
       isInReview: false
-    }
+    },
+    locks: []
   }
 }
 
@@ -107,6 +109,7 @@ describe('Dataset JSDataverse Repository', () => {
       expect(dataset.version).to.deep.equal(datasetExpected.version)
       expect(dataset.metadataBlocks[0].fields.publicationDate).not.to.exist
       expect(dataset.metadataBlocks[0].fields.citationDate).not.to.exist
+      expect(dataset.locks).to.deep.equal(datasetExpected.locks)
     })
   })
 
@@ -191,5 +194,25 @@ describe('Dataset JSDataverse Repository', () => {
         )
         expect(dataset.metadataBlocks[0].fields.citationDate).not.to.exist
       })
+  })
+
+  it('gets the dataset when is locked', async () => {
+    const datasetResponse = await DatasetHelper.create()
+    await DatasetHelper.lock(datasetResponse.id, DatasetLockReason.FINALIZE_PUBLICATION)
+
+    await datasetRepository.getByPersistentId(datasetResponse.persistentId).then((dataset) => {
+      if (!dataset) {
+        throw new Error('Dataset not found')
+      }
+      const datasetExpected = datasetData(dataset.persistentId, dataset.version.id)
+
+      expect(dataset.getTitle()).to.deep.equal(datasetExpected.title)
+      expect(dataset.locks).to.deep.equal([
+        {
+          id: 0,
+          reason: DatasetLockReason.FINALIZE_PUBLICATION
+        }
+      ])
+    })
   })
 })

--- a/tests/e2e-integration/integration/users/infrastructure/repositories/UserJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/users/infrastructure/repositories/UserJSDataverseRepository.spec.ts
@@ -12,7 +12,7 @@ describe('User JSDataverse Repository', () => {
   beforeEach(() => TestsUtils.login())
 
   it('gets the authenticated user', async () => {
-    const expectedUser = { name: 'Dataverse Admin' }
+    const expectedUser = { name: 'Dataverse Admin', persistentId: 'dataverseAdmin' }
     const user = await userRepository.getAuthenticated()
 
     expect(user).to.deep.equal(expectedUser)

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -1,6 +1,7 @@
 import newDatasetData from '../../fixtures/dataset-finch1.json'
 import { DataverseApiHelper } from '../DataverseApiHelper'
 import { FileData } from '../files/FileHelper'
+import { DatasetLockReason } from '../../../../src/dataset/domain/models/Dataset'
 
 export interface DatasetResponse {
   persistentId: string
@@ -145,5 +146,16 @@ export class DatasetHelper extends DataverseApiHelper {
       fieldType,
       'text/plain'
     )
+  }
+
+  static async lock(
+    id: string,
+    reason: DatasetLockReason
+  ): Promise<{
+    status: string
+  }> {
+    return this.request<{
+      status: string
+    }>(`/datasets/${id}/lock/${reason}`, 'POST')
   }
 }


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the integration of the SPA with the js-dataverse implementation to get the dataset locks.

## Which issue(s) this PR closes:

- Closes #206 

## Special notes for your reviewer:
I didn't add an e2e test because the integration + unit tests seemed enough.

## Suggestions on how to test this:
### Step 1: Run the development environment
1. Run `npm I`
3. `cd packages/design-system && npm run build`
4. `cd ../../`
5. Check that you have a  `.env` file such as the .env.example, with the `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000` variable
6.  `cd dev-env`
7. `./run-env.sh unstable`
8. To check the environment go to <http://localhost:8000> and check your local dataverse installation

### Step 2: Test Dataset View mode with the implemented changes
1. Go to <http://localhost:8000>
2. Login as admin using username: dataverseAdmin and password: admin1
3. Create a new Dataset
4. Force a publication lock in the dataset using `curl -H "X-Dataverse-key: $API_TOKEN" -X POST "$SERVER_URL/api/datasets/$ID/lock/finalizePublication"` [Check docs](https://dataverse-guide--9872.org.readthedocs.build/en/9872/api/native-api.html#dataset-locks)
5. From the dataset view mode copy the search parameters from the url. Ex.: `?persistentId=doi:10.5072/FK2/LHGRHP&version=DRAFT`
6. Go to <http://localhost:8000/spa/datasets> and paste the search parameters. Ex.: <http://localhost:8000/spa/datasets?persistentId=doi:10.5072/FK2/LHGRHP&version=DRAFT>
8. You are seeing now the same Dataset in the SPA. Check that the buttons disabled in JSF are also disabled in the SPA. 

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
