### PR TITLE
Feature/358 add unpublished label to collections page

### DIFF
--- a/src/collection/domain/models/Collection.ts
+++ b/src/collection/domain/models/Collection.ts
@@ -4,6 +4,7 @@ export interface Collection {
   id: string
   name: string
   hierarchy: UpwardHierarchyNode
+  isReleased: boolean
   description?: string
   affiliation?: string
 }

--- a/src/collection/infrastructure/mappers/JSCollectionMapper.ts
+++ b/src/collection/infrastructure/mappers/JSCollectionMapper.ts
@@ -14,6 +14,7 @@ export class JSCollectionMapper {
     return {
       id: jsCollection.alias,
       name: jsCollection.name,
+      isReleased: true, // TODO: replace with real value, waiting for https://github.com/IQSS/dataverse-client-javascript/issues/139
       description: jsCollection.description,
       affiliation: jsCollection.affiliation,
       hierarchy: JSCollectionMapper.toHierarchy(

--- a/src/sections/collection/Collection.module.scss
+++ b/src/sections/collection/Collection.module.scss
@@ -13,5 +13,6 @@
 }
 
 .subtext {
+  margin-right: 5px;
   color: $dv-subtext-color;
 }

--- a/src/sections/collection/Collection.module.scss
+++ b/src/sections/collection/Collection.module.scss
@@ -12,7 +12,11 @@
   margin-bottom: $spacer;
 }
 
+.infoContainer {
+  display: flex;
+  gap: 10px;
+}
+
 .subtext {
-  margin-right: 5px;
   color: $dv-subtext-color;
 }

--- a/src/sections/collection/CollectionInfo.tsx
+++ b/src/sections/collection/CollectionInfo.tsx
@@ -13,12 +13,14 @@ export function CollectionInfo({ collection }: CollectionInfoProps) {
     <>
       <header className={styles.header}>
         <h1>{collection.name}</h1>
-        {collection.affiliation && (
-          <span className={styles.subtext}>({collection.affiliation})</span>
-        )}
-        {!collection.isReleased && (
-          <Badge variant={DatasetLabelSemanticMeaning.WARNING}>Unpublished</Badge>
-        )}
+        <div className={styles.infoContainer}>
+          {collection.affiliation && (
+            <span className={styles.subtext}>({collection.affiliation})</span>
+          )}
+          {!collection.isReleased && (
+            <Badge variant={DatasetLabelSemanticMeaning.WARNING}>Unpublished</Badge>
+          )}
+        </div>
       </header>
       {collection.description && (
         <div>

--- a/src/sections/collection/CollectionInfo.tsx
+++ b/src/sections/collection/CollectionInfo.tsx
@@ -1,6 +1,8 @@
 import { Collection } from '../../collection/domain/models/Collection'
 import styles from './Collection.module.scss'
 import { MarkdownComponent } from '../dataset/markdown/MarkdownComponent'
+import { Badge } from '@iqss/dataverse-design-system'
+import { DatasetLabelSemanticMeaning } from '../../dataset/domain/models/Dataset'
 
 interface CollectionInfoProps {
   collection: Collection
@@ -13,6 +15,9 @@ export function CollectionInfo({ collection }: CollectionInfoProps) {
         <h1>{collection.name}</h1>
         {collection.affiliation && (
           <span className={styles.subtext}>({collection.affiliation})</span>
+        )}
+        {!collection.isReleased && (
+          <Badge variant={DatasetLabelSemanticMeaning.WARNING}>Unpublished</Badge>
         )}
       </header>
       {collection.description && (

--- a/src/stories/collection/CollectionInfo.stories.tsx
+++ b/src/stories/collection/CollectionInfo.stories.tsx
@@ -24,6 +24,9 @@ export const WithAffiliation: Story = {
   render: () => <CollectionInfo collection={CollectionMother.createWithAffiliation()} />
 }
 
+export const Unpublished: Story = {
+  render: () => <CollectionInfo collection={CollectionMother.createUnpublished()} />
+}
 export const WithDescription: Story = {
   render: () => <CollectionInfo collection={CollectionMother.createWithDescription()} />
 }

--- a/tests/component/collection/domain/models/CollectionMother.ts
+++ b/tests/component/collection/domain/models/CollectionMother.ts
@@ -8,6 +8,7 @@ export class CollectionMother {
     return {
       id: faker.datatype.uuid(),
       name: faker.lorem.words(3),
+      isReleased: faker.datatype.boolean(),
       description: faker.datatype.boolean()
         ? `${faker.lorem.paragraph()} **${faker.lorem.sentence()}** ${faker.lorem.paragraph()}`
         : undefined,
@@ -20,6 +21,7 @@ export class CollectionMother {
   static createRealistic(): Collection {
     return CollectionMother.create({
       id: 'science',
+      isReleased: true,
       name: 'Collection Name',
       description: 'We do all the science.',
       affiliation: 'Scientific Research University'
@@ -30,6 +32,7 @@ export class CollectionMother {
     return CollectionMother.create({
       id: faker.datatype.uuid(),
       name: FakerHelper.collectionName(),
+      isReleased: faker.datatype.boolean(),
       affiliation: undefined,
       description: undefined,
       ...props
@@ -39,12 +42,18 @@ export class CollectionMother {
   static createComplete(): Collection {
     return CollectionMother.create({
       id: faker.datatype.uuid(),
+      isReleased: faker.datatype.boolean(),
       name: FakerHelper.collectionName(),
       description: FakerHelper.paragraph(),
       affiliation: FakerHelper.affiliation()
     })
   }
-
+  static createUnpublished(): Collection {
+    return CollectionMother.createWithOnlyRequiredFields({
+      isReleased: false,
+      affiliation: FakerHelper.affiliation()
+    })
+  }
   static createWithDescription(): Collection {
     return CollectionMother.createWithOnlyRequiredFields({
       description: FakerHelper.paragraph()

--- a/tests/component/sections/collection/CollectionInfo.spec.tsx
+++ b/tests/component/sections/collection/CollectionInfo.spec.tsx
@@ -6,6 +6,7 @@ describe('CollectionInfo', () => {
     const collection = CollectionMother.create({
       name: 'Collection Name',
       affiliation: 'Affiliation',
+      isReleased: true,
       description: 'Here is a description with [a link](https://dataverse.org)'
     })
     cy.customMount(<CollectionInfo collection={collection} />)
@@ -14,6 +15,7 @@ describe('CollectionInfo', () => {
     cy.findByText('(Affiliation)').should('exist')
     cy.findByText(/Here is a description with/).should('exist')
     cy.findByRole('link', { name: 'a link' }).should('exist')
+    cy.findByText('Unpublished').should('not.exist')
   })
 
   it('does not render affiliation when it is not present', () => {
@@ -32,5 +34,11 @@ describe('CollectionInfo', () => {
     cy.customMount(<CollectionInfo collection={collection} />)
 
     cy.findByText('Description').should('not.exist')
+  })
+  it('renders unpublished label when isReleased is false', () => {
+    const collection = CollectionMother.createUnpublished()
+    cy.customMount(<CollectionInfo collection={collection} />)
+
+    cy.findByText('Unpublished').should('exist')
   })
 })

--- a/tests/e2e-integration/integration/collection/CollectionJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/collection/CollectionJSDataverseRepository.spec.ts
@@ -12,6 +12,7 @@ const collectionExpected = {
   id: 'new-collection',
   name: 'Scientific Research',
   description: 'We do all the science.',
+  isReleased: true,
   affiliation: 'Scientific Research University',
   hierarchy: new UpwardHierarchyNode(
     'Scientific Research',


### PR DESCRIPTION
## What this PR does / why we need it:
Adds an 'Unpublished' label to the Collections page, if the collection has not been published
## Which issue(s) this PR closes:

- Closes #358 

## Special notes for your reviewer:
The flag, isReleased, is not yet available from the javascript library, waiting for this: https://github.com/IQSS/dataverse-client-javascript/issues/139

## Suggestions on how to test this: 
Look at the UnpublishedCollection Story, which shows the label: http://localhost:6006/?path=/story/sections-collection-page-collectioninfo--unpublished

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
This is what the label looks like in JSF:
<img width="1128" alt="Screenshot 2024-04-17 at 9 24 02 AM" src="https://github.com/IQSS/dataverse-frontend/assets/675224/3c67edcd-db43-40a2-850c-d0e03120b17e">


## Is there a release notes update needed for this change?:
no
## Additional documentation:
