### PR TITLE
render Json-LD in Dataset Page

### DIFF
--- a/src/sections/dataset/Dataset.tsx
+++ b/src/sections/dataset/Dataset.tsx
@@ -20,6 +20,7 @@ import { SeparationLine } from '../shared/layout/SeparationLine/SeparationLine'
 import { BreadcrumbsGenerator } from '../shared/hierarchy/BreadcrumbsGenerator'
 import { useAlertContext } from '../alerts/AlertContext'
 import { AlertMessageKey } from '../../alert/domain/models/Alert'
+import { DatasetJsonLd } from './dataset-json-ld/DatasetJsonLd'
 
 interface DatasetProps {
   fileRepository: FileRepository
@@ -46,6 +47,7 @@ export function Dataset({ fileRepository, created }: DatasetProps) {
 
   return (
     <>
+      <DatasetJsonLd persistentId={dataset?.persistentId}></DatasetJsonLd>
       <NotImplementedModal show={isModalOpen} handleClose={hideModal} />
       {!dataset ? (
         <PageNotFound />

--- a/src/sections/dataset/dataset-json-ld/DatasetJsonLd.tsx
+++ b/src/sections/dataset/dataset-json-ld/DatasetJsonLd.tsx
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+
+interface DatasetJsonLdProps {
+  persistentId: string | undefined
+}
+
+export function DatasetJsonLd({ persistentId }: DatasetJsonLdProps) {
+  const addJsonLdScript = (persistentId: string) => {
+    const jsonLdData = {
+      '@context': 'http://schema.org',
+      '@type': 'Dataset',
+      '@id': persistentId,
+      identifier: persistentId,
+      name: 'test',
+      creator: [
+        {
+          '@type': 'Person',
+          givenName: 'Guillermo',
+          familyName: 'Portas',
+          name: 'Portas, Guillermo'
+        }
+      ]
+    }
+    //TODO: replace string with data from server
+    const script = document.createElement('script')
+    script.type = 'application/ld+json'
+    script.text = JSON.stringify(jsonLdData)
+
+    const existingScript = document.querySelector('script[type="application/ld+json"]')
+    if (existingScript) {
+      existingScript.remove()
+    }
+    document.head.appendChild(script)
+  }
+  useEffect(() => {
+    persistentId && addJsonLdScript(persistentId)
+  }, [persistentId])
+  return <></>
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds json-ld to header of View Dataset page.

**Which issue(s) this PR closes**:

Closes #350 

**Special notes for your reviewer**:
This PR is a proof of concept, to test that the json-ld is available in a deployed app.  The json-ld is viewable in the browser view of the DOM, and has dynamic data based on the current dataset, but we need to test on a webpage that can be run in https://search.google.com/test/rich-results

**Suggestions on how to test this**:
Deploy to beta.dataverse.org and do the rich-results test.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no
**Is there a release notes update needed for this change?**:
no
**Additional documentation**:
