### PR TITLE
Feat: Add pagination total results

### DIFF
--- a/public/locales/en/pagination.json
+++ b/public/locales/en/pagination.json
@@ -1,10 +1,10 @@
 {
   "results_one": "1 {{item}}",
-  "results_other": "{{start}} to {{end}} of {{countFormat}} {{item}}s",
+  "results_other": "{{start}} to {{end}} of {{formattedCount}} {{item}}s",
   "accumulated": {
-    "one": "{{countFormat}} {{item}}",
-    "lessThanPageSize": "{{countFormat}} {{item}}s",
-    "moreThanPageSize": "{{accumulated}} of {{countFormat}} {{item}}s seen"
+    "one": "{{formattedCount}} {{item}}",
+    "lessThanPageSize": "{{formattedCount}} {{item}}s",
+    "moreThanPageSize": "{{accumulated}} of {{formattedCount}} {{item}}s seen"
   },
   "pageSize": "{{item}}s per page"
 }

--- a/public/locales/en/pagination.json
+++ b/public/locales/en/pagination.json
@@ -1,10 +1,10 @@
 {
   "results_one": "1 {{item}}",
-  "results_other": "{{start}} to {{end}} of {{count}} {{item}}s",
+  "results_other": "{{start}} to {{end}} of {{countFormat}} {{item}}s",
   "accumulated": {
-    "one": "{{count}} {{item}}",
-    "lessThanPageSize": "{{count}} {{item}}s",
-    "moreThanPageSize": "{{accumulated}} of {{count}} {{item}}s seen"
+    "one": "{{countFormat}} {{item}}",
+    "lessThanPageSize": "{{countFormat}} {{item}}s",
+    "moreThanPageSize": "{{accumulated}} of {{countFormat}} {{item}}s seen"
   },
   "pageSize": "{{item}}s per page"
 }

--- a/src/sections/shared/pagination/PaginationResultsInfo.tsx
+++ b/src/sections/shared/pagination/PaginationResultsInfo.tsx
@@ -18,8 +18,8 @@ export function PaginationResultsInfo({ paginationInfo, accumulated }: Paginatio
       accumulated === 1
         ? 'accumulated.one'
         : accumulated < paginationInfo.pageSize
-        ? 'accumulated.lessThanPageSize'
-        : 'accumulated.moreThanPageSize',
+          ? 'accumulated.lessThanPageSize'
+          : 'accumulated.moreThanPageSize',
     [accumulated, paginationInfo.pageSize]
   )
 
@@ -27,16 +27,18 @@ export function PaginationResultsInfo({ paginationInfo, accumulated }: Paginatio
     <span className={styles.results}>
       {typeof accumulated === 'number'
         ? t(defineLocale(accumulated), {
-            accumulated: accumulated,
-            count: paginationInfo.totalItems,
-            item: paginationInfo.itemName
-          })
+          accumulated: accumulated,
+          count: paginationInfo.totalItems,
+          countFormat: new Intl.NumberFormat().format(paginationInfo.totalItems),
+          item: paginationInfo.itemName
+        })
         : t('results', {
-            start: paginationInfo.pageStartItem,
-            end: paginationInfo.pageEndItem,
-            item: paginationInfo.itemName,
-            count: paginationInfo.totalItems
-          })}
+          start: paginationInfo.pageStartItem,
+          end: paginationInfo.pageEndItem,
+          item: paginationInfo.itemName,
+          count: paginationInfo.totalItems,
+          countFormat: new Intl.NumberFormat().format(paginationInfo.totalItems)
+        })}
     </span>
   )
 }

--- a/src/sections/shared/pagination/PaginationResultsInfo.tsx
+++ b/src/sections/shared/pagination/PaginationResultsInfo.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import styles from './Pagination.module.scss'
 import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
 import { useTranslation } from 'react-i18next'
@@ -23,13 +23,18 @@ export function PaginationResultsInfo({ paginationInfo, accumulated }: Paginatio
     [accumulated, paginationInfo.pageSize]
   )
 
+  const formattedCount = useMemo(
+    () => new Intl.NumberFormat().format(paginationInfo.totalItems),
+    [paginationInfo.totalItems]
+  )
+
   return (
     <span className={styles.results}>
       {typeof accumulated === 'number'
         ? t(defineLocale(accumulated), {
           accumulated: accumulated,
           count: paginationInfo.totalItems,
-          countFormat: new Intl.NumberFormat().format(paginationInfo.totalItems),
+          formattedCount: formattedCount,
           item: paginationInfo.itemName
         })
         : t('results', {
@@ -37,7 +42,7 @@ export function PaginationResultsInfo({ paginationInfo, accumulated }: Paginatio
           end: paginationInfo.pageEndItem,
           item: paginationInfo.itemName,
           count: paginationInfo.totalItems,
-          countFormat: new Intl.NumberFormat().format(paginationInfo.totalItems)
+          formattedCount: formattedCount,
         })}
     </span>
   )

--- a/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
+++ b/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
@@ -56,7 +56,7 @@ describe('PaginationResultsInfo', () => {
 
   it('shows the correct formatted results when accumulated prop passed and results are more than page size', () => {
     const totalCount = 1500
-    const expectedFormattedTotalCount = '1,500'
+    const expectedFormattedTotalCount = new Intl.NumberFormat().format(totalCount)
 
     cy.customMount(
       <PaginationResultsInfo

--- a/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
+++ b/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
@@ -53,4 +53,15 @@ describe('PaginationResultsInfo', () => {
     )
     cy.findByText('10 of 15 Items seen').should('exist')
   })
+
+  it('shows the correct formatted results when accumulated prop passed and results are more than page size', () => {
+    cy.customMount(
+      <PaginationResultsInfo
+        paginationInfo={new PaginationInfo<DatasetPaginationInfo>(1, 100, 1500)}
+        accumulated={500}
+      />
+    )
+    cy.findByText('500 of 1,500 Items seen').should('exist')
+  })
+
 })

--- a/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
+++ b/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
@@ -55,13 +55,15 @@ describe('PaginationResultsInfo', () => {
   })
 
   it('shows the correct formatted results when accumulated prop passed and results are more than page size', () => {
+    const totalCount = 1500
+    const expectedFormattedTotalCount = '1,500'
+
     cy.customMount(
       <PaginationResultsInfo
-        paginationInfo={new PaginationInfo<DatasetPaginationInfo>(1, 100, 1500)}
+        paginationInfo={new PaginationInfo<DatasetPaginationInfo>(1, 100, totalCount)}
         accumulated={500}
       />
     )
-    cy.findByText('500 of 1,500 Items seen').should('exist')
+    cy.findByText(`500 of ${expectedFormattedTotalCount} Items seen`).should('exist')
   })
-
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Formats the total number of items of the pagination result according to the user's preferred language. Applied to locales/en/pagination

**Which issue(s) this PR closes**:

Closes #330 

**Special notes for your reviewer**:

**Suggestions on how to test this**:

Storybook (There are additional areas that can be viewed too)
Sample URL 1: http://localhost:6006/?path=/story/sections-dataset-page-datasetfiles--no-filters

Cypress
Relating tests found in PaginationResultsInfo.spec.tsx

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
See Issue #330 

**Is there a release notes update needed for this change?**:

**Additional documentation**:
