### PR TITLE
280 - Use page search param in home page pagination

### DIFF
--- a/src/sections/home/Home.tsx
+++ b/src/sections/home/Home.tsx
@@ -4,9 +4,10 @@ import { DatasetRepository } from '../../dataset/domain/repositories/DatasetRepo
 import { DatasetsList } from './datasets-list/DatasetsList'
 interface HomeProps {
   datasetRepository: DatasetRepository
+  page?: number
 }
 
-export function Home({ datasetRepository }: HomeProps) {
+export function Home({ datasetRepository, page }: HomeProps) {
   const { t } = useTranslation('home')
 
   return (
@@ -14,7 +15,7 @@ export function Home({ datasetRepository }: HomeProps) {
       <header>
         <h1>{t('title')}</h1>
       </header>
-      <DatasetsList datasetRepository={datasetRepository} />
+      <DatasetsList datasetRepository={datasetRepository} page={page} />
     </Row>
   )
 }

--- a/src/sections/home/HomeFactory.tsx
+++ b/src/sections/home/HomeFactory.tsx
@@ -1,10 +1,18 @@
 import { ReactElement } from 'react'
 import { Home } from './Home'
 import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
+import { useSearchParams } from 'react-router-dom'
 
 const datasetRepository = new DatasetJSDataverseRepository()
 export class HomeFactory {
   static create(): ReactElement {
-    return <Home datasetRepository={datasetRepository} />
+    return <HomeWithSearchParams />
   }
+}
+
+function HomeWithSearchParams() {
+  const [searchParams] = useSearchParams()
+  const page = searchParams.get('page') ? parseInt(searchParams.get('page') as string) : undefined
+
+  return <Home datasetRepository={datasetRepository} page={page} />
 }

--- a/src/sections/home/datasets-list/DatasetsList.tsx
+++ b/src/sections/home/datasets-list/DatasetsList.tsx
@@ -47,6 +47,7 @@ export function DatasetsList({ datasetRepository, page }: DatasetsListProps) {
             onPaginationInfoChange={setPaginationInfo}
             initialPaginationInfo={paginationInfo}
             showPageSizeSelector={false}
+            updateQueryParam
           />
         </>
       )}

--- a/src/sections/home/datasets-list/DatasetsList.tsx
+++ b/src/sections/home/datasets-list/DatasetsList.tsx
@@ -12,12 +12,14 @@ import { DatasetCard } from './dataset-card/DatasetCard'
 
 interface DatasetsListProps {
   datasetRepository: DatasetRepository
+  page?: number
 }
+
 const NO_DATASETS = 0
-export function DatasetsList({ datasetRepository }: DatasetsListProps) {
+export function DatasetsList({ datasetRepository, page }: DatasetsListProps) {
   const { setIsLoading } = useLoading()
   const [paginationInfo, setPaginationInfo] = useState<DatasetPaginationInfo>(
-    new DatasetPaginationInfo()
+    new DatasetPaginationInfo(page)
   )
   const { datasets, isLoading } = useDatasets(datasetRepository, setPaginationInfo, paginationInfo)
 

--- a/src/sections/shared/pagination/PaginationControls.tsx
+++ b/src/sections/shared/pagination/PaginationControls.tsx
@@ -6,6 +6,7 @@ import { PaginationInfo } from '../../../shared/domain/models/PaginationInfo'
 import { useEffect, useState } from 'react'
 import { FilePaginationInfo } from '../../../files/domain/models/FilePaginationInfo'
 import { DatasetPaginationInfo } from '../../../dataset/domain/models/DatasetPaginationInfo'
+import { useSearchParams } from 'react-router-dom'
 
 interface PaginationProps {
   onPaginationInfoChange: (
@@ -13,13 +14,16 @@ interface PaginationProps {
   ) => void
   initialPaginationInfo: PaginationInfo<DatasetPaginationInfo | FilePaginationInfo>
   showPageSizeSelector?: boolean
+  updateQueryParam?: boolean
 }
 const NO_PAGES = 0
 export function PaginationControls({
   onPaginationInfoChange,
   initialPaginationInfo,
-  showPageSizeSelector = true
+  showPageSizeSelector = true,
+  updateQueryParam = false
 }: PaginationProps) {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [paginationInfo, setPaginationInfo] = useState<DatasetPaginationInfo | FilePaginationInfo>(
     initialPaginationInfo
   )
@@ -38,7 +42,12 @@ export function PaginationControls({
 
   useEffect(() => {
     onPaginationInfoChange(paginationInfo)
-  }, [paginationInfo.pageSize, paginationInfo.page])
+  }, [paginationInfo.pageSize])
+
+  useEffect(() => {
+    onPaginationInfoChange(paginationInfo)
+    updateQueryParam && setSearchParams({ page: paginationInfo.page.toString() })
+  }, [paginationInfo.page])
 
   useEffect(() => {
     setPaginationInfo(paginationInfo.withTotal(initialPaginationInfo.totalItems))

--- a/tests/component/sections/home/Home.spec.tsx
+++ b/tests/component/sections/home/Home.spec.tsx
@@ -3,7 +3,7 @@ import { DatasetRepository } from '../../../../src/dataset/domain/repositories/D
 import { DatasetPreviewMother } from '../../dataset/domain/models/DatasetPreviewMother'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
-const totalDatasetsCount = 10
+const totalDatasetsCount = 200
 const datasets = DatasetPreviewMother.createMany(totalDatasetsCount)
 describe('Home page', () => {
   beforeEach(() => {
@@ -19,10 +19,16 @@ describe('Home page', () => {
   it('renders the datasets list', () => {
     cy.customMount(<Home datasetRepository={datasetRepository} />)
 
-    cy.wrap(datasetRepository.getAll).should('be.calledOnce')
+    cy.findByText('1 to 10 of 200 Datasets').should('exist')
 
     datasets.forEach((dataset) => {
       cy.findByText(dataset.title).should('exist')
     })
+  })
+
+  it('renders the home correct page when passing the page number as a query param', () => {
+    cy.customMount(<Home datasetRepository={datasetRepository} page={5} />)
+
+    cy.findByText('41 to 50 of 200 Datasets').should('exist')
   })
 })

--- a/tests/component/sections/home/datasets-list/DatasetsList.spec.tsx
+++ b/tests/component/sections/home/datasets-list/DatasetsList.spec.tsx
@@ -55,4 +55,14 @@ describe('Datasets List', () => {
     )
     cy.findByText('51 to 60 of 200 Datasets').should('exist')
   })
+
+  it('renders the datasets list correct page when passing the page number as a query param', () => {
+    cy.customMount(<DatasetsList datasetRepository={datasetRepository} page={5} />)
+
+    cy.wrap(datasetRepository.getAll).should(
+      'be.calledWith',
+      new DatasetPaginationInfo(1, 10, totalDatasetsCount).goToPage(5)
+    )
+    cy.findByText('41 to 50 of 200 Datasets').should('exist')
+  })
 })

--- a/tests/e2e-integration/e2e/sections/home/Home.spec.ts
+++ b/tests/e2e-integration/e2e/sections/home/Home.spec.ts
@@ -19,19 +19,20 @@ describe('Home Page', () => {
   })
 
   it('navigates to a dataset from the list when clicking the title', () => {
-    cy.wrap(DatasetHelper.destroyAll().then(() => DatasetHelper.createWithTitle(title))).then(
-      () => {
-        cy.visit('/spa')
+    cy.wrap(
+      DatasetHelper.destroyAll().then(() => DatasetHelper.createWithTitle(title)),
+      { timeout: 6000 }
+    ).then(() => {
+      cy.visit('/spa')
 
-        cy.findByText(/Dataverse Admin/i).should('exist')
+      cy.findByText(/Dataverse Admin/i).should('exist')
 
-        cy.findByText(title).should('be.visible')
-        cy.findByText(title).click({ force: true })
+      cy.findByText(title).should('be.visible')
+      cy.findByText(title).click({ force: true })
 
-        cy.url().should('include', 'persistentId')
-        cy.findAllByText(title).should('be.visible')
-      }
-    )
+      cy.url().should('include', 'persistentId')
+      cy.findAllByText(title).should('be.visible')
+    })
   })
 
   it('log in Dataverse Admin user', () => {
@@ -52,13 +53,32 @@ describe('Home Page', () => {
   })
 
   it('displays the correct page of the datasets list when passing the page query param', () => {
-    cy.wrap(DatasetHelper.destroyAll().then(() => DatasetHelper.createMany(12))).then(() => {
+    cy.wrap(
+      DatasetHelper.destroyAll().then(() => DatasetHelper.createMany(12)),
+      { timeout: 6000 }
+    ).then(() => {
       cy.visit('/spa?page=2')
 
       cy.findByText(/Root/i).should('exist')
       cy.findByText(/Dataverse Admin/i).should('exist')
 
       cy.findByText('11 to 12 of 12 Datasets').should('exist')
+    })
+  })
+
+  it('updates the query param when updateQueryParam is true', () => {
+    cy.wrap(
+      DatasetHelper.destroyAll().then(() => DatasetHelper.createMany(12)),
+      { timeout: 6000 }
+    ).then(() => {
+      cy.visit('/spa')
+
+      cy.findByText(/Root/i).should('exist')
+      cy.findByText(/Dataverse Admin/i).should('exist')
+
+      cy.findByRole('button', { name: 'Next' }).click()
+      cy.findByText('11 to 12 of 12 Datasets').should('exist')
+      cy.location('search').should('eq', '?page=2')
     })
   })
 })

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -18,22 +18,35 @@ export class DatasetHelper extends DataverseApiHelper {
   static async create(): Promise<DatasetResponse> {
     return this.request<DatasetResponse>(`/dataverses/root/datasets`, 'POST', newDatasetData)
   }
+
   static async createWithTitle(title: string): Promise<DatasetResponse> {
     newDatasetData.datasetVersion.metadataBlocks.citation.fields[0].value = title
     return this.request<DatasetResponse>(`/dataverses/root/datasets`, 'POST', newDatasetData)
   }
+
   static async destroy(persistentId: string): Promise<DatasetResponse> {
     return this.request<DatasetResponse>(
       `/datasets/:persistentId/destroy/?persistentId=${persistentId}`,
       'DELETE'
     )
   }
+
   static async createAndPublish(): Promise<DatasetResponse> {
     const datasetResponse = await DatasetHelper.create()
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.waitForNoLocks(datasetResponse.persistentId)
     return datasetResponse
   }
+
+  static async createMany(amount: number): Promise<DatasetResponse[]> {
+    const datasets = []
+    for (let i = 0; i < amount; i++) {
+      const datasetResponse = await this.create()
+      datasets.push(datasetResponse)
+    }
+    return datasets
+  }
+
   static async destroyAll(): Promise<void> {
     const response = await this.request<{
       items: Array<{ global_id: string }>


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the functionality of navigating the different pages of the datasets list in the home using the url search params.

## Which issue(s) this PR closes:

- Closes #280 

## Special notes for your reviewer:

## Suggestions on how to test this:
### Step 1: Run the development environment
1. Run `npm I`
3. `cd packages/design-system && npm run build`
4. `cd ../../`
5. Check that you have a  `.env` file such as the .env.example, with the `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000` variable
6.  `cd dev-env`
7. `./run-env.sh unstable`
8. To check the environment go to <http://localhost:8000> and check your local dataverse installation

### Step 2: Test the Home
1. Go to <http://localhost:8000>
2. Login as admin using username: dataverseAdmin and password: admin1
3. Create as many datasets are needed to have pagination in the home page
4. Navigate through the pages using the buttons and check that the page search param corresponds to the current page
5. Open a new tab and paste `http://localhost:8000/spa?page=2` to access directly the page 2 using the url

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No
