### PR TITLE
Fix/454 dataset page actions for draft

### DIFF
--- a/src/dataset/domain/models/Dataset.ts
+++ b/src/dataset/domain/models/Dataset.ts
@@ -217,10 +217,6 @@ export enum DatasetNonNumericVersion {
 export enum DatasetNonNumericVersionSearchParam {
   DRAFT = 'DRAFT'
 }
-// TODO: Maybe add this to some routing related folder or file
-export enum QueryParamsKeys {
-  VERSION = 'version'
-}
 
 export class DatasetVersionNumber {
   constructor(public readonly majorNumber?: number, public readonly minorNumber?: number) {}

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -131,15 +131,11 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       .execute(persistentId, version, includeDeaccessioned)
       .then((jsDataset) => this.fetchDatasetDetails(jsDataset, version))
       .then((datasetDetails) => {
-        if (datasetDetails.jsDatasetPermissions.canEditDataset) {
-          return this.fetchDownloadSizes(persistentId, version).then((downloadSizes) => {
-            datasetDetails.jsDatasetFilesTotalOriginalDownloadSize = downloadSizes[0]
-            datasetDetails.jsDatasetFilesTotalArchivalDownloadSize = downloadSizes[1]
-            return datasetDetails
-          })
-        } else {
+        return this.fetchDownloadSizes(persistentId, version).then((downloadSizes) => {
+          datasetDetails.jsDatasetFilesTotalOriginalDownloadSize = downloadSizes[0]
+          datasetDetails.jsDatasetFilesTotalArchivalDownloadSize = downloadSizes[1]
           return datasetDetails
-        }
+        })
       })
       .then((datasetDetails) => {
         return JSDatasetMapper.toDataset(

--- a/src/sections/Route.enum.ts
+++ b/src/sections/Route.enum.ts
@@ -18,5 +18,6 @@ export const RouteWithParams = {
 }
 
 export enum QueryParamKey {
-  VERSION = 'version'
+  VERSION = 'version',
+  PERSISTENT_ID = 'persistentId'
 }

--- a/src/sections/Route.enum.ts
+++ b/src/sections/Route.enum.ts
@@ -16,3 +16,7 @@ export const RouteWithParams = {
   CREATE_COLLECTION: (ownerCollectionId?: string) =>
     `/collections/${ownerCollectionId ?? 'root'}/create`
 }
+
+export enum QueryParamKey {
+  VERSION = 'version'
+}

--- a/src/sections/collection/datasets-list/DatasetsList.tsx
+++ b/src/sections/collection/datasets-list/DatasetsList.tsx
@@ -56,7 +56,7 @@ export function DatasetsList({ datasetRepository, page, collectionId }: Datasets
             <PaginationResultsInfo paginationInfo={paginationInfo} />
           </div>
           {datasets.map((dataset) => (
-            <DatasetCard dataset={dataset} key={dataset.persistentId} />
+            <DatasetCard dataset={dataset} key={`${dataset.persistentId}-${dataset.version.id}`} />
           ))}
           <PaginationControls
             onPaginationInfoChange={setPaginationInfo}

--- a/src/sections/collection/datasets-list/DatasetsListWithInfiniteScroll.tsx
+++ b/src/sections/collection/datasets-list/DatasetsListWithInfiniteScroll.tsx
@@ -91,7 +91,7 @@ export function DatasetsListWithInfiniteScroll({
             <PaginationResultsInfo paginationInfo={paginationInfo} accumulated={accumulatedCount} />
           </div>
           {accumulatedDatasets.map((dataset) => (
-            <DatasetCard dataset={dataset} key={dataset.persistentId} />
+            <DatasetCard dataset={dataset} key={`${dataset.persistentId}-${dataset.version.id}`} />
           ))}
         </>
       )}

--- a/src/sections/dataset/Dataset.tsx
+++ b/src/sections/dataset/Dataset.tsx
@@ -23,7 +23,7 @@ import { DatasetAlerts } from './dataset-alerts/DatasetAlerts'
 import { DatasetFilesScrollable } from './dataset-files/DatasetFilesScrollable'
 import useCheckPublishCompleted from './useCheckPublishCompleted'
 import useUpdateDatasetAlerts from './useUpdateDatasetAlerts'
-import { Route } from '../Route.enum'
+import { QueryParamKey, Route } from '../Route.enum'
 import { MetadataBlockInfoRepository } from '../../metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
 
 interface DatasetProps {
@@ -60,7 +60,7 @@ export function Dataset({
 
   useEffect(() => {
     if (publishInProgress && publishCompleted && dataset) {
-      navigate(`${Route.DATASETS}?persistentId=${dataset.persistentId}`, {
+      navigate(`${Route.DATASETS}?${QueryParamKey.PERSISTENT_ID}=${dataset.persistentId}`, {
         state: {},
         replace: true
       })

--- a/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
@@ -26,7 +26,11 @@ export function AccessDatasetMenu({
 }: AccessDatasetMenuProps) {
   const { t } = useTranslation('dataset')
 
+  const flesToDownloadSizeIsZero =
+    fileDownloadSizes.map(({ value }) => value).reduce((acc, curr) => acc + curr, 0) === 0
+
   if (
+    flesToDownloadSizeIsZero ||
     !permissions.canDownloadFiles ||
     (version.publishingStatus === DatasetPublishingStatus.DEACCESSIONED &&
       !permissions.canUpdateDataset)

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -32,25 +32,20 @@ export function EditDatasetMenu({ dataset }: EditDatasetMenuProps) {
   const { t } = useTranslation('dataset')
   const navigate = useNavigate()
 
-  console.log(dataset.version)
-
   const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
+    const searchParams = new URLSearchParams()
+    searchParams.set(QueryParamKey.PERSISTENT_ID, dataset.persistentId)
+
+    if (dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT) {
+      searchParams.set(QueryParamKey.VERSION, DatasetNonNumericVersionSearchParam.DRAFT)
+    }
+
     if (eventKey === EditDatasetMenuItems.FILES_UPLOAD) {
-      navigate(
-        `${Route.UPLOAD_DATASET_FILES}?${QueryParamKey.PERSISTENT_ID}=${dataset.persistentId}`
-      )
+      navigate(`${Route.UPLOAD_DATASET_FILES}?${searchParams.toString()}`)
       return
     }
     if (eventKey === EditDatasetMenuItems.METADATA) {
-      const searchParams = new URLSearchParams()
-      searchParams.set(QueryParamKey.PERSISTENT_ID, dataset.persistentId)
-
-      if (dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT) {
-        searchParams.set(QueryParamKey.VERSION, DatasetNonNumericVersionSearchParam.DRAFT)
-      }
-
       navigate(`${Route.EDIT_DATASET_METADATA}?${searchParams.toString()}`)
-
       return
     }
     showModal()

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -1,13 +1,17 @@
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Dataset } from '../../../../dataset/domain/models/Dataset'
+import {
+  Dataset,
+  DatasetNonNumericVersionSearchParam,
+  DatasetPublishingStatus
+} from '../../../../dataset/domain/models/Dataset'
 import { DropdownButton, DropdownButtonItem } from '@iqss/dataverse-design-system'
 import { EditDatasetPermissionsMenu } from './EditDatasetPermissionsMenu'
 import { DeleteDatasetButton } from './DeleteDatasetButton'
 import { DeaccessionDatasetButton } from './DeaccessionDatasetButton'
 import { useNotImplementedModal } from '../../../not-implemented/NotImplementedModalContext'
 import { useSession } from '../../../session/SessionContext'
-import { Route } from '../../../Route.enum'
+import { QueryParamKey, Route } from '../../../Route.enum'
 
 interface EditDatasetMenuProps {
   dataset: Dataset
@@ -28,13 +32,25 @@ export function EditDatasetMenu({ dataset }: EditDatasetMenuProps) {
   const { t } = useTranslation('dataset')
   const navigate = useNavigate()
 
+  console.log(dataset.version)
+
   const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
     if (eventKey === EditDatasetMenuItems.FILES_UPLOAD) {
-      navigate(`${Route.UPLOAD_DATASET_FILES}?persistentId=${dataset.persistentId}`)
+      navigate(
+        `${Route.UPLOAD_DATASET_FILES}?${QueryParamKey.PERSISTENT_ID}=${dataset.persistentId}`
+      )
       return
     }
     if (eventKey === EditDatasetMenuItems.METADATA) {
-      navigate(`${Route.EDIT_DATASET_METADATA}?persistentId=${dataset.persistentId}`)
+      const searchParams = new URLSearchParams()
+      searchParams.set(QueryParamKey.PERSISTENT_ID, dataset.persistentId)
+
+      if (dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT) {
+        searchParams.set(QueryParamKey.VERSION, DatasetNonNumericVersionSearchParam.DRAFT)
+      }
+
+      navigate(`${Route.EDIT_DATASET_METADATA}?${searchParams.toString()}`)
+
       return
     }
     showModal()

--- a/src/sections/dataset/dataset-files/dataset-upload-files-button/DatasetUploadFilesButton.tsx
+++ b/src/sections/dataset/dataset-files/dataset-upload-files-button/DatasetUploadFilesButton.tsx
@@ -4,7 +4,7 @@ import { PlusLg } from 'react-bootstrap-icons'
 import { Button } from '@iqss/dataverse-design-system'
 import { useSession } from '../../../session/SessionContext'
 import { useDataset } from '../../DatasetContext'
-import { Route } from '../../../Route.enum'
+import { QueryParamKey, Route } from '../../../Route.enum'
 import styles from './DatasetUploadFilesButton.module.scss'
 
 export function DatasetUploadFilesButton() {
@@ -18,7 +18,7 @@ export function DatasetUploadFilesButton() {
   }
 
   const handleClick = () => {
-    navigate(`${Route.UPLOAD_DATASET_FILES}?persistentId=${dataset.persistentId}`)
+    navigate(`${Route.UPLOAD_DATASET_FILES}?${QueryParamKey.PERSISTENT_ID}=${dataset.persistentId}`)
   }
 
   return (

--- a/src/sections/dataset/dataset-files/dataset-upload-files-button/DatasetUploadFilesButton.tsx
+++ b/src/sections/dataset/dataset-files/dataset-upload-files-button/DatasetUploadFilesButton.tsx
@@ -5,6 +5,10 @@ import { Button } from '@iqss/dataverse-design-system'
 import { useSession } from '../../../session/SessionContext'
 import { useDataset } from '../../DatasetContext'
 import { QueryParamKey, Route } from '../../../Route.enum'
+import {
+  DatasetNonNumericVersionSearchParam,
+  DatasetPublishingStatus
+} from '../../../../dataset/domain/models/Dataset'
 import styles from './DatasetUploadFilesButton.module.scss'
 
 export function DatasetUploadFilesButton() {
@@ -18,7 +22,14 @@ export function DatasetUploadFilesButton() {
   }
 
   const handleClick = () => {
-    navigate(`${Route.UPLOAD_DATASET_FILES}?${QueryParamKey.PERSISTENT_ID}=${dataset.persistentId}`)
+    const searchParams = new URLSearchParams()
+    searchParams.set(QueryParamKey.PERSISTENT_ID, dataset.persistentId)
+
+    if (dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT) {
+      searchParams.set(QueryParamKey.VERSION, DatasetNonNumericVersionSearchParam.DRAFT)
+    }
+
+    navigate(`${Route.UPLOAD_DATASET_FILES}?${searchParams.toString()}`)
   }
 
   return (

--- a/src/sections/dataset/publish-dataset/PublishDatasetModal.tsx
+++ b/src/sections/dataset/publish-dataset/PublishDatasetModal.tsx
@@ -51,7 +51,7 @@ export function PublishDatasetModal({
 
   function onPublishSucceed() {
     navigate(
-      `${Route.DATASETS}?persistentId=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+      `${Route.DATASETS}?${QueryParamKey.PERSISTENT_ID}=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
       {
         state: { publishInProgress: true },
         replace: true

--- a/src/sections/dataset/publish-dataset/PublishDatasetModal.tsx
+++ b/src/sections/dataset/publish-dataset/PublishDatasetModal.tsx
@@ -8,15 +8,14 @@ import { useSession } from '../../session/SessionContext'
 import { License } from '../dataset-summary/License'
 import {
   DatasetNonNumericVersionSearchParam,
-  defaultLicense,
-  QueryParamsKeys
+  defaultLicense
 } from '../../../dataset/domain/models/Dataset'
 import { SubmissionStatus } from '../../shared/form/DatasetMetadataForm/useSubmitDataset'
 import { usePublishDataset } from './usePublishDataset'
 import { PublishDatasetHelpText } from './PublishDatasetHelpText'
 import styles from './PublishDatasetModal.module.scss'
 import { useNavigate } from 'react-router-dom'
-import { Route } from '../../Route.enum'
+import { QueryParamKey, Route } from '../../Route.enum'
 
 interface PublishDatasetModalProps {
   show: boolean
@@ -52,7 +51,7 @@ export function PublishDatasetModal({
 
   function onPublishSucceed() {
     navigate(
-      `${Route.DATASETS}?persistentId=${persistentId}&${QueryParamsKeys.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+      `${Route.DATASETS}?persistentId=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
       {
         state: { publishInProgress: true },
         replace: true

--- a/src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx
+++ b/src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx
@@ -4,6 +4,7 @@ import { EditDatasetMetadata } from './EditDatasetMetadata'
 import { DatasetProvider } from '../dataset/DatasetProvider'
 import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
 import { MetadataBlockInfoJSDataverseRepository } from '../../metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
+import { searchParamVersionToDomainVersion } from '../../Router'
 
 const datasetRepository = new DatasetJSDataverseRepository()
 const metadataBlockInfoRepository = new MetadataBlockInfoJSDataverseRepository()
@@ -17,9 +18,13 @@ export class EditDatasetMetadataFactory {
 function EditDatasetMetadataWithParams() {
   const [searchParams] = useSearchParams()
   const persistentId = searchParams.get('persistentId') ?? undefined
+  const searchParamVersion = searchParams.get('version') ?? undefined
+  const version = searchParamVersionToDomainVersion(searchParamVersion)
 
   return (
-    <DatasetProvider repository={datasetRepository} searchParams={{ persistentId: persistentId }}>
+    <DatasetProvider
+      repository={datasetRepository}
+      searchParams={{ persistentId: persistentId, version: version }}>
       <EditDatasetMetadata
         datasetRepository={datasetRepository}
         metadataBlockInfoRepository={metadataBlockInfoRepository}

--- a/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
+++ b/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
@@ -62,7 +62,7 @@ export function useSubmitDataset(
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)
           navigate(
-            `${Route.DATASETS}?persistentId=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+            `${Route.DATASETS}?${QueryParamKey.PERSISTENT_ID}=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
             {
               state: { created: true }
             }
@@ -92,7 +92,7 @@ export function useSubmitDataset(
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)
           navigate(
-            `${Route.DATASETS}?persistentId=${currentEditedDatasetPersistentID}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+            `${Route.DATASETS}?${QueryParamKey.PERSISTENT_ID}=${currentEditedDatasetPersistentID}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
             {
               state: { metadataUpdated: true }
             }

--- a/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
+++ b/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
@@ -7,11 +7,8 @@ import { updateDatasetMetadata } from '../../../../dataset/domain/useCases/updat
 import { MetadataFieldsHelper, type DatasetMetadataFormValues } from './MetadataFieldsHelper'
 import { getValidationFailedFieldError } from '../../../../metadata-block-info/domain/models/fieldValidations'
 import { type DatasetMetadataFormMode } from '.'
-import { Route } from '../../../Route.enum'
-import {
-  DatasetNonNumericVersionSearchParam,
-  QueryParamsKeys
-} from '../../../../dataset/domain/models/Dataset'
+import { QueryParamKey, Route } from '../../../Route.enum'
+import { DatasetNonNumericVersionSearchParam } from '../../../../dataset/domain/models/Dataset'
 
 export enum SubmissionStatus {
   NotSubmitted = 'NotSubmitted',
@@ -65,7 +62,7 @@ export function useSubmitDataset(
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)
           navigate(
-            `${Route.DATASETS}?persistentId=${persistentId}&${QueryParamsKeys.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+            `${Route.DATASETS}?persistentId=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
             {
               state: { created: true }
             }
@@ -95,7 +92,7 @@ export function useSubmitDataset(
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)
           navigate(
-            `${Route.DATASETS}?persistentId=${currentEditedDatasetPersistentID}&${QueryParamsKeys.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
+            `${Route.DATASETS}?persistentId=${currentEditedDatasetPersistentID}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`,
             {
               state: { metadataUpdated: true }
             }

--- a/src/sections/upload-dataset-files/UploadDatasetFilesFactory.tsx
+++ b/src/sections/upload-dataset-files/UploadDatasetFilesFactory.tsx
@@ -4,6 +4,7 @@ import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repos
 import { FileJSDataverseRepository } from '../../files/infrastructure/FileJSDataverseRepository'
 import { DatasetProvider } from '../dataset/DatasetProvider'
 import { UploadDatasetFiles } from './UploadDatasetFiles'
+import { searchParamVersionToDomainVersion } from '../../Router'
 
 const datasetRepository = new DatasetJSDataverseRepository()
 const fileRepository = new FileJSDataverseRepository()
@@ -17,9 +18,13 @@ export class UploadDatasetFilesFactory {
 function UploadDatasetFilesWithSearchParams() {
   const [searchParams] = useSearchParams()
   const persistentId = searchParams.get('persistentId') ?? undefined
+  const searchParamVersion = searchParams.get('version') ?? undefined
+  const version = searchParamVersionToDomainVersion(searchParamVersion)
 
   return (
-    <DatasetProvider repository={datasetRepository} searchParams={{ persistentId: persistentId }}>
+    <DatasetProvider
+      repository={datasetRepository}
+      searchParams={{ persistentId: persistentId, version: version }}>
       <UploadDatasetFiles fileRepository={fileRepository} />
     </DatasetProvider>
   )

--- a/tests/component/sections/create-dataset/CreateDataset.spec.tsx
+++ b/tests/component/sections/create-dataset/CreateDataset.spec.tsx
@@ -3,11 +3,9 @@ import { DatasetRepository } from '../../../../src/dataset/domain/repositories/D
 import { MetadataBlockInfoRepository } from '../../../../src/metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
 import { MetadataBlockInfoMother } from '../../metadata-block-info/domain/models/MetadataBlockInfoMother'
 import { NotImplementedModalProvider } from '../../../../src/sections/not-implemented/NotImplementedModalProvider'
-import { FileRepository } from '../../../../src/files/domain/repositories/FileRepository'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
 const metadataBlockInfoRepository: MetadataBlockInfoRepository = {} as MetadataBlockInfoRepository
-const fileRepository: FileRepository = {} as FileRepository
 
 const collectionMetadataBlocksInfo =
   MetadataBlockInfoMother.getByCollectionIdDisplayedOnCreateTrue()

--- a/tests/component/sections/dataset/dataset-action-buttons/DatasetActionButtons.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/DatasetActionButtons.spec.tsx
@@ -1,18 +1,28 @@
+import { DatasetRepository } from '../../../../../src/dataset/domain/repositories/DatasetRepository'
+import { FileSizeUnit } from '../../../../../src/files/domain/models/FileMetadata'
 import { DatasetActionButtons } from '../../../../../src/sections/dataset/dataset-action-buttons/DatasetActionButtons'
 import {
+  DatasetFileDownloadSizeMother,
   DatasetMother,
   DatasetPermissionsMother,
   DatasetVersionMother
 } from '../../../dataset/domain/models/DatasetMother'
 
+const datasetRepository: DatasetRepository = {} as DatasetRepository
+
 describe('DatasetActionButtons', () => {
   it('renders the DatasetActionButtons with the Publish button', () => {
     const dataset = DatasetMother.create({
       version: DatasetVersionMother.createDraftAsLatestVersionWithSomeVersionHasBeenReleased(),
-      permissions: DatasetPermissionsMother.createWithAllAllowed()
+      permissions: DatasetPermissionsMother.createWithAllAllowed(),
+      fileDownloadSizes: [
+        DatasetFileDownloadSizeMother.createOriginal({ value: 2000, unit: FileSizeUnit.BYTES })
+      ]
     })
 
-    cy.mountAuthenticated(<DatasetActionButtons dataset={dataset} />)
+    cy.mountAuthenticated(
+      <DatasetActionButtons dataset={dataset} datasetRepository={datasetRepository} />
+    )
 
     cy.findByRole('group', { name: 'Dataset Action Buttons' }).should('exist')
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')
@@ -28,10 +38,15 @@ describe('DatasetActionButtons', () => {
         canDownloadFiles: true,
         canUpdateDataset: true,
         canPublishDataset: false
-      })
+      }),
+      fileDownloadSizes: [
+        DatasetFileDownloadSizeMother.createOriginal({ value: 2000, unit: FileSizeUnit.BYTES })
+      ]
     })
 
-    cy.mountAuthenticated(<DatasetActionButtons dataset={dataset} />)
+    cy.mountAuthenticated(
+      <DatasetActionButtons dataset={dataset} datasetRepository={datasetRepository} />
+    )
 
     cy.findByRole('group', { name: 'Dataset Action Buttons' }).should('exist')
     cy.findByRole('button', { name: 'Access Dataset' }).should('exist')

--- a/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
@@ -139,4 +139,26 @@ describe('AccessDatasetMenu', () => {
       .should('exist')
       .should('have.attr', 'href', downloadUrls.archival)
   })
+
+  it('does not render the AccessDatasetMenu if the file download sizes are zero', () => {
+    const version = DatasetVersionMother.createReleased()
+    const permissions = DatasetPermissionsMother.createWithFilesDownloadAllowed()
+    const fileDownloadSizes = [
+      DatasetFileDownloadSizeMother.createOriginal({ value: 0, unit: FileSizeUnit.BYTES }),
+      DatasetFileDownloadSizeMother.createArchival({
+        value: 0,
+        unit: FileSizeUnit.BYTES
+      })
+    ]
+    cy.customMount(
+      <AccessDatasetMenu
+        fileDownloadSizes={fileDownloadSizes}
+        hasOneTabularFileAtLeast={true}
+        version={version}
+        permissions={permissions}
+        downloadUrls={downloadUrls}
+      />
+    )
+    cy.findByRole('button', { name: 'Access Dataset' }).should('not.exist')
+  })
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

> Since the default dataset version has changed from :latest to :latest-published, more links need to updated to include&version=DRAFTwhen working with a draft version. The "Access Dataset", "Edit Metadata" and "FIle Upload" actions need to be updated to navigate to the correct dataset url.

**Which issue(s) this PR closes**:

Closes #454 

**Special notes for your reviewer**:
There is also a fix for duplicate react keys on collection page dataset cards.

**Suggestions on how to test this**:

- Create a Dataset, go to that Dataset and click the Edit Dataset => Files (Upload) should navigate correctly to the File Upload page. (`version=DRAFT` query param should be present on the URL)
- Create a Dataset, go to that Dataset and click the Edit Dataset => Metadata should navigate correctly to the Edit dataset metadata page. (`version=DRAFT` query param should be present on the URL)
- Publish that Dataset and navigate to the Files Upload  & the Edit Dataset page. (`version=DRAFT` query param should NOT be present on the URL)
- Access Dataset dropdown should not be visible when the Dataset has no files. Try uploading some files from the JSF version and check that in the Dataset View page on the SPA now the Access Dataset dropdown is visible and works correctly.


**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
No

**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
No