### PR TITLE
236 - Cypress timing error

### DIFF
--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -277,11 +277,14 @@ describe('Dataset', () => {
 
           cy.findByText('Restricted File Icon').should('not.exist')
           cy.findByText('Restricted with access Icon').should('exist')
-
-          cy.findByRole('button', { name: 'Access File' }).should('exist').click()
+          cy.findByRole('button', { name: 'Access File' }).as('accessButton')
+          cy.get('@accessButton').should('exist')
+          cy.get('@accessButton').click()
           cy.findByText('Restricted with Access Granted').should('exist')
 
-          cy.findByRole('button', { name: 'File Options' }).should('exist').click()
+          cy.findByRole('button', { name: 'File Options' }).as('fileOptions')
+          cy.get('@fileOptions').should('exist')
+          cy.get('@fileOptions').click()
           cy.findByText('Unrestrict').should('exist')
         })
     })
@@ -361,7 +364,9 @@ describe('Dataset', () => {
 
             cy.findByText('Edit Files').should('exist')
 
-            cy.findByRole('button', { name: 'Access File' }).should('exist').click()
+            cy.findByRole('button', { name: 'Access File' }).as('accessButton')
+            cy.get('@accessButton').should('exist')
+            cy.get('@accessButton').click()
             cy.findByText('Embargoed').should('exist')
           })
       })


### PR DESCRIPTION
## What this PR does / why we need it:
In the e2e test, the Dataset tests are sometimes failing because the page is asynchronously updated during the Cypress call to click the AccessFileMenu.  To avoid this, the Cypress command for finding the button and the call to click the button are separated into two statements.
here is Cypress documentation on the issue: https://docs.cypress.io/guides/references/error-messages#cy-failed-because-the-page-updated

## Which issue(s) this PR closes:

- Closes #236 

## Special notes for your reviewer:
Due to the timing nature of the error, it's hard to reproduce consistently.  I was able to get my local dev environment in a state where it was happening by adding some console.log statements, and when I applied the fix, the error no longer happened.  
## Suggestions on how to test this:
Run the e2e test locally and check the e2e test on Github Actions.  

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
no
## Is there a release notes update needed for this change?:
no
## Additional documentation:
