### PR TITLE
272 move file permissions

### DIFF
--- a/src/files/domain/models/File.ts
+++ b/src/files/domain/models/File.ts
@@ -1,4 +1,5 @@
 import FileTypeToFriendlyTypeMap from './FileTypeToFriendlyTypeMap'
+import { FileUserPermissions } from './FileUserPermissions'
 
 export enum FileSizeUnit {
   BYTES = 'B',
@@ -182,6 +183,7 @@ export class File {
     public readonly isDeleted: boolean,
     public readonly ingest: FileIngest,
     public readonly downloadUrls: FileDownloadUrls,
+    public userPermissions?: FileUserPermissions,
     public thumbnail?: string,
     readonly directory?: string,
     readonly embargo?: FileEmbargo,
@@ -192,6 +194,9 @@ export class File {
 
   getLink(): string {
     return `/file?id=${this.id}&version=${this.version.number}`
+  }
+  get userHasDownloadPermission(): boolean {
+    return this.userPermissions?.canDownloadFile || false
   }
 
   get isActivelyEmbargoed(): boolean {

--- a/src/files/domain/models/File.ts
+++ b/src/files/domain/models/File.ts
@@ -1,5 +1,4 @@
 import FileTypeToFriendlyTypeMap from './FileTypeToFriendlyTypeMap'
-import { FileUserPermissions } from './FileUserPermissions'
 
 export enum FileSizeUnit {
   BYTES = 'B',
@@ -8,6 +7,10 @@ export enum FileSizeUnit {
   GIGABYTES = 'GB',
   TERABYTES = 'TB',
   PETABYTES = 'PB'
+}
+export interface FilePermissions {
+  canDownloadFile: boolean
+  canEditDataset: boolean
 }
 
 export class FileSize {
@@ -183,7 +186,7 @@ export class File {
     public readonly isDeleted: boolean,
     public readonly ingest: FileIngest,
     public readonly downloadUrls: FileDownloadUrls,
-    public userPermissions?: FileUserPermissions,
+    public filePermissions?: FilePermissions,
     public thumbnail?: string,
     readonly directory?: string,
     readonly embargo?: FileEmbargo,
@@ -196,7 +199,7 @@ export class File {
     return `/file?id=${this.id}&version=${this.version.number}`
   }
   get userHasDownloadPermission(): boolean {
-    return this.userPermissions?.canDownloadFile || false
+    return this.filePermissions?.canDownloadFile || false
   }
 
   get isActivelyEmbargoed(): boolean {

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -1,5 +1,5 @@
 import { FileRepository } from '../domain/repositories/FileRepository'
-import { File, FileDownloadMode } from '../domain/models/File'
+import { File, FileDownloadMode, FilePermissions } from '../domain/models/File'
 import { FilesCountInfo } from '../domain/models/FilesCountInfo'
 import { FileUserPermissions } from '../domain/models/FileUserPermissions'
 import {

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -1,6 +1,7 @@
 import { FileRepository } from '../domain/repositories/FileRepository'
 import { FilesCountInfo } from '../domain/models/FilesCountInfo'
 import { FileUserPermissions } from '../domain/models/FileUserPermissions'
+import { File, FileDownloadMode } from '../domain/models/File'
 import {
   File as JSFile,
   FileDataTable as JSFileTabularData,

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -6,6 +6,7 @@ import {
   File as JSFile,
   FileDataTable as JSFileTabularData,
   FileDownloadSizeMode,
+  FileUserPermissions as JSFileUserPermissions,
   getDatasetFileCounts,
   getDatasetFiles,
   getDatasetFilesTotalDownloadSize,
@@ -48,15 +49,17 @@ export class FileJSDataverseRepository implements FileRepository {
           jsFiles,
           FileJSDataverseRepository.getAllDownloadCount(jsFiles),
           FileJSDataverseRepository.getAllThumbnails(jsFiles),
+          FileJSDataverseRepository.getAllWithPermissions(jsFiles),
           FileJSDataverseRepository.getAllTabularData(jsFiles)
         ])
       )
-      .then(([jsFiles, downloadCounts, thumbnails, jsTabularData]) =>
+      .then(([jsFiles, downloadCounts, thumbnails, jsFileUserPermissions, jsTabularData]) =>
         jsFiles.map((jsFile, index) =>
           JSFileMapper.toFile(
             jsFile,
             datasetVersion,
             downloadCounts[index],
+            jsFileUserPermissions[index],
             thumbnails[index],
             jsTabularData[index]
           )
@@ -90,7 +93,15 @@ export class FileJSDataverseRepository implements FileRepository {
   private static getAllThumbnails(jsFiles: JSFile[]): Promise<(string | undefined)[]> {
     return Promise.all(jsFiles.map((jsFile) => this.getThumbnailById(jsFile.id)))
   }
+  private static getAllWithPermissions(files: JSFile[]): Promise<JSFileUserPermissions[]> {
+    return Promise.all(files.map((jsFile) => this.getFileUserPermissionById(jsFile.id)))
+  }
 
+  private static getFileUserPermissionById(id: number): Promise<JSFileUserPermissions> {
+    return getFileUserPermissions.execute(id).then((jsFileUserPermissions) => {
+      return jsFileUserPermissions
+    })
+  }
   private static getThumbnailById(id: number): Promise<string | undefined> {
     return fetch(`${this.DATAVERSE_BACKEND_URL}/api/access/datafile/${id}?imageThumb=400`)
       .then((response) => {

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -1,5 +1,4 @@
 import { FileRepository } from '../domain/repositories/FileRepository'
-import { File, FileDownloadMode, FilePermissions } from '../domain/models/File'
 import { FilesCountInfo } from '../domain/models/FilesCountInfo'
 import { FileUserPermissions } from '../domain/models/FileUserPermissions'
 import {

--- a/src/files/infrastructure/mappers/JSFileMapper.ts
+++ b/src/files/infrastructure/mappers/JSFileMapper.ts
@@ -14,7 +14,8 @@ import {
   FileSizeUnit,
   FileTabularData,
   FileType,
-  FileVersion
+  FileVersion,
+  FilePermissions
 } from '../../domain/models/File'
 import {
   File as JSFile,
@@ -60,7 +61,7 @@ export class JSFileMapper {
       this.toFileIsDeleted(jsFile.deleted),
       { status: FileIngestStatus.NONE }, // TODO - Implement this when it is added to js-dataverse
       this.toFileOriginalFileDownloadUrl(jsFile.id),
-      this.toFileUserPermissions(jsFile.id, fileUserPermissions),
+      this.toFilePermissions(fileUserPermissions),
       this.toFileThumbnail(thumbnail),
       this.toFileDirectory(jsFile.directoryLabel),
       this.toFileEmbargo(jsFile.embargo),
@@ -70,6 +71,15 @@ export class JSFileMapper {
     )
   }
 
+  static toFilePermissions(jsFileUserPermissions: {
+    canDownloadFile: boolean
+    canEditOwnerDataset: boolean
+  }): FilePermissions {
+    return {
+      canDownloadFile: jsFileUserPermissions.canDownloadFile,
+      canEditDataset: jsFileUserPermissions.canEditOwnerDataset
+    }
+  }
   static toFileUserPermissions(
     jsFileId: number,
     jsFileUserPermissions: {

--- a/src/files/infrastructure/mappers/JSFileMapper.ts
+++ b/src/files/infrastructure/mappers/JSFileMapper.ts
@@ -18,6 +18,7 @@ import {
 } from '../../domain/models/File'
 import {
   File as JSFile,
+  FileUserPermissions as JSFileUserPermissions,
   FileEmbargo as JSFileEmbargo,
   FileChecksum as JSFileChecksum,
   FileCounts as JSFilesCountInfo,
@@ -42,6 +43,7 @@ export class JSFileMapper {
     jsFile: JSFile,
     datasetVersion: DatasetVersion,
     downloadsCount: number,
+    fileUserPermissions: JSFileUserPermissions,
     thumbnail?: string,
     jsTabularData?: JSFileTabularData[]
   ): File {
@@ -58,6 +60,7 @@ export class JSFileMapper {
       this.toFileIsDeleted(jsFile.deleted),
       { status: FileIngestStatus.NONE }, // TODO - Implement this when it is added to js-dataverse
       this.toFileOriginalFileDownloadUrl(jsFile.id),
+      this.toFileUserPermissions(jsFile.id, fileUserPermissions),
       this.toFileThumbnail(thumbnail),
       this.toFileDirectory(jsFile.directoryLabel),
       this.toFileEmbargo(jsFile.embargo),

--- a/src/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/access-file-menu/FileDownloadOptions.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/access-file-menu/FileDownloadOptions.tsx
@@ -4,7 +4,6 @@ import { File } from '../../../../../../../../files/domain/models/File'
 import { FileTabularDownloadOptions } from './FileTabularDownloadOptions'
 import { FileNonTabularDownloadOptions } from './FileNonTabularDownloadOptions'
 import { useTranslation } from 'react-i18next'
-import { useFileDownloadPermission } from '../../../../../../../file/file-permissions/useFileDownloadPermission'
 
 interface FileDownloadOptionsProps {
   file: File
@@ -12,9 +11,8 @@ interface FileDownloadOptionsProps {
 
 export function FileDownloadOptions({ file }: FileDownloadOptionsProps) {
   const { t } = useTranslation('files')
-  const { sessionUserHasFileDownloadPermission } = useFileDownloadPermission(file)
 
-  if (!sessionUserHasFileDownloadPermission) {
+  if (!file.userHasDownloadPermission) {
     return <></>
   }
 

--- a/tests/component/files/domain/models/FileMother.ts
+++ b/tests/component/files/domain/models/FileMother.ts
@@ -11,7 +11,8 @@ import {
   FileSizeUnit,
   FilePublishingStatus,
   FileType,
-  FileChecksum
+  FileChecksum,
+  FilePermissions
 } from '../../../../../src/files/domain/models/File'
 import FileTypeToFriendlyTypeMap from '../../../../../src/files/domain/models/FileTypeToFriendlyTypeMap'
 
@@ -24,7 +25,24 @@ const createFakeFileLabel = (): FileLabel => ({
   type: faker.helpers.arrayElement(Object.values(FileLabelType)),
   value: faker.lorem.word()
 })
+export class FilePermissionsMother {
+  static create(props?: Partial<FilePermissions>): FilePermissions {
+    return {
+      canDownloadFile: faker.datatype.boolean(),
+      canEditDataset: faker.datatype.boolean(),
+      ...props
+    }
+  }
 
+  static createWithFileDownloadAllowed(): FilePermissions {
+    console.log('createWithFileDownloadAllowed')
+    return this.create({ canDownloadFile: true })
+  }
+
+  static createWithFileDownloadNotAllowed(): FilePermissions {
+    return this.create({ canDownloadFile: false })
+  }
+}
 export class FileEmbargoMother {
   static create(dateAvailable?: Date): FileEmbargo {
     return new FileEmbargo(dateAvailable ?? faker.date.future())
@@ -106,6 +124,7 @@ export class FileMother {
         : [],
       checksum: FileChecksumMother.create(),
       thumbnail: thumbnail,
+      filePermissions: FilePermissionsMother.create(),
       directory: valueOrUndefined<string>(faker.system.directoryPath()),
       embargo: valueOrUndefined<FileEmbargo>(FileEmbargoMother.create()),
       tabularData:
@@ -140,6 +159,7 @@ export class FileMother {
       fileMockedData.isDeleted,
       fileMockedData.ingest,
       fileMockedData.downloadUrls,
+      fileMockedData.filePermissions,
       fileMockedData.thumbnail,
       fileMockedData.directory,
       fileMockedData.embargo,
@@ -173,7 +193,10 @@ export class FileMother {
         canBeRequested: false,
         requested: false
       },
-      permissions: { canDownload: true },
+      filePermissions: {
+        canDownloadFile: false,
+        canEditDataset: false
+      },
       labels: [],
       checksum: undefined,
       thumbnail: undefined,
@@ -233,6 +256,7 @@ export class FileMother {
   }
 
   static createNonTabular(props?: Partial<File>): File {
+    console.log('createNonTabular', props)
     return this.createDefault({
       type: new FileType('text/plain'),
       tabularData: undefined,

--- a/tests/component/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/access-file-menu/FileDownloadOptions.spec.tsx
+++ b/tests/component/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/access-file-menu/FileDownloadOptions.spec.tsx
@@ -1,63 +1,42 @@
 import { FileDownloadOptions } from '../../../../../../../../../../src/sections/dataset/dataset-files/files-table/file-actions/file-actions-cell/file-action-buttons/access-file-menu/FileDownloadOptions'
-import { FileMother } from '../../../../../../../../files/domain/models/FileMother'
-import { FileUserPermissionsMother } from '../../../../../../../../files/domain/models/FileUserPermissionsMother'
-import { FilePermissionsProvider } from '../../../../../../../../../../src/sections/file/file-permissions/FilePermissionsProvider'
-import { FileRepository } from '../../../../../../../../../../src/files/domain/repositories/FileRepository'
+import {
+  FileMother,
+  FilePermissionsMother
+} from '../../../../../../../../files/domain/models/FileMother'
 
-const fileNonTabular = FileMother.createNonTabular()
-const fileTabular = FileMother.createTabular()
-const fileRepository = {} as FileRepository
 describe('FileDownloadOptions', () => {
-  beforeEach(() => {
-    fileRepository.getUserPermissionsById = cy.stub().resolves(
-      FileUserPermissionsMother.create({
-        canDownloadFile: true
-      })
-    )
-  })
-
   it('renders the download options header', () => {
-    cy.customMount(
-      <FilePermissionsProvider repository={fileRepository}>
-        <FileDownloadOptions file={fileNonTabular} />
-      </FilePermissionsProvider>
-    )
+    const fileWithPermission = FileMother.createNonTabular({
+      filePermissions: FilePermissionsMother.createWithFileDownloadAllowed()
+    })
+    cy.customMount(<FileDownloadOptions file={fileWithPermission} />)
 
     cy.findByRole('heading', { name: 'Download Options' }).should('exist')
   })
 
   it('does not render the download options if the user does not have permissions', () => {
-    fileRepository.getUserPermissionsById = cy.stub().resolves(
-      FileUserPermissionsMother.create({
-        canDownloadFile: false
-      })
-    )
-
-    cy.customMount(
-      <FilePermissionsProvider repository={fileRepository}>
-        <FileDownloadOptions file={fileNonTabular} />
-      </FilePermissionsProvider>
-    )
+    const fileWithoutPermission = FileMother.createNonTabular({
+      filePermissions: FilePermissionsMother.createWithFileDownloadNotAllowed()
+    })
+    cy.customMount(<FileDownloadOptions file={fileWithoutPermission} />)
 
     cy.findByRole('heading', { name: 'Download Options' }).should('not.exist')
   })
 
   it('renders the download options for a non-tabular file', () => {
-    cy.customMount(
-      <FilePermissionsProvider repository={fileRepository}>
-        <FileDownloadOptions file={fileNonTabular} />{' '}
-      </FilePermissionsProvider>
-    )
+    const nonTabular = FileMother.createNonTabular({
+      filePermissions: FilePermissionsMother.createWithFileDownloadAllowed()
+    })
+    cy.customMount(<FileDownloadOptions file={nonTabular} />)
 
     cy.findByRole('link', { name: 'Plain Text' }).should('exist')
   })
 
   it('renders the download options for a tabular file', () => {
-    cy.customMount(
-      <FilePermissionsProvider repository={fileRepository}>
-        <FileDownloadOptions file={fileTabular} />
-      </FilePermissionsProvider>
-    )
+    const nonTabular = FileMother.createTabular({
+      filePermissions: FilePermissionsMother.createWithFileDownloadAllowed()
+    })
+    cy.customMount(<FileDownloadOptions file={nonTabular} />)
 
     cy.findByRole('link', { name: 'Comma Separated Values (Original File Format)' }).should('exist')
   })


### PR DESCRIPTION
## What this PR does / why we need it:
To fix Cypress timing error, move loading of file permissions out of React hook

## Which issue(s) this PR closes:

- Closes #

## Special notes for your reviewer:

## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
