### PR TITLE
fix: map jsDataset.id and persistentId in JSDatasetMapper.toHierarachy()

### DIFF
--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -71,7 +71,12 @@ export class JSDatasetMapper {
         jsDatasetFilesTotalOriginalDownloadSize,
         jsDatasetFilesTotalArchivalDownloadSize
       ),
-      JSDatasetMapper.toHierarchy(jsDataset.persistentId, version, jsDataset.isPartOf),
+      JSDatasetMapper.toHierarchy(
+        jsDataset.id,
+        jsDataset.persistentId,
+        version,
+        jsDataset.isPartOf
+      ),
       undefined, // TODO: get dataset thumbnail from js-dataverse https://github.com/IQSS/dataverse-frontend/issues/203
       privateUrl,
       requestedVersion
@@ -232,6 +237,7 @@ export class JSDatasetMapper {
   }
 
   static toHierarchy(
+    id: number,
     persistentId: string,
     version: DatasetVersion,
     jsUpwardHierarchyNode: JSUpwardHierarchyNode
@@ -239,8 +245,8 @@ export class JSDatasetMapper {
     return new UpwardHierarchyNode(
       version.title,
       DvObjectType.DATASET,
+      id.toString(),
       persistentId,
-      undefined,
       version.number.toString(),
       JSUpwardHierarchyNodeMapper.toUpwardHierarchyNode(jsUpwardHierarchyNode)
     )

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -177,8 +177,8 @@ const expectedDataset = {
   hierarchy: new UpwardHierarchyNode(
     "Darwin's Finches",
     DvObjectType.DATASET,
+    '505',
     'doi:10.5072/FK2/B4B2MJ',
-    undefined,
     '0.0',
     new UpwardHierarchyNode('Root', DvObjectType.COLLECTION, 'root')
   )
@@ -285,8 +285,8 @@ const expectedDatasetAlternateVersion = {
   hierarchy: new UpwardHierarchyNode(
     "Darwin's Finches",
     DvObjectType.DATASET,
+    '505',
     'doi:10.5072/FK2/B4B2MJ',
-    undefined,
     '0.0',
     new UpwardHierarchyNode('Root', DvObjectType.COLLECTION, 'root')
   )


### PR DESCRIPTION
**What this PR does / why we need it**:
fix the mapping of Hierarchy in the getDataset() usecase
**Which issue(s) this PR closes**:

Closes #403 

**Special notes for your reviewer**:
I think this is the fix that is needed rather than https://github.com/IQSS/dataverse-client-javascript/issues/154.  

**Suggestions on how to test this**:
In the SPA, create a Dataset, then go to File Upload page.  The Dataset Breadcrumb on the File upload page should have the correct link.


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:

**Is there a release notes update needed for this change?**:

**Additional documentation**:
