### PR TITLE
Feature/380 extend breadcrumbsgenerator for action items

### DIFF
--- a/public/locales/en/uploadDatasetFiles.json
+++ b/public/locales/en/uploadDatasetFiles.json
@@ -1,0 +1,3 @@
+{
+  "breadcrumbActionItem": "Upload Files"
+}

--- a/src/sections/shared/hierarchy/BreadcrumbsGenerator.tsx
+++ b/src/sections/shared/hierarchy/BreadcrumbsGenerator.tsx
@@ -3,16 +3,29 @@ import { UpwardHierarchyNode } from '../../../shared/hierarchy/domain/models/Upw
 import { LinkToPage } from '../link-to-page/LinkToPage'
 import { Route } from '../../Route.enum'
 
-interface BreadcrumbGeneratorProps {
-  hierarchy: UpwardHierarchyNode
-}
+type BreadcrumbGeneratorProps =
+  | {
+      hierarchy: UpwardHierarchyNode
+      withActionItem?: false
+      actionItemText?: never
+    }
+  | {
+      hierarchy: UpwardHierarchyNode
+      withActionItem: true
+      actionItemText: string
+    }
 
-export function BreadcrumbsGenerator({ hierarchy }: BreadcrumbGeneratorProps) {
+export function BreadcrumbsGenerator({
+  hierarchy,
+  withActionItem,
+  actionItemText
+}: BreadcrumbGeneratorProps) {
   const hierarchyArray = hierarchy.toArray()
+
   return (
     <Breadcrumb>
       {hierarchyArray.map((item, index) => {
-        const isLast = index === hierarchyArray.length - 1
+        const isLast = withActionItem ? false : index === hierarchyArray.length - 1
         const isFirst = index === 0
 
         if (isLast) {
@@ -49,6 +62,7 @@ export function BreadcrumbsGenerator({ hierarchy }: BreadcrumbGeneratorProps) {
           </Breadcrumb.Item>
         )
       })}
+      {withActionItem && <Breadcrumb.Item active>{actionItemText}</Breadcrumb.Item>}
     </Breadcrumb>
   )
 }

--- a/src/sections/upload-dataset-files/UploadDatasetFiles.tsx
+++ b/src/sections/upload-dataset-files/UploadDatasetFiles.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
 import { FileRepository } from '../../files/domain/repositories/FileRepository'
 import { useLoading } from '../loading/LoadingContext'
 import { useDataset } from '../dataset/DatasetContext'
@@ -14,6 +15,7 @@ export const UploadDatasetFiles = ({
 }: UploadDatasetFilesProps) => {
   const { setIsLoading } = useLoading()
   const { dataset, isLoading } = useDataset()
+  const { t } = useTranslation('uploadDatasetFiles')
 
   useEffect(() => {
     setIsLoading(isLoading)
@@ -29,7 +31,11 @@ export const UploadDatasetFiles = ({
         <PageNotFound />
       ) : (
         <>
-          <BreadcrumbsGenerator hierarchy={dataset.hierarchy} />
+          <BreadcrumbsGenerator
+            hierarchy={dataset.hierarchy}
+            withActionItem
+            actionItemText={t('breadcrumbActionItem')}
+          />
           <article>
             <p>Metadata Files uploading goes here</p>
           </article>

--- a/tests/component/sections/shared/hierarchy/BreadcrumbsGenerator.spec.tsx
+++ b/tests/component/sections/shared/hierarchy/BreadcrumbsGenerator.spec.tsx
@@ -40,4 +40,23 @@ describe('BreadcrumbsGenerator', () => {
     cy.customMount(<BreadcrumbsGenerator hierarchy={root} />)
     cy.findByText('Root').should('have.class', 'active')
   })
+
+  it('shows the action item active when withActionItem is true', () => {
+    const root = UpwardHierarchyNodeMother.createCollection({
+      name: 'Root',
+      id: 'root'
+    })
+    const dataset = UpwardHierarchyNodeMother.createDataset({
+      name: 'Dataset',
+      parent: root,
+      version: '1.0',
+      persistentId: 'doi:10.5072/FK2/ABC123'
+    })
+
+    cy.customMount(
+      <BreadcrumbsGenerator hierarchy={dataset} withActionItem actionItemText="Action Item Text" />
+    )
+    cy.findByText('Action Item Text').should('exist').should('have.class', 'active')
+    cy.findByText('Dataset').should('exist').should('not.have.class', 'active')
+  })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
To extend the functionality of the breadcrumbs to show action items in it.
E.g.: Root > Collection > Dataset > Upload Files

**Which issue(s) this PR closes**:

Closes #380 

**Special notes for your reviewer**:
We may want to fix [Get Dataset Use Case hierarchy property persistentId missing](https://github.com/IQSS/dataverse-client-javascript/issues/154) first so Breadcrumbs shows correct link of dataset in it.

**Suggestions on how to test this**:
Navigate to a dataset and then click on Upload Files, on the Upload Files page the last item of the breadcrumb should be "Upload Files"

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
Yes.
<img width="646" alt="Screenshot 2024-05-15 at 17 09 18" src="https://github.com/IQSS/dataverse-frontend/assets/64560524/a1d3ba0a-fcb7-4bac-b3f1-4894347e3730">
<img width="594" alt="Screenshot 2024-05-15 at 17 08 18" src="https://github.com/IQSS/dataverse-frontend/assets/64560524/480f5354-4f09-4232-811e-9be22af1683f">


**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
No.