### PR TITLE
Feature/340 collection host input

### DIFF
--- a/public/locales/en/createDataset.json
+++ b/public/locales/en/createDataset.json
@@ -7,7 +7,7 @@
   "hostCollection": {
     "label": "Host Collection",
     "description": "The collection which contains this data.",
-    "helpText": "Changing the host dataverse will clear any fields you may have entered data into.",
+    "helpText": "Changing the host collection will clear any fields you may have entered data into.",
     "buttonLabel": "Edit Host Collection"
   },
   "requiredFields": "Asterisks indicate required fields",

--- a/public/locales/en/createDataset.json
+++ b/public/locales/en/createDataset.json
@@ -4,7 +4,7 @@
     "title": "Metadata Tip",
     "content": "After adding the dataset, click the Edit Dataset button to add more metadata."
   },
-  "hostCollection" : {
+  "hostCollection": {
     "label": "Host Collection",
     "description": "The collection which contains this data.",
     "helpText": "Changing the host dataverse will clear any fields you may have entered data into.",

--- a/public/locales/en/createDataset.json
+++ b/public/locales/en/createDataset.json
@@ -4,6 +4,12 @@
     "title": "Metadata Tip",
     "content": "After adding the dataset, click the Edit Dataset button to add more metadata."
   },
+  "hostCollection" : {
+    "label": "Host Collection",
+    "description": "The collection which contains this data.",
+    "helpText": "Changing the host dataverse will clear any fields you may have entered data into.",
+    "buttonLabel": "Edit Host Collection"
+  },
   "requiredFields": "Asterisks indicate required fields",
   "validationAlert": {
     "title": "Validation Error",

--- a/src/dataset/domain/repositories/DatasetRepository.ts
+++ b/src/dataset/domain/repositories/DatasetRepository.ts
@@ -6,7 +6,7 @@ import { DatasetsWithCount } from '../models/DatasetsWithCount'
 export interface DatasetRepository {
   getByPersistentId: (persistentId: string, version?: string) => Promise<Dataset | undefined>
   getByPrivateUrlToken: (privateUrlToken: string) => Promise<Dataset | undefined>
-  create: (dataset: DatasetDTO) => Promise<{ persistentId: string }>
+  create: (dataset: DatasetDTO, collectionId?: string) => Promise<{ persistentId: string }>
   getAllWithCount: (
     collectionId: string,
     paginationInfo: DatasetPaginationInfo

--- a/src/dataset/domain/useCases/createDataset.ts
+++ b/src/dataset/domain/useCases/createDataset.ts
@@ -3,9 +3,10 @@ import { DatasetDTO } from './DTOs/DatasetDTO'
 
 export function createDataset(
   datasetRepository: DatasetRepository,
-  dataset: DatasetDTO
+  dataset: DatasetDTO,
+  collectionId: string
 ): Promise<{ persistentId: string }> {
-  return datasetRepository.create(dataset).catch((error: Error) => {
+  return datasetRepository.create(dataset, collectionId).catch((error: Error) => {
     throw new Error(error.message)
   })
 }

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -27,7 +27,7 @@ import { JSDatasetPreviewMapper } from '../mappers/JSDatasetPreviewMapper'
 import { DatasetDTO } from '../../domain/useCases/DTOs/DatasetDTO'
 import { DatasetDTOMapper } from '../mappers/DatasetDTOMapper'
 import { DatasetsWithCount } from '../../domain/models/DatasetsWithCount'
-
+const defaultCollectionId = 'root'
 const includeDeaccessioned = true
 type DatasetDetails = [JSDataset, string[], string, JSDatasetPermissions, JSDatasetLock[]]
 
@@ -180,9 +180,12 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       })
   }
 
-  create(dataset: DatasetDTO): Promise<{ persistentId: string }> {
+  create(
+    dataset: DatasetDTO,
+    collectionId = defaultCollectionId
+  ): Promise<{ persistentId: string }> {
     return createDataset
-      .execute(DatasetDTOMapper.toJSDatasetDTO(dataset))
+      .execute(DatasetDTOMapper.toJSDatasetDTO(dataset), collectionId)
       .then((jsDatasetIdentifiers: JSDatasetIdentifiers) => ({
         persistentId: jsDatasetIdentifiers.persistentId
       }))

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -8,6 +8,7 @@ import { type MetadataBlockInfoRepository } from '../../metadata-block-info/doma
 import { SeparationLine } from '../shared/layout/SeparationLine/SeparationLine'
 import { DatasetForm } from './DatasetForm'
 import { DatasetFormSkeleton } from './DatasetFormSkeleton'
+import { HostCollectionForm } from './HostCollectionForm/HostCollectionForm'
 
 interface CreateDatasetProps {
   repository: DatasetRepository
@@ -46,7 +47,8 @@ export function CreateDataset({
         <h1>{t('pageTitle')}</h1>
       </header>
       <SeparationLine />
-      Host Collection alias: {collectionId}
+      <HostCollectionForm collectionId={collectionId} />
+
       {isLoadingMetadataBlocksConfiguration ? (
         <DatasetFormSkeleton />
       ) : (

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -46,11 +46,13 @@ export function CreateDataset({
         <h1>{t('pageTitle')}</h1>
       </header>
       <SeparationLine />
+      Host Collection alias: {collectionId}
       {isLoadingMetadataBlocksConfiguration ? (
         <DatasetFormSkeleton />
       ) : (
         <DatasetForm
           repository={repository}
+          collectionId={collectionId}
           metadataBlocks={metadataBlocks}
           formDefaultValues={formDefaultValues}
           errorLoadingMetadataBlocks={errorLoadingMetadataBlocksToRender}

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -44,26 +44,27 @@ export function CreateDataset({
   }, [isLoading, isLoadingMetadataBlocksConfiguration])
 
   return (
-    <article>
+    <>
       <NotImplementedModal show={isModalOpen} handleClose={hideModal} />
+      <article>
+        <header>
+          <h1>{t('pageTitle')}</h1>
+        </header>
+        <SeparationLine />
+        <HostCollectionForm collectionId={collectionId} />
 
-      <header>
-        <h1>{t('pageTitle')}</h1>
-      </header>
-      <SeparationLine />
-      <HostCollectionForm collectionId={collectionId} />
-
-      {isLoadingMetadataBlocksConfiguration ? (
-        <DatasetFormSkeleton />
-      ) : (
-        <DatasetForm
-          repository={repository}
-          collectionId={collectionId}
-          metadataBlocks={metadataBlocks}
-          formDefaultValues={formDefaultValues}
-          errorLoadingMetadataBlocks={errorLoadingMetadataBlocksToRender}
-        />
-      )}
-    </article>
+        {isLoadingMetadataBlocksConfiguration ? (
+          <DatasetFormSkeleton />
+        ) : (
+          <DatasetForm
+            repository={repository}
+            collectionId={collectionId}
+            metadataBlocks={metadataBlocks}
+            formDefaultValues={formDefaultValues}
+            errorLoadingMetadataBlocks={errorLoadingMetadataBlocksToRender}
+          />
+        )}
+      </article>
+    </>
   )
 }

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -9,6 +9,8 @@ import { SeparationLine } from '../shared/layout/SeparationLine/SeparationLine'
 import { DatasetForm } from './DatasetForm'
 import { DatasetFormSkeleton } from './DatasetFormSkeleton'
 import { HostCollectionForm } from './HostCollectionForm/HostCollectionForm'
+import { NotImplementedModal } from '../not-implemented/NotImplementedModal'
+import { useNotImplementedModal } from '../not-implemented/NotImplementedModalContext'
 
 interface CreateDatasetProps {
   repository: DatasetRepository
@@ -23,7 +25,7 @@ export function CreateDataset({
 }: CreateDatasetProps) {
   const { t } = useTranslation('createDataset')
   const { isLoading, setIsLoading } = useLoading()
-
+  const { isModalOpen, hideModal } = useNotImplementedModal()
   const {
     metadataBlocks,
     isLoading: isLoadingMetadataBlocksConfiguration,
@@ -43,6 +45,8 @@ export function CreateDataset({
 
   return (
     <article>
+      <NotImplementedModal show={isModalOpen} handleClose={hideModal} />
+
       <header>
         <h1>{t('pageTitle')}</h1>
       </header>

--- a/src/sections/create-dataset/CreateDatasetFactory.tsx
+++ b/src/sections/create-dataset/CreateDatasetFactory.tsx
@@ -3,13 +3,18 @@ import { useSearchParams } from 'react-router-dom'
 import { CreateDataset } from './CreateDataset'
 import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
 import { MetadataBlockInfoJSDataverseRepository } from '../../metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
+import { NotImplementedModalProvider } from '../not-implemented/NotImplementedModalProvider'
 
 const repository = new DatasetJSDataverseRepository()
 const metadataBlockInfoRepository = new MetadataBlockInfoJSDataverseRepository()
 
 export class CreateDatasetFactory {
   static create(): ReactElement {
-    return <CreateDatasetWithSearchParams />
+    return (
+      <NotImplementedModalProvider>
+        <CreateDatasetWithSearchParams />
+      </NotImplementedModalProvider>
+    )
   }
 }
 

--- a/src/sections/create-dataset/DatasetForm.tsx
+++ b/src/sections/create-dataset/DatasetForm.tsx
@@ -14,6 +14,7 @@ import { Route } from '../Route.enum'
 
 interface DatasetFormProps {
   repository: DatasetRepository
+  collectionId?: string
   metadataBlocks: MetadataBlockInfo[]
   errorLoadingMetadataBlocks: string | null
   formDefaultValues: CreateDatasetFormValues
@@ -21,6 +22,7 @@ interface DatasetFormProps {
 
 export const DatasetForm = ({
   repository,
+  collectionId = 'root',
   metadataBlocks,
   errorLoadingMetadataBlocks,
   formDefaultValues
@@ -29,7 +31,7 @@ export const DatasetForm = ({
   const { t } = useTranslation('createDataset')
   const accordionRef = useRef<HTMLDivElement>(null)
 
-  const { submissionStatus, submitForm } = useCreateDatasetForm(repository)
+  const { submissionStatus, submitForm } = useCreateDatasetForm(repository, collectionId)
 
   const isErrorLoadingMetadataBlocks = Boolean(errorLoadingMetadataBlocks)
 

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
@@ -1,11 +1,11 @@
 
-
 .edit-button-wrapper {
     display: flex ;
   flex-direction: column;
-  justify-content: flex-end;
   align-items: flex-start;
+  justify-content: flex-end;
 }
+
 .input-button-wrapper {
   display: flex;
   gap: 1rem;

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
@@ -5,7 +5,6 @@
   flex-direction: column;
   justify-content: flex-end;
   align-items: flex-start;
-  border: 1px red solid;
 }
 .input-button-wrapper {
   display: flex;

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
@@ -1,0 +1,13 @@
+
+
+.edit-button-wrapper {
+    display: flex ;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-start;
+  border: 1px red solid;
+}
+.input-button-wrapper {
+  display: flex;
+  gap: 1rem;
+}

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.module.scss
@@ -1,12 +1,25 @@
+.input-button-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+
+  @media (min-width: 768px) {
+    flex-direction: row;
+    gap: 0;
+
+    button {
+      width: 100%;
+    }
+  }
+}
 
 .edit-button-wrapper {
-    display: flex ;
+  display: flex;
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-end;
-}
 
-.input-button-wrapper {
-  display: flex;
-  gap: 1rem;
+  @media (min-width: 768px) {
+    padding-left: 1rem;
+  }
 }

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
@@ -19,20 +19,15 @@ export function HostCollectionForm({ collectionId }: HostCollectionFormProps) {
           {t('hostCollection.label')}
         </Form.Group.Label>
         <Col sm={9}>
-          <Row>
-            <Col sm={9}>
+          <Row className={styles['input-button-wrapper']}>
+            <Col sm={6}>
               {t('hostCollection.helpText')}
               <Form.Group.Input type="text" disabled defaultValue={collectionId} />
             </Col>
-            <Col sm={3}>
-              <Row>&nbsp;</Row> {/* Empty row to align the button */}
-              <Row>
-                <Col>
-                  <Button type={'button'} onClick={onClick} variant="secondary">
-                    {t('hostCollection.buttonLabel')}
-                  </Button>
-                </Col>
-              </Row>
+            <Col className={styles['edit-button-wrapper']} sm={3}>
+              <Button type={'button'} onClick={showModal} variant="secondary">
+                {t('hostCollection.buttonLabel')}
+              </Button>
             </Col>
           </Row>
         </Col>

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Col, Row } from '@iqss/dataverse-design-system'
+import { Button, Col } from '@iqss/dataverse-design-system'
 import { Form } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
 import { useNotImplementedModal } from '../../not-implemented/NotImplementedModalContext'
@@ -18,18 +18,16 @@ export function HostCollectionForm({ collectionId }: HostCollectionFormProps) {
         <Form.Group.Label message={t('hostCollection.description')} column sm={3} required>
           {t('hostCollection.label')}
         </Form.Group.Label>
-        <Col sm={9}>
-          <Row className={styles['input-button-wrapper']}>
-            <Col sm={6}>
-              {t('hostCollection.helpText')}
-              <Form.Group.Input type="text" disabled defaultValue={collectionId} />
-            </Col>
-            <Col className={styles['edit-button-wrapper']} sm={3}>
-              <Button type={'button'} onClick={showModal} variant="secondary">
-                {t('hostCollection.buttonLabel')}
-              </Button>
-            </Col>
-          </Row>
+        <Col sm={9} className={styles['input-button-wrapper']}>
+          <Col md={9}>
+            <Form.Group.Text>{t('hostCollection.helpText')}</Form.Group.Text>
+            <Form.Group.Input type="text" disabled defaultValue={collectionId} />
+          </Col>
+          <Col className={styles['edit-button-wrapper']} md={3}>
+            <Button type={'button'} onClick={showModal} variant="secondary">
+              {t('hostCollection.buttonLabel')}
+            </Button>
+          </Col>
         </Col>
       </Form.Group>
     </>

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
@@ -2,7 +2,7 @@ import { Button, Col, Row } from '@iqss/dataverse-design-system'
 import { Form } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
 import { useNotImplementedModal } from '../../not-implemented/NotImplementedModalContext'
-import { NotImplementedModal } from '../../not-implemented/NotImplementedModal'
+import styles from './HostCollectionForm.module.scss'
 
 interface HostCollectionFormProps {
   collectionId: string
@@ -10,13 +10,10 @@ interface HostCollectionFormProps {
 
 export function HostCollectionForm({ collectionId }: HostCollectionFormProps) {
   const { t } = useTranslation('createDataset')
-  const { hideModal, isModalOpen, showModal } = useNotImplementedModal()
-  const onClick = () => {
-    showModal()
-  }
+  const { showModal } = useNotImplementedModal()
+
   return (
     <>
-      <NotImplementedModal show={isModalOpen} handleClose={hideModal} />
       <Form.Group controlId="host-collection">
         <Form.Group.Label message={t('hostCollection.description')} column sm={3} required>
           {t('hostCollection.label')}

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
@@ -1,0 +1,27 @@
+import { Col, Row } from '@iqss/dataverse-design-system'
+import { Form } from '@iqss/dataverse-design-system'
+import { useTranslation } from 'react-i18next'
+
+const description = 'The host collection of the dataset.'
+interface HostCollectionFormProps {
+  collectionId: string
+}
+
+export function HostCollectionForm({ collectionId }: HostCollectionFormProps) {
+  const { t } = useTranslation('createDataset')
+  return (
+    <Form>
+      <Form.Group controlId="basic-form-email">
+        <Form.Group.Label message={t('hostCollection.description')} column sm={3} required>
+          {t('hostCollection.label')}
+        </Form.Group.Label>
+        <Col sm={6}>
+          <Row>{t('hostCollection.helpText')}</Row>
+          <Row>
+            <Form.Group.Input type="text" disabled defaultValue={collectionId} />
+          </Row>
+        </Col>
+      </Form.Group>
+    </Form>
+  )
+}

--- a/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
+++ b/src/sections/create-dataset/HostCollectionForm/HostCollectionForm.tsx
@@ -1,27 +1,45 @@
-import { Col, Row } from '@iqss/dataverse-design-system'
+import { Button, Col, Row } from '@iqss/dataverse-design-system'
 import { Form } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
+import { useNotImplementedModal } from '../../not-implemented/NotImplementedModalContext'
+import { NotImplementedModal } from '../../not-implemented/NotImplementedModal'
 
-const description = 'The host collection of the dataset.'
 interface HostCollectionFormProps {
   collectionId: string
 }
 
 export function HostCollectionForm({ collectionId }: HostCollectionFormProps) {
   const { t } = useTranslation('createDataset')
+  const { hideModal, isModalOpen, showModal } = useNotImplementedModal()
+  const onClick = () => {
+    showModal()
+  }
   return (
-    <Form>
-      <Form.Group controlId="basic-form-email">
+    <>
+      <NotImplementedModal show={isModalOpen} handleClose={hideModal} />
+      <Form.Group controlId="host-collection">
         <Form.Group.Label message={t('hostCollection.description')} column sm={3} required>
           {t('hostCollection.label')}
         </Form.Group.Label>
-        <Col sm={6}>
-          <Row>{t('hostCollection.helpText')}</Row>
+        <Col sm={9}>
           <Row>
-            <Form.Group.Input type="text" disabled defaultValue={collectionId} />
+            <Col sm={9}>
+              {t('hostCollection.helpText')}
+              <Form.Group.Input type="text" disabled defaultValue={collectionId} />
+            </Col>
+            <Col sm={3}>
+              <Row>&nbsp;</Row> {/* Empty row to align the button */}
+              <Row>
+                <Col>
+                  <Button type={'button'} onClick={onClick} variant="secondary">
+                    {t('hostCollection.buttonLabel')}
+                  </Button>
+                </Col>
+              </Row>
+            </Col>
           </Row>
         </Col>
       </Form.Group>
-    </Form>
+    </>
   )
 }

--- a/src/sections/create-dataset/useCreateDatasetForm.tsx
+++ b/src/sections/create-dataset/useCreateDatasetForm.tsx
@@ -12,7 +12,10 @@ export enum SubmissionStatus {
   Errored = 'Errored'
 }
 
-export function useCreateDatasetForm(repository: DatasetRepository): {
+export function useCreateDatasetForm(
+  repository: DatasetRepository,
+  collectionId: string
+): {
   submissionStatus: SubmissionStatus
   submitForm: (formData: CreateDatasetFormValues) => void
 } {
@@ -29,8 +32,8 @@ export function useCreateDatasetForm(repository: DatasetRepository): {
     const formattedFormValues = MetadataFieldsHelper.formatFormValuesToCreateDatasetDTO(
       formDataBackToOriginalKeys
     )
-
-    createDataset(repository, formattedFormValues)
+    console.log('submitting, collectionId = ' + collectionId)
+    createDataset(repository, formattedFormValues, collectionId)
       .then(({ persistentId }) => {
         setSubmissionStatus(SubmissionStatus.SubmitComplete)
         navigate(`${Route.DATASETS}?persistentId=${persistentId}`, {

--- a/src/sections/create-dataset/useCreateDatasetForm.tsx
+++ b/src/sections/create-dataset/useCreateDatasetForm.tsx
@@ -32,7 +32,7 @@ export function useCreateDatasetForm(
     const formattedFormValues = MetadataFieldsHelper.formatFormValuesToCreateDatasetDTO(
       formDataBackToOriginalKeys
     )
-    console.log('submitting, collectionId = ' + collectionId)
+
     createDataset(repository, formattedFormValues, collectionId)
       .then(({ persistentId }) => {
         setSubmissionStatus(SubmissionStatus.SubmitComplete)

--- a/src/stories/create-dataset/DatasetCreate.stories.tsx
+++ b/src/stories/create-dataset/DatasetCreate.stories.tsx
@@ -6,6 +6,7 @@ import { DatasetMockRepository } from '../dataset/DatasetMockRepository'
 import { MetadataBlockInfoMockRepository } from './MetadataBlockInfoMockRepository'
 import { MetadataBlockInfoMockLoadingRepository } from './MetadataBlockInfoMockLoadingRepository'
 import { MetadataBlockInfoMockErrorRepository } from './MetadataBlockInfoMockErrorRepository'
+import { NotImplementedModalProvider } from '../../sections/not-implemented/NotImplementedModalProvider'
 
 const meta: Meta<typeof CreateDataset> = {
   title: 'Pages/Create Dataset',
@@ -17,10 +18,12 @@ type Story = StoryObj<typeof CreateDataset>
 
 export const Default: Story = {
   render: () => (
-    <CreateDataset
-      repository={new DatasetMockRepository()}
-      metadataBlockInfoRepository={new MetadataBlockInfoMockRepository()}
-    />
+    <NotImplementedModalProvider>
+      <CreateDataset
+        repository={new DatasetMockRepository()}
+        metadataBlockInfoRepository={new MetadataBlockInfoMockRepository()}
+      />
+    </NotImplementedModalProvider>
   )
 }
 

--- a/tests/component/sections/create-dataset/CreateDataset.spec.tsx
+++ b/tests/component/sections/create-dataset/CreateDataset.spec.tsx
@@ -3,6 +3,7 @@ import { DatasetRepository } from '../../../../src/dataset/domain/repositories/D
 import { MetadataBlockInfoRepository } from '../../../../src/metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
 import { MetadataBlockInfoMother } from '../../metadata-block-info/domain/models/MetadataBlockInfoMother'
 import { TypeMetadataFieldOptions } from '../../../../src/metadata-block-info/domain/models/MetadataBlockInfo'
+import { NotImplementedModalProvider } from '../../../../src/sections/not-implemented/NotImplementedModalProvider'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
 const metadataBlockInfoRepository: MetadataBlockInfoRepository = {} as MetadataBlockInfoRepository
@@ -63,7 +64,25 @@ describe('Create Dataset', () => {
       .stub()
       .resolves(collectionMetadataBlocksInfo)
   })
-
+  it('renders the Host Collection Form', () => {
+    cy.customMount(
+      <NotImplementedModalProvider>
+        <CreateDataset
+          repository={datasetRepository}
+          collectionId={'test-collectionId'}
+          metadataBlockInfoRepository={metadataBlockInfoRepository}
+        />
+      </NotImplementedModalProvider>
+    )
+    cy.findByText(/^Host Collection/i).should('exist')
+    cy.findByDisplayValue('test-collectionId').should('exist')
+    cy.findByText(/^Edit Host Collection/i)
+      .should('exist')
+      .click()
+      .then(() => {
+        cy.findByText('Not Implemented').should('exist')
+      })
+  })
   it('renders the Create Dataset page and its metadata blocks sections', () => {
     cy.customMount(
       <CreateDataset
@@ -72,7 +91,6 @@ describe('Create Dataset', () => {
       />
     )
     cy.findByText(/Create Dataset/i).should('exist')
-
     cy.findByText(/Citation Metadata/i).should('exist')
     cy.findByText(/Astronomy and Astrophysics Metadata/i).should('exist')
   })


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a read only input field for the host collection in Create Dataset Page

**Which issue(s) this PR closes**:

Closes #340 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Create a new collection then navigate to the collection page.  From the collection page, select the "Add Dataset" dropdown.  On the Create Dataset page, the Host Collection input should be prefilled with the alias of the new collection.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

<img width="1147" alt="Screenshot 2024-05-19 at 8 57 43 PM" src="https://github.com/IQSS/dataverse-frontend/assets/675224/b0d1852b-80d1-4d91-90eb-bda2b655daed">


**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
none