### PR TITLE
220 - Fix: Filters disappear when the filters result in one 1 file

### DIFF
--- a/src/files/domain/models/FileCriteria.ts
+++ b/src/files/domain/models/FileCriteria.ts
@@ -62,6 +62,15 @@ export class FileCriteria {
       searchText
     )
   }
+
+  get someFilterApplied(): boolean {
+    return (
+      this.filterByType !== undefined ||
+      this.filterByAccess !== undefined ||
+      this.filterByTag !== undefined ||
+      this.searchText !== undefined
+    )
+  }
 }
 
 export enum FileSortByOption {

--- a/src/sections/dataset/dataset-files/file-criteria-form/FileCriteriaForm.tsx
+++ b/src/sections/dataset/dataset-files/file-criteria-form/FileCriteriaForm.tsx
@@ -18,7 +18,10 @@ export function FileCriteriaForm({
   onCriteriaChange,
   filesCountInfo
 }: FileCriteriaInputsProps) {
-  if (!filesCountInfo || filesCountInfo.total < MINIMUM_FILES_TO_SHOW_CRITERIA_INPUTS) {
+  if (
+    !filesCountInfo ||
+    (filesCountInfo.total < MINIMUM_FILES_TO_SHOW_CRITERIA_INPUTS && !criteria.someFilterApplied)
+  ) {
     return <></>
   }
   return (

--- a/tests/component/sections/dataset/dataset-files/file-criteria-form/FileCriteriaForm.spec.tsx
+++ b/tests/component/sections/dataset/dataset-files/file-criteria-form/FileCriteriaForm.spec.tsx
@@ -289,4 +289,23 @@ describe('FileCriteriaForm', () => {
 
     cy.findByLabelText('Search').should('have.value', 'test')
   })
+
+  it('renders the file criteria if there are less than 2 files but there is a filter applied', () => {
+    const criteria = new FileCriteria()
+      .withFilterByTag('document')
+      .withFilterByAccess(FileAccessOption.PUBLIC)
+      .withFilterByType('image')
+
+    cy.customMount(
+      <FileCriteriaForm
+        criteria={criteria}
+        onCriteriaChange={onCriteriaChange}
+        filesCountInfo={FilesCountInfoMother.create({ total: 1 })}
+      />
+    )
+
+    cy.findByRole('button', { name: 'File Type: Image' }).should('exist')
+    cy.findByRole('button', { name: 'Access: Public' }).should('exist')
+    cy.findByRole('button', { name: 'File Tags: Document' }).should('exist')
+  })
 })

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -300,7 +300,7 @@ describe('Dataset', () => {
         })
     })
 
-    it('applies filters to the Files Table in the correct order', () => {
+    it.only('applies filters to the Files Table in the correct order', () => {
       const files = [
         FileHelper.create('csv', {
           description: 'Some description',
@@ -403,6 +403,25 @@ describe('Dataset', () => {
           cy.findByText('blob-3').should('not.exist')
           cy.get('table > tbody > tr').eq(0).should('contain', 'blob-5')
           cy.get('table > tbody > tr').eq(1).should('contain', 'blob-4')
+
+          cy.findByLabelText('Search').clear().type('blob-5{enter}', { force: true })
+
+          cy.findByText('1 to 1 of 1 Files').should('exist')
+          cy.findByText('blob').should('not.exist')
+          cy.findByText('blob-1').should('not.exist')
+          cy.findByText('blob-2').should('not.exist')
+          cy.findByText('blob-3').should('not.exist')
+          cy.findByText('blob-4').should('not.exist')
+          cy.findByText('blob-5').should('exist')
+
+          cy.findByLabelText('Search').clear().type('{enter}', { force: true })
+          cy.findByText('1 to 3 of 3 Files').should('exist')
+          cy.findByText('blob').should('exist')
+          cy.findByText('blob-1').should('not.exist')
+          cy.findByText('blob-2').should('not.exist')
+          cy.findByText('blob-3').should('not.exist')
+          cy.findByText('blob-4').should('exist')
+          cy.findByText('blob-5').should('exist')
         })
     })
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR fixes an incorrect behaviour that hides the filters and search bar when the filters results in just 1 file.

The expected behaviour is that after using the filters, if the result is just 1 file, you still can see and use the filters and search bar.

## Which issue(s) this PR closes:

- Closes #202

## Special notes for your reviewer:

## Suggestions on how to test this:
### Step 1: Run the development environment
1. Run `npm I`
3. `cd packages/design-system && npm run build`
4. `cd ../../`
5. Check that you have a  `.env` file such as the .env.example, with the `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000` variable
6.  `cd dev-env`
7. `./run-env.sh unstable`
8. To check the environment go to <http://localhost:8000> and check your local dataverse installation

### Step 2: Test Dataset View mode
1. Go to <http://localhost:8000>
2. Login as admin using username: dataverseAdmin and password: admin1
3. Create a new Dataset and add different type of files.
5. From the dataset view mode copy the search parameters from the url. Ex.: `?persistentId=doi:10.5072/FK2/LHGRHP&version=DRAFT`
6. Go to <http://localhost:8000/spa/datasets> and paste the search parameters. Ex.: <http://localhost:8000/spa/datasets?persistentId=doi:10.5072/FK2/LHGRHP&version=DRAFT>
8. You are seeing now the same Dataset in the SPA. Use the filters to show just 1 result and check that the filters are still available so you can go back to showing all the results. 

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
Video from the incorrect behaviour:

![bugfilters](https://github.com/IQSS/dataverse-frontend/assets/17010447/11fe50da-822e-46db-ae50-4a95f9058854)