### PR TITLE
Fix - Collection page datasets not being refetched after navigating from a sub collection.

### DIFF
--- a/src/sections/collection/Collection.tsx
+++ b/src/sections/collection/Collection.tsx
@@ -52,9 +52,18 @@ export function Collection({
           </>
         )}
         {infiniteScrollEnabled ? (
-          <DatasetsListWithInfiniteScroll datasetRepository={datasetRepository} collectionId={id} />
+          <DatasetsListWithInfiniteScroll
+            datasetRepository={datasetRepository}
+            collectionId={id}
+            key={id}
+          />
         ) : (
-          <DatasetsList datasetRepository={datasetRepository} page={page} collectionId={id} />
+          <DatasetsList
+            datasetRepository={datasetRepository}
+            page={page}
+            collectionId={id}
+            key={id}
+          />
         )}
       </Col>
     </Row>

--- a/src/stories/create-dataset/CreateDataset.stories.tsx
+++ b/src/stories/create-dataset/CreateDataset.stories.tsx
@@ -11,7 +11,11 @@ import { NotImplementedModalProvider } from '../../sections/not-implemented/NotI
 const meta: Meta<typeof CreateDataset> = {
   title: 'Pages/Create Dataset',
   component: CreateDataset,
-  decorators: [WithI18next, WithLayout]
+  decorators: [WithI18next, WithLayout],
+  parameters: {
+    // Sets the delay for all stories.
+    chromatic: { delay: 15000, pauseAnimationAtEnd: true }
+  }
 }
 export default meta
 type Story = StoryObj<typeof CreateDataset>


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix bug about datasets from collection not changing when collection changed.

**Which issue(s) this PR closes**:

Closes #408 

**Special notes for your reviewer**:

**Suggestions on how to test this**:
Navigate to a dataset in a sub-collection, then click on the breadcrumbs to go to the parent collection for that dataset.
The datasets in that collection will be displayed, and then click on the breadcrumb root to display the new datasets in the root collection.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No.

**Is there a release notes update needed for this change?**:
No.

**Additional documentation**:
No.
