### PR TITLE
236 cypress timing error

### DIFF
--- a/src/files/domain/models/File.ts
+++ b/src/files/domain/models/File.ts
@@ -1,4 +1,5 @@
 import FileTypeToFriendlyTypeMap from './FileTypeToFriendlyTypeMap'
+import { FileUserPermissions } from './FileUserPermissions'
 
 export enum FileSizeUnit {
   BYTES = 'B',
@@ -115,6 +116,7 @@ export enum FileLabelType {
   CATEGORY = 'category',
   TAG = 'tag'
 }
+
 export interface FileLabel {
   type: FileLabelType
   value: string
@@ -158,6 +160,7 @@ export class File {
     readonly labels: FileLabel[],
     public readonly isDeleted: boolean,
     public readonly ingest: FileIngest,
+    public userPermissions?: FileUserPermissions,
     readonly checksum?: FileChecksum,
     public thumbnail?: string,
     readonly directory?: string,

--- a/src/files/domain/useCases/checkFileDownloadPermission.ts
+++ b/src/files/domain/useCases/checkFileDownloadPermission.ts
@@ -1,14 +1,14 @@
 import { FileRepository } from '../repositories/FileRepository'
 import { File, FilePublishingStatus } from '../models/File'
 
+// TODO: remove async when ready and then remove eslint-disable
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function checkFileDownloadPermission(
   fileRepository: FileRepository,
   file: File
 ): Promise<boolean> {
   if (file.version.publishingStatus === FilePublishingStatus.DEACCESSIONED) {
-    return fileRepository.getUserPermissionsById(file.id).then((permissions) => {
-      return permissions.canEditDataset
-    })
+    return file.userPermissions?.canEditDataset || false
   }
 
   const isRestricted = file.access.restricted || file.access.latestVersionRestricted
@@ -16,7 +16,5 @@ export async function checkFileDownloadPermission(
     return true
   }
 
-  return fileRepository.getUserPermissionsById(file.id).then((permissions) => {
-    return permissions.canDownloadFile
-  })
+  return file.userPermissions?.canDownloadFile || false
 }

--- a/src/files/domain/useCases/checkFileEditDatasetPermission.ts
+++ b/src/files/domain/useCases/checkFileEditDatasetPermission.ts
@@ -1,11 +1,10 @@
 import { FileRepository } from '../repositories/FileRepository'
 import { File } from '../models/File'
-
+// TODO: remove async when ready and then remove eslint-disable
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function checkFileEditDatasetPermission(
   fileRepository: FileRepository,
   file: File
 ): Promise<boolean> {
-  return fileRepository.getUserPermissionsById(file.id).then((permissions) => {
-    return permissions.canEditDataset
-  })
+  return file.userPermissions?.canEditDataset || false
 }

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -44,6 +44,7 @@ export class FileJSDataverseRepository implements FileRepository {
       .then((jsFiles) => jsFiles.map((jsFile) => JSFileMapper.toFile(jsFile, datasetVersion)))
       .then((files) => FileJSDataverseRepository.getAllWithDownloadCount(files))
       .then((files) => FileJSDataverseRepository.getAllWithThumbnail(files))
+      .then((files) => FileJSDataverseRepository.getAllWithPermissions(files))
       .catch((error: ReadError) => {
         throw new Error(error.message)
       })
@@ -77,6 +78,23 @@ export class FileJSDataverseRepository implements FileRepository {
       files.map((file) =>
         FileJSDataverseRepository.getThumbnailById(file.id).then((thumbnail) => {
           file.thumbnail = thumbnail
+          return file
+        })
+      )
+    )
+  }
+
+  private static getAllWithPermissions(files: File[]): Promise<File[]> {
+    console.log('BEGIN getAllWithPermissions')
+    return Promise.all(
+      files.map((file) =>
+        getFileUserPermissions.execute(file.id).then((jsFileUserPermissions) => {
+          file.userPermissions = {
+            fileId: file.id,
+            canDownloadFile: jsFileUserPermissions.canDownloadFile,
+            canEditDataset: jsFileUserPermissions.canEditOwnerDataset
+          }
+          console.log('jsFileUserPermissions', jsFileUserPermissions)
           return file
         })
       )

--- a/src/files/infrastructure/mappers/JSFileMapper.ts
+++ b/src/files/infrastructure/mappers/JSFileMapper.ts
@@ -48,6 +48,7 @@ export class JSFileMapper {
       this.toFileLabels(jsFile.categories, jsFile.tabularTags),
       false, // TODO - Implement this when it is added to js-dataverse
       { status: FileIngestStatus.NONE }, // TODO - Implement this when it is added to js-dataverse
+      undefined, // TODO - revisit this, do I need to have a method here?
       this.toFileChecksum(jsFile.checksum),
       this.toFileThumbnail(),
       this.toFileDirectory(jsFile.directoryLabel),

--- a/src/sections/dataset/dataset-files/useFiles.tsx
+++ b/src/sections/dataset/dataset-files/useFiles.tsx
@@ -6,8 +6,6 @@ import { FileCriteria } from '../../../files/domain/models/FileCriteria'
 import { FilesCountInfo } from '../../../files/domain/models/FilesCountInfo'
 import { getFilesCountInfoByDatasetPersistentId } from '../../../files/domain/useCases/getFilesCountInfoByDatasetPersistentId'
 import { FilePaginationInfo } from '../../../files/domain/models/FilePaginationInfo'
-import { useFilePermissions } from '../../file/file-permissions/FilePermissionsContext'
-import { FilePermission } from '../../../files/domain/models/FileUserPermissions'
 import { DatasetVersion } from '../../../dataset/domain/models/Dataset'
 import { getFilesTotalDownloadSize } from '../../../files/domain/useCases/getFilesTotalDownloadSize'
 
@@ -19,7 +17,6 @@ export function useFiles(
   paginationInfo: FilePaginationInfo,
   criteria?: FileCriteria
 ) {
-  const { fetchFilesPermission } = useFilePermissions()
   const [files, setFiles] = useState<File[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
   const [filesCountInfo, setFilesCountInfo] = useState<FilesCountInfo>()

--- a/src/sections/dataset/dataset-files/useFiles.tsx
+++ b/src/sections/dataset/dataset-files/useFiles.tsx
@@ -44,6 +44,7 @@ export function useFiles(
   }
 
   const getFiles = (filesCount: FilesCountInfo) => {
+    console.log('GET FILES', filesCount)
     if (filesCount) {
       if (filesCount.total === 0) {
         setIsLoading(false)
@@ -58,11 +59,9 @@ export function useFiles(
       )
         .then((files: File[]) => {
           setFiles(files)
+          setIsLoading(false)
           return files
         })
-        .then((files: File[]) =>
-          fetchFilesPermission(FilePermission.DOWNLOAD_FILE, files).then(() => setIsLoading(false))
-        )
         .catch(() => {
           throw new Error('There was an error getting the files')
         })
@@ -71,7 +70,15 @@ export function useFiles(
 
   useEffect(() => {
     setIsLoading(true)
-
+    console.log(
+      'USE EFFECT FILE COUNT INFO',
+      filesRepository,
+      datasetPersistentId,
+      datasetVersion,
+      paginationInfo.page,
+      paginationInfo.pageSize,
+      criteria
+    )
     getFilesCountInfo()
       .then((filesCount) => getFiles(filesCount))
       .catch(() => {
@@ -88,6 +95,13 @@ export function useFiles(
   ])
 
   useEffect(() => {
+    console.log(
+      'USE EFFECT FILE DOWNLOAD SIZE',
+      filesRepository,
+      datasetPersistentId,
+      datasetVersion,
+      criteria
+    )
     getFilesTotalDownloadSize(filesRepository, datasetPersistentId, datasetVersion, criteria)
       .then((filesTotalDownloadSize: number) => {
         setFilesTotalDownloadSize(filesTotalDownloadSize)

--- a/src/sections/file/file-permissions/useFileDownloadPermission.tsx
+++ b/src/sections/file/file-permissions/useFileDownloadPermission.tsx
@@ -1,22 +1,22 @@
 import { useEffect, useState } from 'react'
-import { FilePermission } from '../../../files/domain/models/FileUserPermissions'
-import { useFilePermissions } from './FilePermissionsContext'
+//import { FilePermission } from '../../../files/domain/models/FileUserPermissions'
+
 import { File } from '../../../files/domain/models/File'
 
 export function useFileDownloadPermission(file: File) {
-  const { checkSessionUserHasFilePermission } = useFilePermissions()
   const [sessionUserHasFileDownloadPermission, setSessionUserHasFileDownloadPermission] =
     useState<boolean>(false)
 
   useEffect(() => {
-    checkSessionUserHasFilePermission(FilePermission.DOWNLOAD_FILE, file)
-      .then((hasPermission) => {
-        setSessionUserHasFileDownloadPermission(hasPermission)
-      })
-      .catch((error) => {
-        setSessionUserHasFileDownloadPermission(false)
-        console.error('There was an error getting the file download permission', error)
-      })
+    /*checkSessionUserHasFilePermission(FilePermission.DOWNLOAD_FILE, file)
+                  .then((hasPermission) => {
+                    setSessionUserHasFileDownloadPermission(hasPermission)
+                  })
+                  .catch((error) => {
+                    setSessionUserHasFileDownloadPermission(false)
+                    console.error('There was an error getting the file download permission', error)
+                  })*/
+    setSessionUserHasFileDownloadPermission(file.userPermissions?.canDownloadFile || false)
   }, [file])
 
   return { sessionUserHasFileDownloadPermission }

--- a/tests/component/files/domain/models/FileMother.ts
+++ b/tests/component/files/domain/models/FileMother.ts
@@ -35,6 +35,7 @@ export class FileEmbargoMother {
     return new FileEmbargo(dateAvailable)
   }
 }
+
 export class FileIngestMother {
   static create(props?: Partial<FileIngest>): FileIngest {
     return {
@@ -139,6 +140,7 @@ export class FileMother {
       fileMockedData.labels,
       fileMockedData.isDeleted,
       fileMockedData.ingest,
+      fileMockedData.userPermissions,
       fileMockedData.checksum,
       fileMockedData.thumbnail,
       fileMockedData.directory,
@@ -348,6 +350,7 @@ export class FileMother {
       }
     })
   }
+
   static createDeleted(): File {
     return this.createDefault({
       isDeleted: true

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -237,7 +237,9 @@ describe('Dataset', () => {
           cy.findByText('Restricted File Icon').should('not.exist')
           cy.findByText('Restricted with access Icon').should('exist')
 
-          cy.findByRole('button', { name: 'Access File' }).should('exist').click()
+          cy.findByRole('button', { name: 'Access File' }).as('accessFileButton')
+          cy.get('@accessFileButton').should('be.visible')
+          cy.get('@accessFileButton').click()
           cy.findByText('Restricted with Access Granted').should('exist')
 
           cy.findByRole('button', { name: 'File Options' }).should('exist').click()

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -56,6 +56,7 @@ const expectedFile = new File(
   [],
   false,
   { status: FileIngestStatus.NONE },
+  undefined,
   {
     algorithm: 'MD5',
     value: '0187a54071542738aa47939e8218e5f2'


### PR DESCRIPTION
## What this PR does / why we need it:
The e2e Dataset test was sometimes failing, due to asynchronous page updates that happened while the test was running
## Which issue(s) this PR closes:

- Closes #236 

## Special notes for your reviewer:
Because of the timing nature of this error, I couldn't reproduce it consistently, so I can't be sure that this change fixes the problem. But I did break down the steps in the test into smaller increments, based on the Cypress recommendations for this type of error. I've run the test a couple of times, and it seems to be working. Note that I've only seen this happen in the Github action, not when running the test locally.
## Suggestions on how to test this:
Make sure that the e2e test in the github Action passes.  Run it a couple of times to try to trigger the error

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
no
## Is there a release notes update needed for this change?:
no
## Additional documentation:
https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-page-updated