### PR TITLE
321 default dataset version

### DIFF
--- a/src/dataset/domain/models/Dataset.ts
+++ b/src/dataset/domain/models/Dataset.ts
@@ -214,7 +214,7 @@ export enum DatasetNonNumericVersion {
   DRAFT = ':draft',
   LATEST_PUBLISHED = ':latest-published'
 }
-export enum DatasetVersionNonNumericSearchParam {
+export enum DatasetNonNumericVersionSearchParam {
   DRAFT = 'DRAFT'
 }
 

--- a/src/dataset/domain/models/Dataset.ts
+++ b/src/dataset/domain/models/Dataset.ts
@@ -211,7 +211,11 @@ export enum DatasetPublishingStatus {
 
 export enum DatasetNonNumericVersion {
   LATEST = ':latest',
-  DRAFT = ':draft'
+  DRAFT = ':draft',
+  LATEST_PUBLISHED = ':latest-published'
+}
+export enum DatasetVersionNonNumericSearchParam {
+  DRAFT = 'DRAFT'
 }
 
 export class DatasetVersionNumber {

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -1,5 +1,5 @@
 import { DatasetRepository } from '../../domain/repositories/DatasetRepository'
-import { Dataset } from '../../domain/models/Dataset'
+import { Dataset, DatasetNonNumericVersion } from '../../domain/models/Dataset'
 import {
   getDataset,
   getAllDatasetPreviews,
@@ -116,9 +116,10 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
 
   getByPersistentId(
     persistentId: string,
-    version?: string,
+    version: string = DatasetNonNumericVersion.LATEST_PUBLISHED,
     requestedVersion?: string
   ): Promise<Dataset | undefined> {
+    console.log('getByPersistentId', persistentId, version, requestedVersion)
     return getDataset
       .execute(persistentId, version, includeDeaccessioned)
       .then((jsDataset) => this.fetchDatasetDetails(jsDataset, version))
@@ -147,10 +148,14 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       })
       .catch((error: ReadError) => {
         console.error(error)
-        if (!version) {
+        if (version === DatasetNonNumericVersion.LATEST_PUBLISHED) {
           throw new Error(`Failed to get dataset by persistent ID: ${error.message}`)
         }
-        return this.getByPersistentId(persistentId, undefined, (requestedVersion = version))
+        return this.getByPersistentId(
+          persistentId,
+          DatasetNonNumericVersion.LATEST_PUBLISHED,
+          (requestedVersion = version)
+        )
       })
   }
   getByPrivateUrlToken(privateUrlToken: string): Promise<Dataset | undefined> {

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -119,7 +119,6 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
     version: string = DatasetNonNumericVersion.LATEST_PUBLISHED,
     requestedVersion?: string
   ): Promise<Dataset | undefined> {
-    console.log('getByPersistentId', persistentId, version, requestedVersion)
     return getDataset
       .execute(persistentId, version, includeDeaccessioned)
       .then((jsDataset) => this.fetchDatasetDetails(jsDataset, version))

--- a/src/sections/collection/datasets-list/dataset-card/DatasetCardHeader.tsx
+++ b/src/sections/collection/datasets-list/dataset-card/DatasetCardHeader.tsx
@@ -6,7 +6,7 @@ import { DatasetIcon } from '../../../dataset/dataset-icon/DatasetIcon'
 import {
   DatasetPublishingStatus,
   DatasetVersion,
-  DatasetVersionNonNumericSearchParam
+  DatasetNonNumericVersionSearchParam
 } from '../../../../dataset/domain/models/Dataset'
 
 interface DatasetCardHeaderProps {
@@ -19,7 +19,7 @@ function getSearchParams(
 ): Record<string, string> {
   const params: Record<string, string> = { persistentId: persistentId }
   if (publishingStatus === DatasetPublishingStatus.DRAFT) {
-    params.version = DatasetVersionNonNumericSearchParam.DRAFT
+    params.version = DatasetNonNumericVersionSearchParam.DRAFT
   }
   return params
 }

--- a/src/sections/collection/datasets-list/dataset-card/DatasetCardHeader.tsx
+++ b/src/sections/collection/datasets-list/dataset-card/DatasetCardHeader.tsx
@@ -3,17 +3,33 @@ import { LinkToPage } from '../../../shared/link-to-page/LinkToPage'
 import { Route } from '../../../Route.enum'
 import { DatasetLabels } from '../../../dataset/dataset-labels/DatasetLabels'
 import { DatasetIcon } from '../../../dataset/dataset-icon/DatasetIcon'
-import { DatasetVersion } from '../../../../dataset/domain/models/Dataset'
+import {
+  DatasetPublishingStatus,
+  DatasetVersion,
+  DatasetVersionNonNumericSearchParam
+} from '../../../../dataset/domain/models/Dataset'
 
 interface DatasetCardHeaderProps {
   persistentId: string
   version: DatasetVersion
 }
+function getSearchParams(
+  persistentId: string,
+  publishingStatus: DatasetPublishingStatus
+): Record<string, string> {
+  const params: Record<string, string> = { persistentId: persistentId }
+  if (publishingStatus === DatasetPublishingStatus.DRAFT) {
+    params.version = DatasetVersionNonNumericSearchParam.DRAFT
+  }
+  return params
+}
 export function DatasetCardHeader({ persistentId, version }: DatasetCardHeaderProps) {
   return (
     <div className={styles.header}>
       <div className={styles.title}>
-        <LinkToPage page={Route.DATASETS} searchParams={{ persistentId: persistentId }}>
+        <LinkToPage
+          page={Route.DATASETS}
+          searchParams={getSearchParams(persistentId, version.publishingStatus)}>
           {version.title}
         </LinkToPage>
         <DatasetLabels labels={version.labels} />

--- a/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
+++ b/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
@@ -8,6 +8,7 @@ import { MetadataFieldsHelper, type DatasetMetadataFormValues } from './Metadata
 import { getValidationFailedFieldError } from '../../../../metadata-block-info/domain/models/fieldValidations'
 import { type DatasetMetadataFormMode } from '.'
 import { Route } from '../../../Route.enum'
+import { DatasetVersionNonNumericSearchParam } from '../../../../dataset/domain/models/Dataset'
 
 export enum SubmissionStatus {
   NotSubmitted = 'NotSubmitted',
@@ -56,11 +57,12 @@ export function useSubmitDataset(
     )
 
     if (mode === 'create') {
+      const DRAFT_PARAM = DatasetVersionNonNumericSearchParam.DRAFT
       createDataset(datasetRepository, formattedFormValues, collectionId)
         .then(({ persistentId }) => {
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)
-          navigate(`${Route.DATASETS}?persistentId=${persistentId}`, {
+          navigate(`${Route.DATASETS}?persistentId=${persistentId}&version=${DRAFT_PARAM}`, {
             state: { created: true }
           })
           return

--- a/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
+++ b/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
@@ -8,7 +8,7 @@ import { MetadataFieldsHelper, type DatasetMetadataFormValues } from './Metadata
 import { getValidationFailedFieldError } from '../../../../metadata-block-info/domain/models/fieldValidations'
 import { type DatasetMetadataFormMode } from '.'
 import { Route } from '../../../Route.enum'
-import { DatasetVersionNonNumericSearchParam } from '../../../../dataset/domain/models/Dataset'
+import { DatasetNonNumericVersionSearchParam } from '../../../../dataset/domain/models/Dataset'
 
 export enum SubmissionStatus {
   NotSubmitted = 'NotSubmitted',
@@ -57,14 +57,16 @@ export function useSubmitDataset(
     )
 
     if (mode === 'create') {
-      const DRAFT_PARAM = DatasetVersionNonNumericSearchParam.DRAFT
       createDataset(datasetRepository, formattedFormValues, collectionId)
         .then(({ persistentId }) => {
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)
-          navigate(`${Route.DATASETS}?persistentId=${persistentId}&version=${DRAFT_PARAM}`, {
-            state: { created: true }
-          })
+          navigate(
+            `${Route.DATASETS}?persistentId=${persistentId}&version=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+            {
+              state: { created: true }
+            }
+          )
           return
         })
         .catch((err) => {

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -1,6 +1,6 @@
 import {
   DatasetLabelValue,
-  DatasetVersionNonNumericSearchParam
+  DatasetNonNumericVersionSearchParam
 } from '../../../../../src/dataset/domain/models/Dataset'
 import { TestsUtils } from '../../../shared/TestsUtils'
 import { DatasetHelper, DatasetResponse } from '../../../shared/datasets/DatasetHelper'
@@ -12,7 +12,7 @@ import { FILES_TAB_INFINITE_SCROLL_ENABLED } from '../../../../../src/sections/d
 type Dataset = {
   datasetVersion: { metadataBlocks: { citation: { fields: { value: string }[] } } }
 }
-const DRAFT_PARAM = DatasetVersionNonNumericSearchParam.DRAFT
+const DRAFT_PARAM = DatasetNonNumericVersionSearchParam.DRAFT
 
 describe('Dataset', () => {
   before(() => {

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -1,4 +1,7 @@
-import { DatasetLabelValue } from '../../../../../src/dataset/domain/models/Dataset'
+import {
+  DatasetLabelValue,
+  DatasetVersionNonNumericSearchParam
+} from '../../../../../src/dataset/domain/models/Dataset'
 import { TestsUtils } from '../../../shared/TestsUtils'
 import { DatasetHelper, DatasetResponse } from '../../../shared/datasets/DatasetHelper'
 import { FileHelper } from '../../../shared/files/FileHelper'
@@ -9,6 +12,7 @@ import { FILES_TAB_INFINITE_SCROLL_ENABLED } from '../../../../../src/sections/d
 type Dataset = {
   datasetVersion: { metadataBlocks: { citation: { fields: { value: string }[] } } }
 }
+const DRAFT_PARAM = DatasetVersionNonNumericSearchParam.DRAFT
 
 describe('Dataset', () => {
   before(() => {
@@ -24,7 +28,7 @@ describe('Dataset', () => {
       cy.wrap(DatasetHelper.create())
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.fixture('dataset-finch1.json').then((dataset: Dataset) => {
             cy.findByRole('heading', {
@@ -72,7 +76,7 @@ describe('Dataset', () => {
         .its('persistentId')
         .then((persistentId: string) => {
           cy.wrap(TestsUtils.logout())
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Page Not Found').should('exist')
         })
@@ -181,7 +185,7 @@ describe('Dataset', () => {
       )
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Root').should('exist')
           cy.findByRole('link', { name: 'Scientific Research' }).should('exist').click()
@@ -196,7 +200,7 @@ describe('Dataset', () => {
       cy.wrap(DatasetHelper.create())
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Files').should('exist')
 
@@ -208,7 +212,7 @@ describe('Dataset', () => {
       cy.wrap(DatasetHelper.createWithFiles(FileHelper.createMany(3)), { timeout: 5000 })
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Files').should('exist')
 
@@ -228,7 +232,7 @@ describe('Dataset', () => {
         cy.wrap(DatasetHelper.createWithFiles(FileHelper.createMany(30)), { timeout: 20000 })
           .its('persistentId')
           .then((persistentId: string) => {
-            cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+            cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
             cy.findByText('Files').should('exist')
 
@@ -252,7 +256,7 @@ describe('Dataset', () => {
         cy.wrap(DatasetHelper.createWithFiles(FileHelper.createMany(30)), { timeout: 20000 })
           .its('persistentId')
           .then((persistentId: string) => {
-            cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+            cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
             cy.findByText('Files').should('exist')
 
@@ -282,7 +286,7 @@ describe('Dataset', () => {
       cy.wrap(DatasetHelper.createWithFiles(FileHelper.createMany(3)))
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Files').should('exist')
 
@@ -319,7 +323,7 @@ describe('Dataset', () => {
       cy.wrap(DatasetHelper.createWithFiles(FileHelper.createManyRestricted(1)))
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Files').should('exist')
 
@@ -402,7 +406,7 @@ describe('Dataset', () => {
           .then((persistentId: string) => {
             cy.wait(1500) // Wait for the files to be embargoed
 
-            cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+            cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
             cy.wait(1500) // Wait for the files to be loaded
 
@@ -460,7 +464,7 @@ describe('Dataset', () => {
       cy.wrap(DatasetHelper.createWithFiles(files))
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Files').should('exist')
 
@@ -580,7 +584,7 @@ describe('Dataset', () => {
       cy.wrap(FileHelper.createImage().then((file) => DatasetHelper.createWithFiles([file])))
         .its('persistentId')
         .then((persistentId: string) => {
-          cy.visit(`/spa/datasets?persistentId=${persistentId}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
           cy.findByText('Files').should('exist')
 

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -6,6 +6,7 @@ import {
   DatasetLabel,
   DatasetLabelSemanticMeaning,
   DatasetLockReason,
+  DatasetNonNumericVersion,
   DatasetPublishingStatus,
   DatasetVersion,
   MetadataBlockName
@@ -19,6 +20,7 @@ import {
 import { DatasetPaginationInfo } from '../../../../src/dataset/domain/models/DatasetPaginationInfo'
 import { DatasetDTO } from '../../../../src/dataset/domain/useCases/DTOs/DatasetDTO'
 import { CollectionHelper } from '../../shared/collection/CollectionHelper'
+const DRAFT_PARAM = DatasetNonNumericVersion.DRAFT
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -142,23 +144,25 @@ describe('Dataset JSDataverse Repository', () => {
   it('gets the dataset by persistentId', async () => {
     const datasetResponse = await DatasetHelper.create(collectionId)
 
-    await datasetRepository.getByPersistentId(datasetResponse.persistentId).then((dataset) => {
-      if (!dataset) {
-        throw new Error('Dataset not found')
-      }
-      const datasetExpected = datasetData(dataset.persistentId, dataset.version.id)
+    await datasetRepository
+      .getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
+      .then((dataset) => {
+        if (!dataset) {
+          throw new Error('Dataset not found')
+        }
+        const datasetExpected = datasetData(dataset.persistentId, dataset.version.id)
 
-      expect(dataset.license).to.deep.equal(datasetExpected.license)
-      expect(dataset.metadataBlocks).to.deep.equal(datasetExpected.metadataBlocks)
-      expect(dataset.summaryFields).to.deep.equal(datasetExpected.summaryFields)
-      expect(dataset.version).to.deep.equal(datasetExpected.version)
-      expect(dataset.metadataBlocks[0].fields.publicationDate).not.to.exist
-      expect(dataset.metadataBlocks[0].fields.citationDate).not.to.exist
-      expect(dataset.permissions).to.deep.equal(datasetExpected.permissions)
-      expect(dataset.locks).to.deep.equal(datasetExpected.locks)
-      expect(dataset.downloadUrls).to.deep.equal(datasetExpected.downloadUrls)
-      expect(dataset.fileDownloadSizes).to.deep.equal(datasetExpected.fileDownloadSizes)
-    })
+        expect(dataset.license).to.deep.equal(datasetExpected.license)
+        expect(dataset.metadataBlocks).to.deep.equal(datasetExpected.metadataBlocks)
+        expect(dataset.summaryFields).to.deep.equal(datasetExpected.summaryFields)
+        expect(dataset.version).to.deep.equal(datasetExpected.version)
+        expect(dataset.metadataBlocks[0].fields.publicationDate).not.to.exist
+        expect(dataset.metadataBlocks[0].fields.citationDate).not.to.exist
+        expect(dataset.permissions).to.deep.equal(datasetExpected.permissions)
+        expect(dataset.locks).to.deep.equal(datasetExpected.locks)
+        expect(dataset.downloadUrls).to.deep.equal(datasetExpected.downloadUrls)
+        expect(dataset.fileDownloadSizes).to.deep.equal(datasetExpected.fileDownloadSizes)
+      })
   })
 
   it('gets a published dataset by persistentId without user authentication', async () => {
@@ -247,7 +251,7 @@ describe('Dataset JSDataverse Repository', () => {
     const datasetResponse = await DatasetHelper.create(collectionId)
 
     await datasetRepository
-      .getByPersistentId(datasetResponse.persistentId, 'DRAFT')
+      .getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       .then((dataset) => {
         if (!dataset) {
           throw new Error('Dataset not found')
@@ -338,20 +342,22 @@ describe('Dataset JSDataverse Repository', () => {
     const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.lock(datasetResponse.id, DatasetLockReason.FINALIZE_PUBLICATION)
 
-    await datasetRepository.getByPersistentId(datasetResponse.persistentId).then((dataset) => {
-      if (!dataset) {
-        throw new Error('Dataset not found')
-      }
-      const datasetExpected = datasetData(dataset.persistentId, dataset.version.id)
-
-      expect(dataset.version.title).to.deep.equal(datasetExpected.title)
-      expect(dataset.locks).to.deep.equal([
-        {
-          userPersistentId: 'dataverseAdmin',
-          reason: DatasetLockReason.FINALIZE_PUBLICATION
+    await datasetRepository
+      .getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
+      .then((dataset) => {
+        if (!dataset) {
+          throw new Error('Dataset not found')
         }
-      ])
-    })
+        const datasetExpected = datasetData(dataset.persistentId, dataset.version.id)
+
+        expect(dataset.version.title).to.deep.equal(datasetExpected.title)
+        expect(dataset.locks).to.deep.equal([
+          {
+            userPersistentId: 'dataverseAdmin',
+            reason: DatasetLockReason.FINALIZE_PUBLICATION
+          }
+        ])
+      })
   })
 
   it('creates a new dataset from DatasetDTO', async () => {

--- a/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/files/FileJSDataverseRepository.spec.ts
@@ -24,9 +24,13 @@ import { FilesCountInfo } from '../../../../src/files/domain/models/FilesCountIn
 import { DatasetVersionMother } from '../../../component/dataset/domain/models/DatasetMother'
 import { FilePaginationInfo } from '../../../../src/files/domain/models/FilePaginationInfo'
 import { FilePreview } from '../../../../src/files/domain/models/FilePreview'
-import { DatasetPublishingStatus } from '../../../../src/dataset/domain/models/Dataset'
+import {
+  DatasetNonNumericVersion,
+  DatasetPublishingStatus
+} from '../../../../src/dataset/domain/models/Dataset'
 import { File } from '../../../../src/files/domain/models/File'
 import { FileIngest, FileIngestStatus } from '../../../../src/files/domain/models/FileIngest'
+const DRAFT_PARAM = DatasetNonNumericVersion.DRAFT
 
 chai.use(chaiAsPromised)
 const expect = chai.expect
@@ -175,7 +179,11 @@ describe('File JSDataverse Repository', () => {
   describe('Get all files by dataset persistentId', () => {
     it('gets all the files by dataset persistentId with the basic information', async () => {
       const dataset = await DatasetHelper.createWithFiles(FileHelper.createMany(3)).then(
-        (datasetResponse) => datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        (datasetResponse) =>
+          datasetRepository.getByPersistentId(
+            datasetResponse.persistentId,
+            DatasetNonNumericVersion.DRAFT
+          )
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -202,7 +210,10 @@ describe('File JSDataverse Repository', () => {
         jsonData: JSON.stringify({ description: 'This is an example file' })
       }
       const dataset = await DatasetHelper.createWithFiles([fileData]).then((datasetResponse) =>
-        datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        datasetRepository.getByPersistentId(
+          datasetResponse.persistentId,
+          DatasetNonNumericVersion.DRAFT
+        )
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -215,7 +226,11 @@ describe('File JSDataverse Repository', () => {
 
     it('gets all the files by dataset persistentId after dataset publication', async () => {
       const dataset = await DatasetHelper.createWithFiles(FileHelper.createMany(3)).then(
-        (datasetResponse) => datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        (datasetResponse) =>
+          datasetRepository.getByPersistentId(
+            datasetResponse.persistentId,
+            DatasetNonNumericVersion.DRAFT
+          )
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -297,7 +312,10 @@ describe('File JSDataverse Repository', () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(3))
       if (!datasetResponse.files) throw new Error('Files not found')
 
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DatasetNonNumericVersion.DRAFT
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       const expectedLabels = [
@@ -317,7 +335,10 @@ describe('File JSDataverse Repository', () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(1, 'csv'))
       if (!datasetResponse.files) throw new Error('Files not found')
       await TestsUtils.waitForNoLocks(datasetResponse.persistentId) // Wait for the tabular data to be ingested
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DatasetNonNumericVersion.DRAFT
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       const expectedLabels = [{ type: FileLabelType.TAG, value: 'Survey' }]
@@ -336,7 +357,10 @@ describe('File JSDataverse Repository', () => {
       )
       if (!datasetResponse.files) throw new Error('Files not found')
 
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DatasetNonNumericVersion.DRAFT
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       await fileRepository
@@ -350,7 +374,10 @@ describe('File JSDataverse Repository', () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(3))
       if (!datasetResponse.files) throw new Error('Files not found')
 
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DRAFT_PARAM
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       const embargoDate = '2100-10-20'
@@ -373,7 +400,10 @@ describe('File JSDataverse Repository', () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(1, 'csv'))
       if (!datasetResponse.files) throw new Error('Files not found')
 
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DRAFT_PARAM
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       await fileRepository
@@ -397,7 +427,8 @@ describe('File JSDataverse Repository', () => {
 
     it('gets the files pagination selection when passing pagination', async () => {
       const dataset = await DatasetHelper.createWithFiles(FileHelper.createMany(3)).then(
-        (datasetResponse) => datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        (datasetResponse) =>
+          datasetRepository.getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -417,7 +448,8 @@ describe('File JSDataverse Repository', () => {
 
     it('gets all the files by dataset persistentId when passing sortBy criteria', async () => {
       const dataset = await DatasetHelper.createWithFiles(FileHelper.createMany(3)).then(
-        (datasetResponse) => datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        (datasetResponse) =>
+          datasetRepository.getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -442,7 +474,7 @@ describe('File JSDataverse Repository', () => {
         FileHelper.create('txt'),
         FileHelper.create('csv')
       ]).then((datasetResponse) =>
-        datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        datasetRepository.getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -462,7 +494,10 @@ describe('File JSDataverse Repository', () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(3))
       if (!datasetResponse.files) throw new Error('Files not found')
 
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DRAFT_PARAM
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       await FileHelper.restrict(datasetResponse.files[0].id)
@@ -483,7 +518,10 @@ describe('File JSDataverse Repository', () => {
       const datasetResponse = await DatasetHelper.createWithFiles(FileHelper.createMany(3))
       if (!datasetResponse.files) throw new Error('Files not found')
 
-      const dataset = await datasetRepository.getByPersistentId(datasetResponse.persistentId)
+      const dataset = await datasetRepository.getByPersistentId(
+        datasetResponse.persistentId,
+        DRAFT_PARAM
+      )
       if (!dataset) throw new Error('Dataset not found')
 
       const category = { type: FileLabelType.CATEGORY, value: 'category' }
@@ -503,7 +541,8 @@ describe('File JSDataverse Repository', () => {
 
     it('gets all the files by dataset persistentId when passing searchText criteria', async () => {
       const dataset = await DatasetHelper.createWithFiles(FileHelper.createMany(3)).then(
-        (datasetResponse) => datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        (datasetResponse) =>
+          datasetRepository.getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -585,7 +624,7 @@ describe('File JSDataverse Repository', () => {
     })
 
     it('gets FilesCountInfo by dataset persistentId', async () => {
-      const dataset = await datasetRepository.getByPersistentId(datasetPersistentId)
+      const dataset = await datasetRepository.getByPersistentId(datasetPersistentId, DRAFT_PARAM)
       if (!dataset) throw new Error('Dataset not found')
 
       const expectedFilesCountInfo: FilesCountInfo = {
@@ -662,7 +701,7 @@ describe('File JSDataverse Repository', () => {
     })
 
     it('gets FilesCountInfo by dataset persistentId when passing filterByType criteria', async () => {
-      const dataset = await datasetRepository.getByPersistentId(datasetPersistentId)
+      const dataset = await datasetRepository.getByPersistentId(datasetPersistentId, DRAFT_PARAM)
       if (!dataset) throw new Error('Dataset not found')
 
       const expectedFilesCountInfo: FilesCountInfo = {
@@ -754,7 +793,7 @@ describe('File JSDataverse Repository', () => {
         })
       ]
       const dataset = await DatasetHelper.createWithFiles(files).then((datasetResponse) =>
-        datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        datasetRepository.getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       )
       if (!dataset) throw new Error('Dataset not found')
 
@@ -795,7 +834,7 @@ describe('File JSDataverse Repository', () => {
         })
       ]
       const dataset = await DatasetHelper.createWithFiles(files).then((datasetResponse) =>
-        datasetRepository.getByPersistentId(datasetResponse.persistentId)
+        datasetRepository.getByPersistentId(datasetResponse.persistentId, DRAFT_PARAM)
       )
       if (!dataset) throw new Error('Dataset not found')
 


### PR DESCRIPTION
**What this PR does / why we need it**: 
Changes the default dataset version requested from :latest to :latest-published.  This is needed to match the behavior of the JSF.  In the JSF, If a dataset has a draft version and a published version,  View Dataset page shows the published version by default (when there isn't a version search param in the url).

**Which issue(s) this PR closes**:

Closes #321 

**Special notes for your reviewer**:  
Now that the default version is :latest-published, in order to view the draft version of a dataset, you need to add 'version=DRAFT' to the view dataset url.  (The draft version used to be displayed by default when the user has permission to view it).

**Suggestions on how to test this**:
Create a dataset that has a published version and a draft version.  Test that the version displayed in the View Dataset page is the published version, when no version search param is used.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
no
**Is there a release notes update needed for this change?**:

**Additional documentation**:
