### PR TITLE
244 - Integration download dataset

### DIFF
--- a/public/locales/en/dataset.json
+++ b/public/locales/en/dataset.json
@@ -58,7 +58,7 @@
         "header": "Download Options",
         "zip": "Download ZIP",
         "originalZip": "Original Format ZIP",
-        "archiveZip": "Archive Format (.tab) ZIP"
+        "archivalZip": "Archival Format (.tab) ZIP"
       }
     },
     "uploadFiles": "Upload Files"

--- a/public/locales/en/dataset.json
+++ b/public/locales/en/dataset.json
@@ -54,9 +54,12 @@
     },
     "accessDataset": {
       "title": "Access Dataset",
-      "downloadZip": "Download ZIP",
-      "downloadOriginalZip": "Original Format ZIP",
-      "downloadArchiveZip": "Archive Format (.tab) ZIP"
+      "downloadOptions": {
+        "header": "Download Options",
+        "zip": "Download ZIP",
+        "originalZip": "Original Format ZIP",
+        "archiveZip": "Archive Format (.tab) ZIP"
+      }
     },
     "uploadFiles": "Upload Files"
   },

--- a/src/dataset/domain/models/Dataset.ts
+++ b/src/dataset/domain/models/Dataset.ts
@@ -264,6 +264,11 @@ export interface PrivateUrl {
   urlSnippet: string
 }
 
+export interface DatasetDownloadUrls {
+  original: string
+  archival: string
+}
+
 export class Dataset {
   constructor(
     public readonly persistentId: string,
@@ -280,9 +285,10 @@ export class Dataset {
     public readonly hasOneTabularFileAtLeast: boolean,
     public readonly isValid: boolean,
     public readonly isReleased: boolean,
+    public readonly downloadUrls: DatasetDownloadUrls,
+    public readonly fileDownloadSizes: FileDownloadSize[],
     public readonly thumbnail?: string,
-    public readonly privateUrl?: PrivateUrl,
-    public readonly fileDownloadSizes?: FileDownloadSize[]
+    public readonly privateUrl?: PrivateUrl
   ) {}
 
   public getTitle(): string {
@@ -365,9 +371,10 @@ export class Dataset {
       public readonly hasOneTabularFileAtLeast: boolean,
       public readonly isValid: boolean,
       public readonly isReleased: boolean,
+      public readonly downloadUrls: DatasetDownloadUrls,
+      public readonly fileDownloadSizes: FileDownloadSize[],
       public readonly thumbnail?: string,
-      public readonly privateUrl?: PrivateUrl,
-      public readonly fileDownloadSizes?: FileDownloadSize[]
+      public readonly privateUrl?: PrivateUrl
     ) {
       this.withLabels()
       this.withAlerts()
@@ -475,9 +482,10 @@ export class Dataset {
         this.hasOneTabularFileAtLeast,
         this.isValid,
         this.isReleased,
+        this.downloadUrls,
+        this.fileDownloadSizes,
         this.thumbnail,
-        this.privateUrl,
-        this.fileDownloadSizes
+        this.privateUrl
       )
     }
   }

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -1,27 +1,28 @@
 import {
   Dataset as JSDataset,
+  DatasetLock as JSDatasetLock,
   DatasetMetadataBlock as JSDatasetMetadataBlock,
   DatasetMetadataBlocks as JSDatasetMetadataBlocks,
   DatasetMetadataFields as JSDatasetMetadataFields,
-  DatasetVersionInfo as JSDatasetVersionInfo,
   DatasetUserPermissions as JSDatasetPermissions,
-  DatasetLock as JSDatasetLock
+  DatasetVersionInfo as JSDatasetVersionInfo
 } from '@iqss/dataverse-client-javascript'
 import { DatasetVersionState as JSDatasetVersionState } from '@iqss/dataverse-client-javascript/dist/datasets/domain/models/Dataset'
 import {
   Dataset,
-  DatasetPublishingStatus,
+  DatasetDownloadUrls,
+  DatasetLock,
+  DatasetLockReason,
   DatasetMetadataBlock,
   DatasetMetadataBlocks,
   DatasetMetadataFields,
+  DatasetPermissions,
+  DatasetPublishingStatus,
   DatasetVersion,
   MetadataBlockName,
-  DatasetPermissions,
-  DatasetLock,
-  DatasetLockReason,
-  PrivateUrl,
-  DatasetDownloadUrls
+  PrivateUrl
 } from '../../domain/models/Dataset'
+import { FileDownloadMode, FileDownloadSize, FileSizeUnit } from '../../../files/domain/models/File'
 
 export class JSDatasetMapper {
   static toDataset(
@@ -30,6 +31,8 @@ export class JSDatasetMapper {
     summaryFieldsNames: string[],
     jsDatasetPermissions: JSDatasetPermissions,
     jsDatasetLocks: JSDatasetLock[],
+    jsDatasetFilesTotalOriginalDownloadSize: number,
+    jsDatasetFilesTotalArchivalDownloadSize: number,
     requestedVersion?: string,
     privateUrl?: PrivateUrl
   ): Dataset {
@@ -57,7 +60,10 @@ export class JSDatasetMapper {
       true, // TODO Connect with dataset isValid
       JSDatasetMapper.toIsReleased(jsDataset.versionInfo),
       JSDatasetMapper.toDownloadUrls(jsDataset.persistentId, version),
-      [], // TODO: Connect with file download use case
+      JSDatasetMapper.toFileDownloadSizes(
+        jsDatasetFilesTotalOriginalDownloadSize,
+        jsDatasetFilesTotalArchivalDownloadSize
+      ),
       undefined, // TODO: get dataset thumbnail from Dataverse https://github.com/IQSS/dataverse-frontend/issues/203
       privateUrl
     ).build()
@@ -228,5 +234,23 @@ export class JSDatasetMapper {
       original: `/api/access/dataset/:persistentId/versions/${version.toString()}?persistentId=${jsDatasetPersistentId}&format=original`,
       archival: `/api/access/dataset/:persistentId/versions/${version.toString()}?persistentId=${jsDatasetPersistentId}`
     }
+  }
+
+  static toFileDownloadSizes(
+    jsDatasetFilesTotalOriginalDownloadSize: number,
+    jsDatasetFilesTotalArchivalDownloadSize: number
+  ): FileDownloadSize[] {
+    return [
+      new FileDownloadSize(
+        jsDatasetFilesTotalOriginalDownloadSize,
+        FileSizeUnit.BYTES,
+        FileDownloadMode.ORIGINAL
+      ),
+      new FileDownloadSize(
+        jsDatasetFilesTotalArchivalDownloadSize,
+        FileSizeUnit.BYTES,
+        FileDownloadMode.ARCHIVAL
+      )
+    ]
   }
 }

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -19,7 +19,8 @@ import {
   DatasetPermissions,
   DatasetLock,
   DatasetLockReason,
-  PrivateUrl
+  PrivateUrl,
+  DatasetDownloadUrls
 } from '../../domain/models/Dataset'
 
 export class JSDatasetMapper {
@@ -32,9 +33,14 @@ export class JSDatasetMapper {
     requestedVersion?: string,
     privateUrl?: PrivateUrl
   ): Dataset {
+    const version = JSDatasetMapper.toVersion(
+      jsDataset.versionId,
+      jsDataset.versionInfo,
+      requestedVersion
+    )
     return new Dataset.Builder(
       jsDataset.persistentId,
-      JSDatasetMapper.toVersion(jsDataset.versionId, jsDataset.versionInfo, requestedVersion),
+      version,
       citation,
       JSDatasetMapper.toSummaryFields(jsDataset.metadataBlocks, summaryFieldsNames),
       jsDataset.license,
@@ -50,7 +56,7 @@ export class JSDatasetMapper {
       true, // TODO Connect with dataset hasOneTabularFileAtLeast
       true, // TODO Connect with dataset isValid
       JSDatasetMapper.toIsReleased(jsDataset.versionInfo),
-      undefined,
+      JSDatasetMapper.toDownloadUrls(jsDataset.persistentId, version),
       [], // TODO: Connect with file download use case
       undefined, // TODO: get dataset thumbnail from Dataverse https://github.com/IQSS/dataverse-frontend/issues/203
       privateUrl
@@ -212,5 +218,15 @@ export class JSDatasetMapper {
         reason: jsDatasetLock.lockType as unknown as DatasetLockReason
       }
     })
+  }
+
+  static toDownloadUrls(
+    jsDatasetPersistentId: string,
+    version: DatasetVersion
+  ): DatasetDownloadUrls {
+    return {
+      original: `/api/access/dataset/:persistentId/versions/${version.toString()}?persistentId=${jsDatasetPersistentId}&format=original`,
+      archival: `/api/access/dataset/:persistentId/versions/${version.toString()}?persistentId=${jsDatasetPersistentId}`
+    }
   }
 }

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -50,9 +50,10 @@ export class JSDatasetMapper {
       true, // TODO Connect with dataset hasOneTabularFileAtLeast
       true, // TODO Connect with dataset isValid
       JSDatasetMapper.toIsReleased(jsDataset.versionInfo),
+      undefined,
+      [], // TODO: Connect with file download use case
       undefined, // TODO: get dataset thumbnail from Dataverse https://github.com/IQSS/dataverse-frontend/issues/203
-      privateUrl,
-      [] // TODO: Connect with file download use case
+      privateUrl
     ).build()
   }
 

--- a/src/files/domain/models/File.ts
+++ b/src/files/domain/models/File.ts
@@ -63,17 +63,16 @@ export class FileSize {
   }
 }
 
-export enum FileDownloadSizeMode {
-  ALL = 'All',
-  ORIGINAL = 'Original',
-  ARCHIVAL = 'Archival'
+export enum FileDownloadMode {
+  ORIGINAL = 'original',
+  ARCHIVAL = 'archival'
 }
 
 export class FileDownloadSize extends FileSize {
   constructor(
     readonly value: number,
     readonly unit: FileSizeUnit,
-    readonly mode: FileDownloadSizeMode
+    readonly mode: FileDownloadMode
   ) {
     super(value, unit)
   }

--- a/src/files/domain/models/File.ts
+++ b/src/files/domain/models/File.ts
@@ -20,7 +20,7 @@ export class FileSize {
   }
 
   constructor(readonly value: number, readonly unit: FileSizeUnit) {
-    ;[this.value, this.unit] = this.convertToLargestUnit(value, unit)
+    ;[this.value, this.unit] = FileSize.convertToLargestUnit(value, unit)
   }
 
   toString(): string {
@@ -33,7 +33,7 @@ export class FileSize {
     return this.value * FileSize.multiplier[this.unit]
   }
 
-  private convertToLargestUnit(value: number, unit: FileSizeUnit): [number, FileSizeUnit] {
+  static convertToLargestUnit(value: number, unit: FileSizeUnit): [number, FileSizeUnit] {
     let convertedValue = value
     let convertedUnit = unit
 
@@ -45,7 +45,7 @@ export class FileSize {
     return [convertedValue, convertedUnit]
   }
 
-  private getNextUnit(unit: FileSizeUnit): FileSizeUnit {
+  static getNextUnit(unit: FileSizeUnit): FileSizeUnit {
     switch (unit) {
       case FileSizeUnit.BYTES:
         return FileSizeUnit.KILOBYTES
@@ -75,6 +75,7 @@ export class FileDownloadSize extends FileSize {
     readonly mode: FileDownloadMode
   ) {
     super(value, unit)
+    ;[this.value, this.unit] = FileDownloadSize.convertToLargestUnit(value, unit)
   }
 }
 

--- a/src/sections/dataset/dataset-action-buttons/DatasetActionButtons.tsx
+++ b/src/sections/dataset/dataset-action-buttons/DatasetActionButtons.tsx
@@ -21,6 +21,7 @@ export function DatasetActionButtons({ dataset }: DatasetActionButtonsProps) {
         permissions={dataset.permissions}
         hasOneTabularFileAtLeast={dataset.hasOneTabularFileAtLeast}
         fileDownloadSizes={dataset.fileDownloadSizes}
+        downloadUrls={dataset.downloadUrls}
       />
       <PublishDatasetMenu dataset={dataset} />
       <SubmitForReviewButton dataset={dataset} />

--- a/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
@@ -66,7 +66,7 @@ const DatasetDownloadOptions = ({
 }: DatasetDownloadOptionsProps) => {
   const { t } = useTranslation('dataset')
   function getFormattedFileSize(mode: FileDownloadMode): string {
-    const foundSize = fileDownloadSizes && fileDownloadSizes.find((size) => size.mode === mode)
+    const foundSize = fileDownloadSizes.find((size) => size.mode === mode)
     return foundSize ? foundSize.toString() : ''
   }
 
@@ -77,14 +77,14 @@ const DatasetDownloadOptions = ({
         {getFormattedFileSize(FileDownloadMode.ORIGINAL)})
       </DropdownButtonItem>
       <DropdownButtonItem href={downloadUrls[FileDownloadMode.ARCHIVAL]}>
-        {t('datasetActionButtons.accessDataset.downloadOptions.archiveZip')} (
+        {t('datasetActionButtons.accessDataset.downloadOptions.archivalZip')} (
         {getFormattedFileSize(FileDownloadMode.ARCHIVAL)})
       </DropdownButtonItem>
     </>
   ) : (
     <DropdownButtonItem href={downloadUrls[FileDownloadMode.ORIGINAL]}>
       {t('datasetActionButtons.accessDataset.downloadOptions.zip')} (
-      {getFormattedFileSize(FileDownloadMode.ORIGINAL)}) )
+      {getFormattedFileSize(FileDownloadMode.ORIGINAL)})
     </DropdownButtonItem>
   )
 }

--- a/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
@@ -1,4 +1,5 @@
 import {
+  DatasetDownloadUrls,
   DatasetPermissions,
   DatasetPublishingStatus,
   DatasetVersion
@@ -6,22 +7,26 @@ import {
 import { DropdownButton, DropdownButtonItem, DropdownHeader } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
 
-import { FileDownloadSize, FileDownloadSizeMode } from '../../../../files/domain/models/File'
+import { FileDownloadSize, FileDownloadMode } from '../../../../files/domain/models/File'
 import { Download } from 'react-bootstrap-icons'
 
 interface AccessDatasetMenuProps {
   version: DatasetVersion
   permissions: DatasetPermissions
   hasOneTabularFileAtLeast: boolean
-  fileDownloadSizes?: FileDownloadSize[]
+  fileDownloadSizes: FileDownloadSize[]
+  downloadUrls: DatasetDownloadUrls
 }
 
 export function AccessDatasetMenu({
   version,
   permissions,
   hasOneTabularFileAtLeast,
-  fileDownloadSizes
+  fileDownloadSizes,
+  downloadUrls
 }: AccessDatasetMenuProps) {
+  const { t } = useTranslation('dataset')
+
   if (
     !permissions.canDownloadFiles ||
     (version.publishingStatus === DatasetPublishingStatus.DEACCESSIONED &&
@@ -30,41 +35,6 @@ export function AccessDatasetMenu({
     return <></>
   }
 
-  function getFormattedFileSize(mode: FileDownloadSizeMode): string {
-    const foundSize = fileDownloadSizes && fileDownloadSizes.find((size) => size.mode === mode)
-    return foundSize ? foundSize.toString() : ''
-  }
-
-  const handleDownload = (type: FileDownloadSizeMode) => {
-    //TODO: implement download feature
-    console.log('downloading file ' + type)
-  }
-
-  interface DatasetDownloadOptionsProps {
-    datasetContainsTabularFiles: boolean
-  }
-
-  const DatasetDownloadOptions = ({ datasetContainsTabularFiles }: DatasetDownloadOptionsProps) => {
-    return datasetContainsTabularFiles ? (
-      <>
-        <DropdownButtonItem onClick={() => handleDownload(FileDownloadSizeMode.ORIGINAL)}>
-          {t('datasetActionButtons.accessDataset.downloadOriginalZip')} (
-          {getFormattedFileSize(FileDownloadSizeMode.ORIGINAL)})
-        </DropdownButtonItem>
-        <DropdownButtonItem onClick={() => handleDownload(FileDownloadSizeMode.ARCHIVAL)}>
-          {t('datasetActionButtons.accessDataset.downloadArchiveZip')} (
-          {getFormattedFileSize(FileDownloadSizeMode.ARCHIVAL)})
-        </DropdownButtonItem>
-      </>
-    ) : (
-      <DropdownButtonItem onClick={() => handleDownload(FileDownloadSizeMode.ORIGINAL)}>
-        {t('datasetActionButtons.accessDataset.downloadZip')} (
-        {getFormattedFileSize(FileDownloadSizeMode.ORIGINAL)}) )
-      </DropdownButtonItem>
-    )
-  }
-
-  const { t } = useTranslation('dataset')
   return (
     <DropdownButton
       id={`access-dataset-menu`}
@@ -72,10 +42,50 @@ export function AccessDatasetMenu({
       asButtonGroup
       variant="primary">
       <DropdownHeader>
-        Download Options <Download></Download>
+        {t('datasetActionButtons.accessDataset.downloadOptions.header')} <Download></Download>
       </DropdownHeader>
-      <DatasetDownloadOptions datasetContainsTabularFiles={hasOneTabularFileAtLeast} />
+      <DatasetDownloadOptions
+        hasOneTabularFileAtLeast={hasOneTabularFileAtLeast}
+        fileDownloadSizes={fileDownloadSizes}
+        downloadUrls={downloadUrls}
+      />
     </DropdownButton>
+  )
+}
+
+interface DatasetDownloadOptionsProps {
+  hasOneTabularFileAtLeast: boolean
+  fileDownloadSizes: FileDownloadSize[]
+  downloadUrls: DatasetDownloadUrls
+}
+
+const DatasetDownloadOptions = ({
+  hasOneTabularFileAtLeast,
+  fileDownloadSizes,
+  downloadUrls
+}: DatasetDownloadOptionsProps) => {
+  const { t } = useTranslation('dataset')
+  function getFormattedFileSize(mode: FileDownloadMode): string {
+    const foundSize = fileDownloadSizes && fileDownloadSizes.find((size) => size.mode === mode)
+    return foundSize ? foundSize.toString() : ''
+  }
+
+  return hasOneTabularFileAtLeast ? (
+    <>
+      <DropdownButtonItem href={downloadUrls[FileDownloadMode.ORIGINAL]}>
+        {t('datasetActionButtons.accessDataset.downloadOptions.originalZip')} (
+        {getFormattedFileSize(FileDownloadMode.ORIGINAL)})
+      </DropdownButtonItem>
+      <DropdownButtonItem href={downloadUrls[FileDownloadMode.ARCHIVAL]}>
+        {t('datasetActionButtons.accessDataset.downloadOptions.archiveZip')} (
+        {getFormattedFileSize(FileDownloadMode.ARCHIVAL)})
+      </DropdownButtonItem>
+    </>
+  ) : (
+    <DropdownButtonItem href={downloadUrls[FileDownloadMode.ORIGINAL]}>
+      {t('datasetActionButtons.accessDataset.downloadOptions.zip')} (
+      {getFormattedFileSize(FileDownloadMode.ORIGINAL)}) )
+    </DropdownButtonItem>
   )
 }
 

--- a/src/stories/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.stories.tsx
+++ b/src/stories/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { WithI18next } from '../../../WithI18next'
 import { WithSettings } from '../../../WithSettings'
 import {
+  DatasetDownloadUrlsMother,
   DatasetFileDownloadSizeMother,
   DatasetPermissionsMother,
   DatasetVersionMother
@@ -28,6 +29,7 @@ export const WithDownloadNotAllowed: Story = {
       version={DatasetVersionMother.createReleased()}
       permissions={DatasetPermissionsMother.createWithFilesDownloadNotAllowed()}
       fileDownloadSizes={[DatasetFileDownloadSizeMother.createOriginal()]}
+      downloadUrls={DatasetDownloadUrlsMother.create()}
     />
   )
 }
@@ -38,6 +40,7 @@ export const WithoutTabularFiles: Story = {
       version={DatasetVersionMother.createReleased()}
       permissions={DatasetPermissionsMother.createWithAllAllowed()}
       fileDownloadSizes={[DatasetFileDownloadSizeMother.createOriginal()]}
+      downloadUrls={DatasetDownloadUrlsMother.create()}
     />
   )
 }
@@ -51,6 +54,7 @@ export const WithTabularFiles: Story = {
         DatasetFileDownloadSizeMother.createArchival(),
         DatasetFileDownloadSizeMother.createOriginal()
       ]}
+      downloadUrls={DatasetDownloadUrlsMother.create()}
     />
   )
 }

--- a/tests/component/dataset/domain/models/DatasetMother.ts
+++ b/tests/component/dataset/domain/models/DatasetMother.ts
@@ -204,12 +204,12 @@ export class DatasetFileDownloadSizeMother {
     )
   }
 
-  static createArchival(): FileDownloadSize {
-    return this.create({ mode: FileDownloadMode.ARCHIVAL })
+  static createArchival(props?: Partial<FileDownloadSize>): FileDownloadSize {
+    return this.create({ mode: FileDownloadMode.ARCHIVAL, ...props })
   }
 
-  static createOriginal(): FileDownloadSize {
-    return this.create({ mode: FileDownloadMode.ORIGINAL })
+  static createOriginal(props?: Partial<FileDownloadSize>): FileDownloadSize {
+    return this.create({ mode: FileDownloadMode.ORIGINAL, ...props })
   }
 }
 

--- a/tests/component/dataset/domain/models/DatasetMother.ts
+++ b/tests/component/dataset/domain/models/DatasetMother.ts
@@ -2,6 +2,7 @@ import { faker } from '@faker-js/faker'
 import {
   ANONYMIZED_FIELD_VALUE,
   Dataset,
+  DatasetDownloadUrls,
   DatasetLabelSemanticMeaning,
   DatasetLabelValue,
   DatasetLock,
@@ -14,7 +15,7 @@ import {
 } from '../../../../../src/dataset/domain/models/Dataset'
 import {
   FileDownloadSize,
-  FileDownloadSizeMode,
+  FileDownloadMode,
   FileSizeUnit
 } from '../../../../../src/files/domain/models/File'
 
@@ -199,16 +200,33 @@ export class DatasetFileDownloadSizeMother {
     return new FileDownloadSize(
       props?.value ?? faker.datatype.number(),
       props?.unit ?? faker.helpers.arrayElement(Object.values(FileSizeUnit)),
-      props?.mode ?? faker.helpers.arrayElement(Object.values(FileDownloadSizeMode))
+      props?.mode ?? faker.helpers.arrayElement(Object.values(FileDownloadMode))
     )
   }
 
   static createArchival(): FileDownloadSize {
-    return this.create({ mode: FileDownloadSizeMode.ARCHIVAL })
+    return this.create({ mode: FileDownloadMode.ARCHIVAL })
   }
 
   static createOriginal(): FileDownloadSize {
-    return this.create({ mode: FileDownloadSizeMode.ORIGINAL })
+    return this.create({ mode: FileDownloadMode.ORIGINAL })
+  }
+}
+
+export class DatasetDownloadUrlsMother {
+  static create(props?: Partial<DatasetDownloadUrls>): DatasetDownloadUrls {
+    return {
+      original: this.createDownloadUrl(),
+      archival: this.createDownloadUrl(),
+      ...props
+    }
+  }
+
+  static createDownloadUrl(): string {
+    const blob = new Blob(['Name,Age,Location\nJohn,25,New York\nJane,30,San Francisco'], {
+      type: 'text/csv'
+    })
+    return URL.createObjectURL(blob)
   }
 }
 
@@ -315,9 +333,10 @@ export class DatasetMother {
       hasOneTabularFileAtLeast: faker.datatype.boolean(),
       isValid: faker.datatype.boolean(),
       isReleased: faker.datatype.boolean(),
+      downloadUrls: DatasetDownloadUrlsMother.create(),
       thumbnail: undefined,
       privateUrl: undefined,
-      fileDownloadSizes: undefined,
+      fileDownloadSizes: [],
       ...props
     }
 
@@ -334,9 +353,10 @@ export class DatasetMother {
       dataset.hasOneTabularFileAtLeast,
       dataset.isValid,
       dataset.isReleased,
+      dataset.downloadUrls,
+      dataset.fileDownloadSizes,
       dataset.thumbnail,
-      dataset.privateUrl,
-      dataset.fileDownloadSizes
+      dataset.privateUrl
     ).build()
   }
 
@@ -470,8 +490,8 @@ export class DatasetMother {
       hasValidTermsOfAccess: true,
       hasOneTabularFileAtLeast: true,
       fileDownloadSizes: [
-        new FileDownloadSize(21.98, FileSizeUnit.KILOBYTES, FileDownloadSizeMode.ORIGINAL),
-        new FileDownloadSize(21.98, FileSizeUnit.KILOBYTES, FileDownloadSizeMode.ARCHIVAL)
+        new FileDownloadSize(21.98, FileSizeUnit.KILOBYTES, FileDownloadMode.ORIGINAL),
+        new FileDownloadSize(21.98, FileSizeUnit.KILOBYTES, FileDownloadMode.ARCHIVAL)
       ],
       isValid: true,
       ...props

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -147,7 +147,11 @@ const expectedDataset = {
   isReleased: false,
   thumbnail: undefined,
   privateUrl: undefined,
-  fileDownloadSizes: []
+  fileDownloadSizes: [],
+  downloadUrls: {
+    original: `/api/access/dataset/:persistentId/versions/0.0?persistentId=doi:10.5072/FK2/B4B2MJ&format=original`,
+    archival: `/api/access/dataset/:persistentId/versions/0.0?persistentId=doi:10.5072/FK2/B4B2MJ`
+  }
 }
 const expectedDatasetAlternateVersion = {
   persistentId: 'doi:10.5072/FK2/B4B2MJ',
@@ -237,7 +241,11 @@ const expectedDatasetAlternateVersion = {
     canPublishDataset: true,
     canUpdateDataset: true
   },
-  thumbnail: undefined
+  thumbnail: undefined,
+  downloadUrls: {
+    original: `/api/access/dataset/:persistentId/versions/0.0?persistentId=doi:10.5072/FK2/B4B2MJ&format=original`,
+    archival: `/api/access/dataset/:persistentId/versions/0.0?persistentId=doi:10.5072/FK2/B4B2MJ`
+  }
 }
 describe('JS Dataset Mapper', () => {
   it('maps jsDataset model to the domain Dataset model', () => {

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -11,6 +11,11 @@ import {
   DatasetMetadataBlock
 } from '@iqss/dataverse-client-javascript/dist/datasets/domain/models/Dataset'
 import { DatasetLockReason } from '../../../../../src/dataset/domain/models/Dataset'
+import {
+  FileDownloadMode,
+  FileDownloadSize,
+  FileSizeUnit
+} from '../../../../../src/files/domain/models/File'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -70,6 +75,8 @@ const jsDatasetLocks: JSDatasetLock[] = [
     datasetPersistentId: 'doi:10.5072/FK2/B4B2MJ'
   }
 ]
+const jsDatasetFilesTotalOriginalDownloadSize = 5
+const jsDatasetFilesTotalArchivalDownloadSize = 7
 const expectedDataset = {
   persistentId: 'doi:10.5072/FK2/B4B2MJ',
   version: {
@@ -147,7 +154,10 @@ const expectedDataset = {
   isReleased: false,
   thumbnail: undefined,
   privateUrl: undefined,
-  fileDownloadSizes: [],
+  fileDownloadSizes: [
+    new FileDownloadSize(5, FileSizeUnit.BYTES, FileDownloadMode.ORIGINAL),
+    new FileDownloadSize(7, FileSizeUnit.BYTES, FileDownloadMode.ARCHIVAL)
+  ],
   downloadUrls: {
     original: `/api/access/dataset/:persistentId/versions/0.0?persistentId=doi:10.5072/FK2/B4B2MJ&format=original`,
     archival: `/api/access/dataset/:persistentId/versions/0.0?persistentId=doi:10.5072/FK2/B4B2MJ`
@@ -172,7 +182,10 @@ const expectedDatasetAlternateVersion = {
   isReleased: false,
   isValid: true,
   privateUrl: undefined,
-  fileDownloadSizes: [],
+  fileDownloadSizes: [
+    new FileDownloadSize(5, FileSizeUnit.BYTES, FileDownloadMode.ORIGINAL),
+    new FileDownloadSize(7, FileSizeUnit.BYTES, FileDownloadMode.ARCHIVAL)
+  ],
   labels: [
     { semanticMeaning: 'dataset', value: 'Draft' },
     { semanticMeaning: 'warning', value: 'Unpublished' }
@@ -254,7 +267,9 @@ describe('JS Dataset Mapper', () => {
       citation,
       datasetSummaryFields,
       jsDatasetPermissions,
-      jsDatasetLocks
+      jsDatasetLocks,
+      jsDatasetFilesTotalOriginalDownloadSize,
+      jsDatasetFilesTotalArchivalDownloadSize
     )
     expect(expectedDataset).to.deep.equal(mapped)
   })
@@ -265,6 +280,8 @@ describe('JS Dataset Mapper', () => {
       datasetSummaryFields,
       jsDatasetPermissions,
       jsDatasetLocks,
+      jsDatasetFilesTotalOriginalDownloadSize,
+      jsDatasetFilesTotalArchivalDownloadSize,
       '4.0'
     )
 
@@ -306,7 +323,9 @@ describe('JS Dataset Mapper', () => {
         citation,
         datasetSummaryFields,
         jsDatasetPermissions,
-        jsDatasetLocks
+        jsDatasetLocks,
+        jsDatasetFilesTotalOriginalDownloadSize,
+        jsDatasetFilesTotalArchivalDownloadSize
       )
     )
   })
@@ -346,7 +365,9 @@ describe('JS Dataset Mapper', () => {
         citation,
         datasetSummaryFields,
         jsDatasetPermissions,
-        jsDatasetLocks
+        jsDatasetLocks,
+        jsDatasetFilesTotalOriginalDownloadSize,
+        jsDatasetFilesTotalArchivalDownloadSize
       )
     )
   })
@@ -385,7 +406,9 @@ describe('JS Dataset Mapper', () => {
         citation,
         datasetSummaryFields,
         jsDatasetPermissions,
-        jsDatasetLocks
+        jsDatasetLocks,
+        jsDatasetFilesTotalOriginalDownloadSize,
+        jsDatasetFilesTotalArchivalDownloadSize
       )
     )
   })

--- a/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
@@ -1,10 +1,12 @@
 import { AccessDatasetMenu } from '../../../../../../src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu'
 import {
+  DatasetDownloadUrlsMother,
   DatasetFileDownloadSizeMother,
   DatasetPermissionsMother,
   DatasetVersionMother
 } from '../../../../dataset/domain/models/DatasetMother'
 
+const downloadUrls = DatasetDownloadUrlsMother.create()
 describe('AccessDatasetMenu', () => {
   it('renders the AccessDatasetMenu if the user has download files permissions and the dataset is not deaccessioned', () => {
     const version = DatasetVersionMother.createReleased()
@@ -19,6 +21,7 @@ describe('AccessDatasetMenu', () => {
         hasOneTabularFileAtLeast={true}
         version={version}
         permissions={permissions}
+        downloadUrls={downloadUrls}
       />
     )
 
@@ -41,6 +44,7 @@ describe('AccessDatasetMenu', () => {
         hasOneTabularFileAtLeast={true}
         version={version}
         permissions={permissions}
+        downloadUrls={downloadUrls}
       />
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')
@@ -59,6 +63,7 @@ describe('AccessDatasetMenu', () => {
         hasOneTabularFileAtLeast={true}
         version={version}
         permissions={permissions}
+        downloadUrls={downloadUrls}
       />
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('not.exist')
@@ -77,10 +82,12 @@ describe('AccessDatasetMenu', () => {
         hasOneTabularFileAtLeast={true}
         version={version}
         permissions={permissions}
+        downloadUrls={downloadUrls}
       />
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('not.exist')
   })
+
   it('displays one dropdown option if there are no tabular files', () => {
     const version = DatasetVersionMother.createReleased()
     const permissions = DatasetPermissionsMother.createWithFilesDownloadAllowed()
@@ -91,12 +98,16 @@ describe('AccessDatasetMenu', () => {
         hasOneTabularFileAtLeast={false}
         version={version}
         permissions={permissions}
+        downloadUrls={downloadUrls}
       />
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')
     cy.findByRole('button', { name: 'Access Dataset' }).click()
-    cy.findByText(/Download ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/).should('exist')
+    cy.findByText(/Download ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/)
+      .should('exist')
+      .should('have.attr', 'href', downloadUrls.original)
   })
+
   it('displays two dropdown options if there is at least one', () => {
     const version = DatasetVersionMother.createReleased()
     const permissions = DatasetPermissionsMother.createWithFilesDownloadAllowed()
@@ -110,11 +121,16 @@ describe('AccessDatasetMenu', () => {
         hasOneTabularFileAtLeast={true}
         version={version}
         permissions={permissions}
+        downloadUrls={downloadUrls}
       />
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')
     cy.findByRole('button', { name: 'Access Dataset' }).click()
-    cy.findByText(/Original Format ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/).should('exist')
-    cy.findByText(/Archive Format \(\.tab\) ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/).should('exist')
+    cy.findByText(/Original Format ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/)
+      .should('exist')
+      .should('have.attr', 'href', downloadUrls.original)
+    cy.findByText(/Archive Format \(\.tab\) ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/)
+      .should('exist')
+      .should('have.attr', 'href', downloadUrls.archival)
   })
 })

--- a/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
@@ -5,6 +5,7 @@ import {
   DatasetPermissionsMother,
   DatasetVersionMother
 } from '../../../../dataset/domain/models/DatasetMother'
+import { FileSizeUnit } from '../../../../../../src/files/domain/models/File'
 
 const downloadUrls = DatasetDownloadUrlsMother.create()
 describe('AccessDatasetMenu', () => {
@@ -91,7 +92,9 @@ describe('AccessDatasetMenu', () => {
   it('displays one dropdown option if there are no tabular files', () => {
     const version = DatasetVersionMother.createReleased()
     const permissions = DatasetPermissionsMother.createWithFilesDownloadAllowed()
-    const fileDownloadSizes = [DatasetFileDownloadSizeMother.createOriginal()]
+    const fileDownloadSizes = [
+      DatasetFileDownloadSizeMother.createOriginal({ value: 2000, unit: FileSizeUnit.BYTES })
+    ]
     cy.customMount(
       <AccessDatasetMenu
         fileDownloadSizes={fileDownloadSizes}
@@ -103,7 +106,7 @@ describe('AccessDatasetMenu', () => {
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')
     cy.findByRole('button', { name: 'Access Dataset' }).click()
-    cy.findByText(/Download ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/)
+    cy.findByText('Download ZIP (2 KB)')
       .should('exist')
       .should('have.attr', 'href', downloadUrls.original)
   })
@@ -112,8 +115,11 @@ describe('AccessDatasetMenu', () => {
     const version = DatasetVersionMother.createReleased()
     const permissions = DatasetPermissionsMother.createWithFilesDownloadAllowed()
     const fileDownloadSizes = [
-      DatasetFileDownloadSizeMother.createOriginal(),
-      DatasetFileDownloadSizeMother.createArchival()
+      DatasetFileDownloadSizeMother.createOriginal({ value: 2000, unit: FileSizeUnit.BYTES }),
+      DatasetFileDownloadSizeMother.createArchival({
+        value: 43483094340394,
+        unit: FileSizeUnit.BYTES
+      })
     ]
     cy.customMount(
       <AccessDatasetMenu
@@ -126,10 +132,10 @@ describe('AccessDatasetMenu', () => {
     )
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')
     cy.findByRole('button', { name: 'Access Dataset' }).click()
-    cy.findByText(/Original Format ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/)
+    cy.findByText('Original Format ZIP (2 KB)')
       .should('exist')
       .should('have.attr', 'href', downloadUrls.original)
-    cy.findByText(/Archive Format \(\.tab\) ZIP \(\d+(\.\d+)? (B|KB|MB|GB|TB|PB)\)/)
+    cy.findByText('Archival Format (.tab) ZIP (39.5 TB)')
       .should('exist')
       .should('have.attr', 'href', downloadUrls.archival)
   })

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -367,7 +367,7 @@ describe('Dataset', () => {
       })
     })
 
-    it.only('applies filters to the Files Table in the correct order', () => {
+    it('applies filters to the Files Table in the correct order', () => {
       const files = [
         FileHelper.create('csv', {
           description: 'Some description',

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -504,4 +504,38 @@ describe('Dataset', () => {
         })
     })
   })
+
+  it('downloads the dataset', () => {
+    cy.wrap(
+      DatasetHelper.createWithFiles(FileHelper.createMany(2)).then((dataset) =>
+        DatasetHelper.publish(dataset.persistentId)
+      )
+    )
+      .its('persistentId')
+      .then((persistentId: string) => {
+        cy.wait(1500) // Wait for the dataset to be published
+        cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+        cy.wait(1500) // Wait for the page to load
+
+        cy.findByText('Files').should('exist')
+
+        cy.findByRole('button', { name: 'Access Dataset' }).should('exist').click({ force: true })
+
+        // Workaround for issue where Cypress gets stuck on the download
+        cy.window()
+          .document()
+          .then(function (doc) {
+            doc.addEventListener('click', () => {
+              setTimeout(function () {
+                doc.location.reload()
+              }, 5000)
+            })
+            cy.findByRole('link', { name: /Original Format ZIP/ })
+              .should('exist')
+              .click({ force: true })
+          })
+
+        cy.findAllByText('1 Downloads').should('exist')
+      })
+  })
 })

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -90,7 +90,11 @@ const datasetData = (persistentId: string, versionId: number) => {
       canManageFilesPermissions: true,
       canDeleteDataset: true
     },
-    locks: []
+    locks: [],
+    downloadUrls: {
+      original: `/api/access/dataset/:persistentId/versions/:draft?persistentId=${persistentId}&format=original`,
+      archival: `/api/access/dataset/:persistentId/versions/:draft?persistentId=${persistentId}`
+    }
   }
 }
 
@@ -119,6 +123,7 @@ describe('Dataset JSDataverse Repository', () => {
       expect(dataset.metadataBlocks[0].fields.citationDate).not.to.exist
       expect(dataset.permissions).to.deep.equal(datasetExpected.permissions)
       expect(dataset.locks).to.deep.equal(datasetExpected.locks)
+      expect(dataset.downloadUrls).to.deep.equal(datasetExpected.downloadUrls)
     })
   })
 

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -8,6 +8,11 @@ import {
   DatasetVersion
 } from '../../../../src/dataset/domain/models/Dataset'
 import { DatasetHelper } from '../../shared/datasets/DatasetHelper'
+import {
+  FileDownloadMode,
+  FileDownloadSize,
+  FileSizeUnit
+} from '../../../../src/files/domain/models/File'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -94,7 +99,11 @@ const datasetData = (persistentId: string, versionId: number) => {
     downloadUrls: {
       original: `/api/access/dataset/:persistentId/versions/:draft?persistentId=${persistentId}&format=original`,
       archival: `/api/access/dataset/:persistentId/versions/:draft?persistentId=${persistentId}`
-    }
+    },
+    fileDownloadSizes: [
+      new FileDownloadSize(0, FileSizeUnit.BYTES, FileDownloadMode.ORIGINAL),
+      new FileDownloadSize(0, FileSizeUnit.BYTES, FileDownloadMode.ARCHIVAL)
+    ]
   }
 }
 
@@ -124,6 +133,7 @@ describe('Dataset JSDataverse Repository', () => {
       expect(dataset.permissions).to.deep.equal(datasetExpected.permissions)
       expect(dataset.locks).to.deep.equal(datasetExpected.locks)
       expect(dataset.downloadUrls).to.deep.equal(datasetExpected.downloadUrls)
+      expect(dataset.fileDownloadSizes).to.deep.equal(datasetExpected.fileDownloadSizes)
     })
   })
 


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the integration to download the dataset using the Dataverse API. With this integration the user would be able to download the dataset both in original and archival formats using the Access Dataset button in the Dataset page.

## Which issue(s) this PR closes:

- Closes #244 

## Special notes for your reviewer:

## Suggestions on how to test this:
### Step 1: Run the development environment
1. Run `npm I`
3. `cd packages/design-system && npm run build`
4. `cd ../../`
5. Check that you have a  `.env` file such as the .env.example, with the `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000` variable
6.  `cd dev-env`
7. `./run-env.sh unstable`
8. To check the environment go to <http://localhost:8000> and check your local dataverse installation

### Step 2: Test Dataset View mode with the implemented changes to download the files
1. Go to <http://localhost:8000>
2. Login as admin using username: dataverseAdmin and password: admin1
3. Create a new Dataset
4. Upload some files to the dataset
5. From the dataset view mode copy the search parameters from the url. Ex.: `?persistentId=doi:10.5072/FK2/LHGRHP&version=DRAFT`
6. Go to <http://localhost:8000/spa/datasets> and paste the search parameters. Ex.: <http://localhost:8000/spa/datasets?persistentId=doi:10.5072/FK2/LHGRHP&version=DRAFT>
8. You are currently viewing the same dataset in the SPA. In the files table, locate the "Access Dataset" dropdown on the right of the page. Use the button to download the dataset and check that is working as expected.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
