### PR TITLE
312 - Integration file citation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-pr119.d958605",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr125.e6f6629",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3604,9 +3604,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-pr119.d958605",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr119.d958605/4553b0ded76a1365d9756232948999044379a4d2",
-      "integrity": "sha512-SA8H/2i1adovipzaoDBU/UkskzVsVo5OHqXVwJYsHh1tFPaMI3awfz2btBLY99xc8WxcWmfvy9EBBtMgCJ59jw==",
+      "version": "2.0.0-pr125.e6f6629",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr125.e6f6629/b757ff9142e42b1889145efdffde7d447b07a978",
+      "integrity": "sha512-G8YREju87hYvCJfg8mHmIYf9n+ouSB4LBSnCqJC9988lRzjTy1tDc/GJAFyv46Nl9VwTMMqUZqUergC/h9lPyw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-pr119.d958605",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr125.e6f6629",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -9,6 +9,7 @@ import {
   getDatasetFiles,
   getDatasetFilesTotalDownloadSize,
   getFile,
+  getFileCitation,
   getFileDataTables,
   getFileDownloadCount,
   getFileUserPermissions,
@@ -25,7 +26,6 @@ import { FilePreview } from '../domain/models/FilePreview'
 import { JSFilesCountInfoMapper } from './mappers/JSFilesCountInfoMapper'
 import { JSFileMetadataMapper } from './mappers/JSFileMetadataMapper'
 import { DatasetVersionMother } from '../../../tests/component/dataset/domain/models/DatasetMother'
-import { FileCitationMother } from '../../../tests/component/files/domain/models/FileMother'
 import { FilePermissions } from '../domain/models/FilePermissions'
 import { JSFilePermissionsMapper } from './mappers/JSFilePermissionsMapper'
 
@@ -205,10 +205,12 @@ export class FileJSDataverseRepository implements FileRepository {
       })
   }
 
-  // eslint-disable-next-line unused-imports/no-unused-vars
   private static getCitationById(id: number): Promise<string> {
-    // TODO: Implement once get citation is implemented in js-dataverse https://github.com/IQSS/dataverse-client-javascript/issues/117
-    return Promise.resolve(FileCitationMother.create('File Title'))
+    return getFileCitation
+      .execute(id, undefined, includeDeaccessioned)
+      .catch((error: ReadError) => {
+        throw new Error(error.message)
+      })
   }
 
   getMultipleFileDownloadUrl(ids: number[], downloadMode: FileDownloadMode): string {

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -50,13 +50,13 @@ export class FileJSDataverseRepository implements FileRepository {
         DomainFileMapper.toJSFileSearchCriteria(criteria),
         DomainFileMapper.toJSFileOrderCriteria(criteria.sortBy)
       )
-      .then((jsFiles) =>
+      .then((jsFilesSubset) =>
         Promise.all([
-          jsFiles,
-          FileJSDataverseRepository.getAllDownloadCount(jsFiles),
-          FileJSDataverseRepository.getAllThumbnails(jsFiles),
-          FileJSDataverseRepository.getAllWithPermissions(jsFiles),
-          FileJSDataverseRepository.getAllTabularData(jsFiles)
+          jsFilesSubset.files,
+          FileJSDataverseRepository.getAllDownloadCount(jsFilesSubset.files),
+          FileJSDataverseRepository.getAllThumbnails(jsFilesSubset.files),
+          FileJSDataverseRepository.getAllWithPermissions(jsFilesSubset.files),
+          FileJSDataverseRepository.getAllTabularData(jsFilesSubset.files)
         ])
       )
       .then(([jsFiles, downloadCounts, thumbnails, permissions, tabularData]) =>

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -26,7 +26,6 @@ import { FilePaginationInfo } from '../../../../src/files/domain/models/FilePagi
 import { FilePreview } from '../../../../src/files/domain/models/FilePreview'
 import { DatasetPublishingStatus } from '../../../../src/dataset/domain/models/Dataset'
 import { File } from '../../../../src/files/domain/models/File'
-import { FileCitationMother } from '../../../component/files/domain/models/FileMother'
 import { FileIngest, FileIngestStatus } from '../../../../src/files/domain/models/FileIngest'
 
 chai.use(chaiAsPromised)
@@ -82,6 +81,9 @@ const filePreviewExpectedData = (id: number): FilePreview => {
   }
 }
 
+const expectedFileCitationRegex = new RegExp(
+  `^Finch, Fiona, ${new Date().getFullYear()}, "Darwin's Finches", <a href="https:\\/\\/doi\\.org\\/10\\.5072\\/FK2\\/[A-Z0-9]+" target="_blank">https:\\/\\/doi\\.org\\/10\\.5072\\/FK2\\/[A-Z0-9]+<\\/a>, Root, DRAFT VERSION; blob \\[fileName\\]$`
+)
 const fileExpectedData = (id: number): File => {
   return {
     id: id,
@@ -93,12 +95,7 @@ const fileExpectedData = (id: number): File => {
       canBeRequested: false,
       requested: false
     },
-    citation: FileCitationMother.create('File Title'), // TODO: Implement once get citation is implemented in js-dataverse
-    permissions: {
-      fileId: id,
-      canDownloadFile: true,
-      canEditDataset: true
-    },
+    citation: '',
     ingest: new FileIngest(FileIngestStatus.NONE),
     metadata: {
       type: new FileType('text/plain'),
@@ -823,7 +820,7 @@ describe('File JSDataverse Repository', () => {
         expect(file.access).to.deep.equal(expectedFile.access)
         expect(file.permissions).to.deep.equal(expectedFile.permissions)
         expect(file.datasetVersion).to.deep.equal(expectedFile.datasetVersion)
-        expect(file.citation).to.deep.equal(expectedFile.citation)
+        expect(file.citation).to.match(expectedFileCitationRegex)
         compareMetadata(file.metadata, expectedFile.metadata)
       })
     })


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds the integration of the UI with the js-dataverse implementation to get the file citation.

## Which issue(s) this PR closes:

- Closes #312 

## Special notes for your reviewer:

## Suggestions on how to test this:
### Step 1: Run the development environment
1. Run `npm I`
3. `cd packages/design-system && npm run build`
4. `cd ../../`
5. Check that you have a  `.env` file such as the .env.example, with the `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000` variable
6.  `cd dev-env`
7. `./run-env.sh unstable`
8. To check the environment go to <http://localhost:8000> and check your local dataverse installation

### Step 2: Test File Page
1. Go to <http://localhost:8000>
2. Login as admin using username: dataverseAdmin and password: admin1
3. Create a new Dataset
4. Upload a file to the dataset
5. From the dataset view mode click on some file to go to the File Page in JSF
6. From the url copy the fileId number
7. Go to <http://localhost:8000/spa/files> and paste the fileId number as an id query param to go to the SPA version of the File Page. Ex.: <http://localhost:8000/spa/files?id=212121>
8. You are currently viewing the same file in the SPA.  Check the file citation text, it should match the JSF version.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
