### PR TITLE
279 - Fix remove loading text

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,7 @@ import { ThemeProvider } from '@iqss/dataverse-design-system'
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement)
 root.render(
   <React.StrictMode>
-    <React.Suspense fallback="loading">
+    <React.Suspense>
       <LoadingProvider>
         <ThemeProvider>
           <App />

--- a/src/stories/WithI18next.tsx
+++ b/src/stories/WithI18next.tsx
@@ -5,7 +5,7 @@ import { StoryFn } from '@storybook/react'
 
 export const WithI18next = (Story: StoryFn) => {
   return (
-    <Suspense fallback={<div>loading translations...</div>}>
+    <Suspense>
       <I18nextProvider i18n={i18next}>
         <Story />
       </I18nextProvider>


### PR DESCRIPTION
## What this PR does / why we need it:
This PR removes the loading text that appears when accessing the SPA.

![image](https://github.com/IQSS/dataverse-frontend/assets/23359572/64999787-f8bf-4c4b-8d41-e97700d6b94b)

## Which issue(s) this PR closes:

- Closes #279 

## Special notes for your reviewer:
The loading message was a placeholder for the React Suspense fallback. This fallback exists to give some feedback to the user about the page being loaded but it didn't seem to be necessary since we don't have long loading times and there is already a loading indicator when accessing any SPA page

Check the video to see the loading text appearing:
https://github.com/IQSS/dataverse-frontend/assets/17010447/60c11a1e-6ad3-4827-861c-1655a5ebb651

## Suggestions on how to test this:
### Step 1: Run the development environment
1. Run `npm I`
3. `cd packages/design-system && npm run build`
4. `cd ../../`
5. Check that you have a  `.env` file such as the .env.example, with the `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000` variable
6.  `cd dev-env`
7. `./run-env.sh unstable`
8. To check the environment go to <http://localhost:8000> and check your local dataverse installation

### Step 2: Test Dataset View mode with the implemented changes to download the files
1. Go to <http://localhost:8000/spa>
2. Check that during the loading of the page, no 'loading' text appears at the top left corner of the page.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
