### PR TITLE
Fix/393 Match api email validation

### DIFF
--- a/src/metadata-block-info/domain/models/fieldValidations.ts
+++ b/src/metadata-block-info/domain/models/fieldValidations.ts
@@ -2,7 +2,7 @@ import { DateFormats } from './MetadataBlockInfo'
 
 export function isValidEmail(email: string): boolean {
   const EMAIL_REGEX =
-    /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/
+    /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])/
   return EMAIL_REGEX.test(email)
 }
 
@@ -75,4 +75,31 @@ export function isValidDateFormat(dateString: string, acceptedFormat?: DateForma
       yearFormatRegex.test(dateString)
     )
   }
+}
+
+/**
+ * Extracts the invalid value from the error message, removing 'Validation Failed:' and everything after '(Invalid value:'
+ * @param errorMessage
+ * @returns the invalid value or null if it can't be extracted
+ * @example
+ * getValidationFailedFieldError("Validation Failed: Point of Contact E-mail test@test.c  is not a valid email address. (Invalid value:edu.harvard.iq.dataverse.DatasetFieldValueValue[ id=null ]).java.util.stream.ReferencePipeline$3@561b5200")
+ * // returns "Point of Contact E-mail test@test.c  is not a valid email address."
+ */
+
+export function getValidationFailedFieldError(errorMessage: string): string | null {
+  const validationFailedKeyword = 'Validation Failed:'
+  const invalidValueKeyword = '(Invalid value:'
+
+  const validationFailedKeywordIndex = errorMessage.indexOf(validationFailedKeyword)
+  const invalidValueKeywordIndex = errorMessage.indexOf(invalidValueKeyword)
+
+  if (validationFailedKeywordIndex !== -1 && invalidValueKeywordIndex !== -1) {
+    const start = validationFailedKeywordIndex + validationFailedKeyword.length
+    const end = invalidValueKeywordIndex
+    const extractedValue = errorMessage.slice(start, end).trim()
+
+    return extractedValue
+  }
+
+  return null
 }

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -41,7 +41,7 @@ export function CreateDataset({
     if (!isLoadingMetadataBlocksConfiguration) {
       setIsLoading(false)
     }
-  }, [isLoading, isLoadingMetadataBlocksConfiguration])
+  }, [isLoading, isLoadingMetadataBlocksConfiguration, setIsLoading])
 
   return (
     <>

--- a/src/sections/create-dataset/DatasetForm.module.scss
+++ b/src/sections/create-dataset/DatasetForm.module.scss
@@ -1,0 +1,3 @@
+.form-container {
+  scroll-margin-top: 62px;
+}

--- a/src/sections/create-dataset/MetadataBlockFormFields/MetadataFormField/Fields/PrimitiveMultiple.tsx
+++ b/src/sections/create-dataset/MetadataBlockFormFields/MetadataFormField/Fields/PrimitiveMultiple.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Controller, useFieldArray, useFormContext } from 'react-hook-form'
 import { Col, Form, Row } from '@iqss/dataverse-design-system'
 import { TypeMetadataFieldOptions } from '../../../../../metadata-block-info/domain/models/MetadataBlockInfo'
@@ -36,20 +36,20 @@ export const PrimitiveMultiple = ({
     control: control
   })
 
-  const builtFieldNameWithIndex = (fieldIndex: number) => {
-    return MetadataFieldsHelper.defineFieldName(
-      name,
-      metadataBlockName,
-      compoundParentName,
-      fieldIndex
-    )
-  }
-
-  // We give the label the same ID as the first field, so that clicking on the label focuses the first field
-  const controlID = useMemo(
-    () => builtFieldNameWithIndex(0),
+  const builtFieldNameWithIndex = useCallback(
+    (fieldIndex: number) => {
+      return MetadataFieldsHelper.defineFieldName(
+        name,
+        metadataBlockName,
+        compoundParentName,
+        fieldIndex
+      )
+    },
     [name, metadataBlockName, compoundParentName]
   )
+
+  // We give the label the same ID as the first field, so that clicking on the label focuses the first field
+  const controlID = useMemo(() => builtFieldNameWithIndex(0), [builtFieldNameWithIndex])
 
   const handleOnAddField = (index: number) => {
     insert(

--- a/src/sections/create-dataset/MetadataBlockFormFields/index.tsx
+++ b/src/sections/create-dataset/MetadataBlockFormFields/index.tsx
@@ -1,4 +1,4 @@
-import { MetadataBlockInfo } from '../../../metadata-block-info/domain/models/MetadataBlockInfo'
+import { type MetadataBlockInfo } from /* istanbul ignore next */ '../../../metadata-block-info/domain/models/MetadataBlockInfo'
 import { MetadataFormField } from './MetadataFormField'
 
 interface Props {

--- a/tests/component/metadata-block-info/domain/models/MetadataBlockInfoMother.ts
+++ b/tests/component/metadata-block-info/domain/models/MetadataBlockInfoMother.ts
@@ -4838,4 +4838,32 @@ export class MetadataBlockInfoMother {
       }
     ]
   }
+
+  static wrongCollectionMetadataBlocksInfo(): MetadataBlockInfo[] {
+    return [
+      {
+        id: 1,
+        name: 'citation',
+        displayName: 'Citation Metadata',
+        displayOnCreate: true,
+        metadataFields: {
+          title: {
+            name: 'title',
+            displayName: 'Title',
+            title: 'Title',
+            type: 'TEXT',
+            typeClass: 'primitive',
+            watermark: '',
+            description: 'The main title of the Dataset',
+            multiple: false,
+            isControlledVocabulary: false,
+            displayFormat: '',
+            isRequired: false,
+            displayOnCreate: true,
+            displayOrder: 0
+          }
+        }
+      }
+    ]
+  }
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a mismatch between the email validation of the SPA Dataset creation form and the email validation of the dataverse api.
Also improves the UX to display the alert error banner only when creations fail, with messages specific to both the client-javascript api wrapper and the dataverse api itself (from the latter extracting only the field-related part of the error and not the part of the error related to Java invalid value exceptions).

**Which issue(s) this PR closes**:

Closes #393 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Enter an invalid email (test@test.e) and check that the error message is displayed below the field.
It is a bit difficult to test the error messages in the banners as the validations are being fulfilled from the form before it is submitted.
One option could be to test locally, modifying the code so that no fields are required within the form and submitting the form, in `useDefineRules.tsx` set the required property to `false`.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
The same error banner is maintained, only now when the user submits the form, if there is an error and this banner appears, it is automatically focused with an specific message about the error.

**_Error thrown from the dataverse api_** 👇
<img width="1221" alt="Screenshot 2024-05-20 at 11 01 07" src="https://github.com/IQSS/dataverse-frontend/assets/64560524/360289f9-40d3-47bc-8438-5629a4cd2c95">

**_Error thrown from the client-javascript api wrapper_** 👇
<img width="1225" alt="Screenshot 2024-05-20 at 11 03 05" src="https://github.com/IQSS/dataverse-frontend/assets/64560524/e593671e-eb17-4066-8498-c8742873e43e">

**_How the error banner is focused_** 👇
_In this example the client-side validations were removed just to show the focus case._
[alert-error-behaviour.webm](https://github.com/IQSS/dataverse-frontend/assets/64560524/3f33ef1a-a518-4be7-904a-2c352a79db59)




**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
No.
