### PR TITLE
387 Fix Race Condition in e2e tests

### DIFF
--- a/tests/e2e-integration/e2e/sections/collection/Collection.spec.ts
+++ b/tests/e2e-integration/e2e/sections/collection/Collection.spec.ts
@@ -12,7 +12,7 @@ describe('Collection Page', () => {
 
   beforeEach(() => {
     TestsUtils.login()
-    cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+    cy.wrap(DatasetHelper.destroyAll())
   })
 
   it('successfully loads root collection when accessing the home', () => {

--- a/tests/e2e-integration/e2e/sections/collection/Collection.spec.ts
+++ b/tests/e2e-integration/e2e/sections/collection/Collection.spec.ts
@@ -2,7 +2,7 @@ import { DatasetHelper } from '../../../shared/datasets/DatasetHelper'
 import { TestsUtils } from '../../../shared/TestsUtils'
 import { faker } from '@faker-js/faker'
 import { CollectionHelper } from '../../../shared/collection/CollectionHelper'
-
+const collectionId = 'CollectionPageTest' + Date.now().toString()
 describe('Collection Page', () => {
   const title = faker.lorem.sentence()
   before(() => {
@@ -12,7 +12,6 @@ describe('Collection Page', () => {
 
   beforeEach(() => {
     TestsUtils.login()
-    cy.wrap(DatasetHelper.destroyAll())
   })
 
   it('successfully loads root collection when accessing the home', () => {
@@ -132,18 +131,23 @@ describe('Collection Page', () => {
   })
 
   it('12 Datasets - displays first 10 datasets, scroll to the bottom and displays the remaining 2 datasets', () => {
-    cy.wrap(DatasetHelper.createMany(12), { timeout: 10_000 }).then(() => {
-      cy.wait(2_000) // Wait for the datasets to be created
-      cy.visit('/spa')
+    const collectionId = 'collection-1' + Date.now().toString()
+    cy.wrap(CollectionHelper.create(collectionId)).then(() => {
+      cy.wrap(DatasetHelper.createMany(12, collectionId), { timeout: 10_000 }).then(() => {
+        cy.wait(2_000) // Wait for the datasets to be created
+        cy.visit(`/spa/collections?id=${collectionId}`)
 
-      cy.findAllByText(/Root/i).should('exist')
-      cy.findByText(/Dataverse Admin/i).should('exist')
+        cy.findAllByText(/Scientific Research/i).should('exist')
+        cy.findByText(/Dataverse Admin/i).should('exist')
 
-      cy.findByText('10 of 12 Datasets seen').should('exist')
+        cy.findByText('10 of 12 Datasets seen').should('exist')
 
-      cy.get('[data-testid="scrollable-container"]').scrollTo('bottom', { ensureScrollable: false })
-      cy.wait(1_500)
-      cy.findByText('12 of 12 Datasets seen').should('exist')
+        cy.get('[data-testid="scrollable-container"]').scrollTo('bottom', {
+          ensureScrollable: false
+        })
+        cy.wait(1_500)
+        cy.findByText('12 of 12 Datasets seen').should('exist')
+      })
     })
   })
 })

--- a/tests/e2e-integration/e2e/sections/collection/Collection.spec.ts
+++ b/tests/e2e-integration/e2e/sections/collection/Collection.spec.ts
@@ -2,7 +2,7 @@ import { DatasetHelper } from '../../../shared/datasets/DatasetHelper'
 import { TestsUtils } from '../../../shared/TestsUtils'
 import { faker } from '@faker-js/faker'
 import { CollectionHelper } from '../../../shared/collection/CollectionHelper'
-const collectionId = 'CollectionPageTest' + Date.now().toString()
+
 describe('Collection Page', () => {
   const title = faker.lorem.sentence()
   before(() => {

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -19,9 +19,6 @@ describe('Dataset', () => {
   })
 
   describe('Visit the Dataset Page as a logged in user', () => {
-    beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll())
-    })
     it('successfully loads a dataset in draft mode', () => {
       cy.wrap(DatasetHelper.create())
         .its('persistentId')

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -191,9 +191,6 @@ describe('Dataset', () => {
   })
 
   describe('Visualizing the Files Tab', () => {
-    beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll())
-    })
     it('successfully loads the files tab', () => {
       cy.wrap(DatasetHelper.create())
         .its('persistentId')
@@ -532,9 +529,6 @@ describe('Dataset', () => {
   })
 
   describe('Downloading files', () => {
-    beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll())
-    })
     it('downloads the dataset', () => {
       cy.wrap(
         DatasetHelper.createWithFiles(FileHelper.createMany(2)).then((dataset) =>

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -20,7 +20,7 @@ describe('Dataset', () => {
 
   describe('Visit the Dataset Page as a logged in user', () => {
     beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+      cy.wrap(DatasetHelper.destroyAll())
     })
     it('successfully loads a dataset in draft mode', () => {
       cy.wrap(DatasetHelper.create())
@@ -195,7 +195,7 @@ describe('Dataset', () => {
 
   describe('Visualizing the Files Tab', () => {
     beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+      cy.wrap(DatasetHelper.destroyAll())
     })
     it('successfully loads the files tab', () => {
       cy.wrap(DatasetHelper.create())
@@ -536,7 +536,7 @@ describe('Dataset', () => {
 
   describe('Downloading files', () => {
     beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+      cy.wrap(DatasetHelper.destroyAll())
     })
     it('downloads the dataset', () => {
       cy.wrap(

--- a/tests/e2e-integration/e2e/sections/file/File.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/file/File.spec.tsx
@@ -13,7 +13,7 @@ describe('File', () => {
   })
   describe('Visit the File Page as a logged in user', () => {
     beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+      cy.wrap(DatasetHelper.destroyAll())
     })
 
     it('successfully loads a file in draft mode', () => {

--- a/tests/e2e-integration/e2e/sections/file/File.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/file/File.spec.tsx
@@ -12,10 +12,6 @@ describe('File', () => {
     TestsUtils.login()
   })
   describe('Visit the File Page as a logged in user', () => {
-    beforeEach(() => {
-      cy.wrap(DatasetHelper.destroyAll())
-    })
-
     it('successfully loads a file in draft mode', () => {
       cy.wrap(
         DatasetHelper.createWithFile(FileHelper.create()).then(

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -130,7 +130,7 @@ describe('Dataset JSDataverse Repository', () => {
   before(() => TestsUtils.setup())
   beforeEach(() => {
     TestsUtils.login()
-    cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+    cy.wrap(DatasetHelper.destroyAll())
   })
 
   it('gets the dataset by persistentId', async () => {

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../../src/files/domain/models/FileMetadata'
 import { DatasetPaginationInfo } from '../../../../src/dataset/domain/models/DatasetPaginationInfo'
 import { DatasetDTO } from '../../../../src/dataset/domain/useCases/DTOs/DatasetDTO'
+import { CollectionHelper } from '../../shared/collection/CollectionHelper'
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -124,17 +125,19 @@ const datasetData = (persistentId: string, versionId: number) => {
     ]
   }
 }
-
+const collectionId = 'DatasetJSDataverseRepository'
 const datasetRepository = new DatasetJSDataverseRepository()
 describe('Dataset JSDataverse Repository', () => {
-  before(() => TestsUtils.setup())
+  before(() => {
+    TestsUtils.setup()
+    TestsUtils.login().then(() => CollectionHelper.createAndPublish(collectionId))
+  })
   beforeEach(() => {
     TestsUtils.login()
-    cy.wrap(DatasetHelper.destroyAll())
   })
 
   it('gets the dataset by persistentId', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
 
     await datasetRepository.getByPersistentId(datasetResponse.persistentId).then((dataset) => {
       if (!dataset) {
@@ -156,7 +159,7 @@ describe('Dataset JSDataverse Repository', () => {
   })
 
   it('gets a published dataset by persistentId without user authentication', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.publish(datasetResponse.persistentId)
 
     await TestsUtils.wait(1500)
@@ -202,7 +205,7 @@ describe('Dataset JSDataverse Repository', () => {
   })
 
   it('gets the dataset by persistentId and version number', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.waitForNoLocks(datasetResponse.persistentId)
     await datasetRepository
@@ -238,7 +241,7 @@ describe('Dataset JSDataverse Repository', () => {
   })
 
   it('gets the dataset by persistentId and version DRAFT keyword', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
 
     await datasetRepository
       .getByPersistentId(datasetResponse.persistentId, 'DRAFT')
@@ -254,7 +257,7 @@ describe('Dataset JSDataverse Repository', () => {
   })
 
   it('gets the dataset by privateUrlToken', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
     const privateUrlResponse = await DatasetHelper.createPrivateUrl(datasetResponse.id)
 
     await datasetRepository.getByPrivateUrlToken(privateUrlResponse.token).then((dataset) => {
@@ -270,7 +273,7 @@ describe('Dataset JSDataverse Repository', () => {
   })
 
   it('gets the dataset after changing the citation date field type', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
 
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.waitForNoLocks(datasetResponse.persistentId)
@@ -292,22 +295,28 @@ describe('Dataset JSDataverse Repository', () => {
   })
 
   it('gets the DatasetPreview', () => {
-    return DatasetHelper.createAndPublish().then((datasetResponse) => {
-      const paginationInfo = new DatasetPaginationInfo(1, 20)
+    const previewCollectionId = 'DatasetJSDataverseRepositoryPreview' + Date.now().toString()
 
-      return datasetRepository.getAllWithCount('root', paginationInfo).then((datasetsWithCount) => {
-        expect(datasetsWithCount.totalCount).to.equal(1)
-        expect(datasetsWithCount.datasetPreviews[0].version.title).to.equal("Darwin's Finches")
-        expect(datasetsWithCount.datasetPreviews[0].persistentId).to.equal(
-          datasetResponse.persistentId
-        )
+    cy.wrap(CollectionHelper.createAndPublish(previewCollectionId)).then(() => {
+      return DatasetHelper.createAndPublish(previewCollectionId).then((datasetResponse) => {
+        const paginationInfo = new DatasetPaginationInfo(1, 20)
+
+        return datasetRepository
+          .getAllWithCount(previewCollectionId, paginationInfo)
+          .then((datasetsWithCount) => {
+            expect(datasetsWithCount.totalCount).to.equal(1)
+            expect(datasetsWithCount.datasetPreviews[0].version.title).to.equal("Darwin's Finches")
+            expect(datasetsWithCount.datasetPreviews[0].persistentId).to.equal(
+              datasetResponse.persistentId
+            )
+          })
       })
     })
   })
 
   it.skip('gets the dataset by persistentId when the dataset is deaccessioned', async () => {
     // TODO - Implement once the getDatasetCitation includes deaccessioned datasets
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
 
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.wait(1500)
@@ -323,7 +332,7 @@ describe('Dataset JSDataverse Repository', () => {
     })
   })
   it('gets the dataset by persistentId when is locked', async () => {
-    const datasetResponse = await DatasetHelper.create()
+    const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.lock(datasetResponse.id, DatasetLockReason.FINALIZE_PUBLICATION)
 
     await datasetRepository.getByPersistentId(datasetResponse.persistentId).then((dataset) => {

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -272,7 +272,7 @@ describe('File JSDataverse Repository', () => {
         })
     })
 
-    it.only('gets all the files by dataset persistentId after file has been downloaded', async () => {
+    it('gets all the files by dataset persistentId after file has been downloaded', async () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(3))
       if (!datasetResponse.files) throw new Error('Files not found')
 

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -155,7 +155,7 @@ describe('File JSDataverse Repository', () => {
   })
   beforeEach(() => {
     TestsUtils.login()
-    cy.wrap(DatasetHelper.destroyAll(), { timeout: 10000 })
+    cy.wrap(DatasetHelper.destroyAll())
   })
 
   const compareMetadata = (fileMetadata: FileMetadata, expectedFileMetadata: FileMetadata) => {

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -283,7 +283,7 @@ describe('File JSDataverse Repository', () => {
       if (!dataset) throw new Error('Dataset not found')
 
       await FileHelper.download(datasetResponse.files[0].id)
-      await TestsUtils.wait(1500) // Wait for the file to be downloaded
+      await TestsUtils.wait(3000) // Wait for the file to be downloaded
 
       await fileRepository
         .getAllByDatasetPersistentId(dataset.persistentId, dataset.version)

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -155,7 +155,6 @@ describe('File JSDataverse Repository', () => {
   })
   beforeEach(() => {
     TestsUtils.login()
-    cy.wrap(DatasetHelper.destroyAll())
   })
 
   const compareMetadata = (fileMetadata: FileMetadata, expectedFileMetadata: FileMetadata) => {

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -272,7 +272,7 @@ describe('File JSDataverse Repository', () => {
         })
     })
 
-    it('gets all the files by dataset persistentId after file has been downloaded', async () => {
+    it.only('gets all the files by dataset persistentId after file has been downloaded', async () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(3))
       if (!datasetResponse.files) throw new Error('Files not found')
 

--- a/tests/e2e-integration/shared/DataverseApiHelper.ts
+++ b/tests/e2e-integration/shared/DataverseApiHelper.ts
@@ -17,14 +17,6 @@ export class DataverseApiHelper {
       'PUT',
       'author, datasetContact, contributor, depositor, grantNumber, publication'
     )
-    // In case a previous test run has left some orphans, clear them out
-    cy.request({
-      url: `${this.API_URL}/admin/index/clear-orphans?sync=true`,
-      method: 'GET',
-      headers: {
-        'X-Dataverse-key': this.API_TOKEN
-      }
-    })
   }
 
   static async request<T>(

--- a/tests/e2e-integration/shared/DataverseApiHelper.ts
+++ b/tests/e2e-integration/shared/DataverseApiHelper.ts
@@ -17,6 +17,14 @@ export class DataverseApiHelper {
       'PUT',
       'author, datasetContact, contributor, depositor, grantNumber, publication'
     )
+    // In case a previous test run has left some orphans, clear them out
+    cy.request({
+      url: `${this.API_URL}/admin/index/clear-orphans?sync=true`,
+      method: 'GET',
+      headers: {
+        'X-Dataverse-key': this.API_TOKEN
+      }
+    })
   }
 
   static async request<T>(

--- a/tests/e2e-integration/shared/collection/CollectionHelper.ts
+++ b/tests/e2e-integration/shared/collection/CollectionHelper.ts
@@ -3,10 +3,12 @@ import newCollectionData from '../../fixtures/new-collection-data.json'
 
 export interface CollectionResponse {
   id: string
+  isReleased: boolean
 }
 
 interface CollectionPayload {
   alias: string
+  isReleased: boolean
 }
 
 export class CollectionHelper extends DataverseApiHelper {
@@ -16,7 +18,7 @@ export class CollectionHelper extends DataverseApiHelper {
       'GET'
     ).catch(() => undefined)
     if (collection) {
-      return { id: collection.alias }
+      return { id: collection.alias, isReleased: collection.isReleased }
     }
 
     const newCollection: CollectionPayload = await this.request<CollectionPayload>(
@@ -27,6 +29,24 @@ export class CollectionHelper extends DataverseApiHelper {
         alias: id
       }
     )
-    return { id: newCollection.alias }
+    return { id: newCollection.alias, isReleased: newCollection.isReleased }
+  }
+  static async publish(id: string): Promise<{
+    status: string
+    id: string
+  }> {
+    const response = await this.request<{
+      status: string
+    }>(`/dataverses/${id}/actions/:publish`, 'POST')
+
+    return { ...response, id }
+  }
+  static async createAndPublish(id = 'subcollection'): Promise<CollectionResponse> {
+    const collectionResponse = await CollectionHelper.create(id)
+    console.log(collectionResponse)
+    if (!collectionResponse.isReleased) {
+      await CollectionHelper.publish(collectionResponse.id)
+    }
+    return collectionResponse
   }
 }

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -66,7 +66,7 @@ export class DatasetHelper extends DataverseApiHelper {
     for (const dataset of response.items as Array<{ global_id: string }>) {
       await this.destroy(dataset.global_id)
     }
-    await this.request<DatasetResponse>('/admin/index/clear-orphans', 'GET')
+    await this.request<DatasetResponse>('/admin/index/clear-orphans?sync=true', 'GET')
   }
 
   static async destroyAll(): Promise<void> {

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -43,8 +43,8 @@ export class DatasetHelper extends DataverseApiHelper {
       throw error
     }
   }
-  static async createAndPublish(): Promise<DatasetResponse> {
-    const datasetResponse = await DatasetHelper.create()
+  static async createAndPublish(collectionId = 'root'): Promise<DatasetResponse> {
+    const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.waitForNoLocks(datasetResponse.persistentId)
     return datasetResponse
@@ -133,20 +133,26 @@ export class DatasetHelper extends DataverseApiHelper {
     }>(`/datasets/${id}/privateUrl?anonymizedAccess=true`, 'POST')
   }
 
-  static async createWithFiles(filesData: FileData[]): Promise<DatasetResponse> {
-    const datasetResponse = await this.create()
+  static async createWithFiles(
+    filesData: FileData[],
+    collectionId = 'root'
+  ): Promise<DatasetResponse> {
+    const datasetResponse = await this.create(collectionId)
     const files = await this.uploadFiles(datasetResponse.persistentId, filesData)
     return { ...datasetResponse, files: files }
   }
 
-  static async createWithFile(fileData: FileData): Promise<DatasetResponse> {
-    const datasetResponse = await this.create()
+  static async createWithFile(fileData: FileData, collectionId = 'root'): Promise<DatasetResponse> {
+    const datasetResponse = await this.create(collectionId)
     const file = await this.uploadFile(datasetResponse.persistentId, fileData)
     return { ...datasetResponse, file: file }
   }
 
-  static async createWithFileAndPublish(fileData: FileData): Promise<DatasetResponse> {
-    const datasetResponse = await DatasetHelper.createWithFile(fileData)
+  static async createWithFileAndPublish(
+    fileData: FileData,
+    collectionId = 'root'
+  ): Promise<DatasetResponse> {
+    const datasetResponse = await DatasetHelper.createWithFile(fileData, collectionId)
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.waitForNoLocks(datasetResponse.persistentId)
 

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -50,10 +50,10 @@ export class DatasetHelper extends DataverseApiHelper {
     return datasetResponse
   }
 
-  static async createMany(amount: number): Promise<DatasetResponse[]> {
+  static async createMany(amount: number, collectionId = 'root'): Promise<DatasetResponse[]> {
     const datasets = []
     for (let i = 0; i < amount; i++) {
-      const datasetResponse = await this.create()
+      const datasetResponse = await this.create(collectionId)
       datasets.push(datasetResponse)
     }
     return datasets

--- a/tests/e2e-integration/shared/files/FileHelper.ts
+++ b/tests/e2e-integration/shared/files/FileHelper.ts
@@ -111,7 +111,7 @@ export class FileHelper extends DataverseApiHelper {
     cy.visit(`/file.xhtml?fileId=${id}`)
       .get('#actionButtonBlock > div:nth-child(1) > div > button')
       .click()
-      .get('#fileForm\\:j_idt273')
+      .get('#fileForm\\:j_idt274')
       .click()
     return Promise.resolve()
   }

--- a/tests/support/commands.tsx
+++ b/tests/support/commands.tsx
@@ -78,7 +78,7 @@ Cypress.Commands.add('loginAsAdmin', (go?: string) => {
       cy.findByLabelText('Username/Email').type('dataverseAdmin')
       cy.findByLabelText('Password').type('admin1')
       cy.findByRole('button', { name: /Log In/i }).click()
-      cy.findByText(/Dataverse Admin/i).should('exist')
+      cy.findAllByText(/Dataverse Admin/i).should('exist')
       if (go) cy.visit(go)
     }
   })


### PR DESCRIPTION
**What this PR does / why we need it**: Then e2e tests were sometimes failing because the destroyAll() method does not always clear the solr index correctly.  Rather than always calling destroyAll(), the tests were updated to create datasets in separate collections, where necessary, so that dataset counts are not affected by the order of tests.

**Which issue(s) this PR closes**:

Closes #387 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Run the e2e test locally `npm run test:e2e`
Check that then e2e test in Github action succeeds

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
