### PR TITLE
Collection permissions check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-pr155.be01a3f",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr175.3f8ee0a",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3610,9 +3610,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-pr155.be01a3f",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr155.be01a3f/dea4dac3ef3aab1802b444ccc08326843c530d80",
-      "integrity": "sha512-Q2KhE3JGu3BaTD1TB3l0iQ6yZIvpUOkds8Zk0nezNymm4pL8gjdISomJDUXFFW9tQuAZ0PkXuOEQGmVfzEUKNA==",
+      "version": "2.0.0-pr175.3f8ee0a",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr175.3f8ee0a/8896348d8b93c7f362dd41f6ed5e701c5b04e49a",
+      "integrity": "sha512-LS85ZcOTdmuiGrOJFjsGwsdoiVhd4WKDO1736Qy6q1Mmrws9K1HjV7DJFtiXuSNWzrN4mxToaBJfoHNDao7lbg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-pr155.be01a3f",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr175.3f8ee0a",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/public/locales/en/createCollection.json
+++ b/public/locales/en/createCollection.json
@@ -59,5 +59,6 @@
   "formButtons": {
     "save": "Create Collection",
     "cancel": "Cancel"
-  }
+  },
+  "notAllowedToCreateCollection": "You do not have permissions to create a collection within this collection."
 }

--- a/public/locales/en/createDataset.json
+++ b/public/locales/en/createDataset.json
@@ -5,5 +5,6 @@
     "description": "The collection which contains this data.",
     "helpText": "Changing the host collection will clear any fields you may have entered data into.",
     "buttonLabel": "Edit Host Collection"
-  }
+  },
+  "notAllowedToCreateDataset": "You do not have permissions to create a dataset within this collection."
 }

--- a/src/collection/domain/models/Collection.ts
+++ b/src/collection/domain/models/Collection.ts
@@ -8,3 +8,5 @@ export interface Collection {
   description?: string
   affiliation?: string
 }
+
+export const ROOT_COLLECTION_ALIAS = 'root'

--- a/src/collection/domain/models/CollectionUserPermissions.ts
+++ b/src/collection/domain/models/CollectionUserPermissions.ts
@@ -1,0 +1,9 @@
+export interface CollectionUserPermissions {
+  canAddCollection: boolean
+  canAddDataset: boolean
+  canViewUnpublishedCollection: boolean
+  canEditCollection: boolean
+  canManageCollectionPermissions: boolean
+  canPublishCollection: boolean
+  canDeleteCollection: boolean
+}

--- a/src/collection/domain/repositories/CollectionRepository.ts
+++ b/src/collection/domain/repositories/CollectionRepository.ts
@@ -1,7 +1,9 @@
 import { Collection } from '../models/Collection'
+import { CollectionUserPermissions } from '../models/CollectionUserPermissions'
 import { CollectionDTO } from '../useCases/DTOs/CollectionDTO'
 
 export interface CollectionRepository {
   getById: (id: string) => Promise<Collection>
   create(collection: CollectionDTO, hostCollection?: string): Promise<number>
+  getUserPermissions(collectionIdOrAlias: number | string): Promise<CollectionUserPermissions>
 }

--- a/src/collection/domain/useCases/getCollectionUserPermissions.ts
+++ b/src/collection/domain/useCases/getCollectionUserPermissions.ts
@@ -1,0 +1,11 @@
+import { CollectionRepository } from '../repositories/CollectionRepository'
+import { CollectionUserPermissions } from '../models/CollectionUserPermissions'
+
+export function getCollectionUserPermissions(
+  collectionRepository: CollectionRepository,
+  collectionIdOrAlias: number | string
+): Promise<CollectionUserPermissions> {
+  return collectionRepository.getUserPermissions(collectionIdOrAlias).catch((error: Error) => {
+    throw new Error(error.message)
+  })
+}

--- a/src/collection/infrastructure/repositories/CollectionJSDataverseRepository.ts
+++ b/src/collection/infrastructure/repositories/CollectionJSDataverseRepository.ts
@@ -1,8 +1,13 @@
 import { CollectionRepository } from '../../domain/repositories/CollectionRepository'
 import { Collection } from '../../domain/models/Collection'
-import { createCollection, getCollection } from '@iqss/dataverse-client-javascript'
+import {
+  createCollection,
+  getCollection,
+  getCollectionUserPermissions
+} from '@iqss/dataverse-client-javascript'
 import { JSCollectionMapper } from '../mappers/JSCollectionMapper'
 import { CollectionDTO } from '../../domain/useCases/DTOs/CollectionDTO'
+import { CollectionUserPermissions } from '../../domain/models/CollectionUserPermissions'
 
 export class CollectionJSDataverseRepository implements CollectionRepository {
   getById(id: string): Promise<Collection> {
@@ -15,5 +20,11 @@ export class CollectionJSDataverseRepository implements CollectionRepository {
     return createCollection
       .execute(collection, hostCollection)
       .then((newCollectionIdentifier) => newCollectionIdentifier)
+  }
+
+  getUserPermissions(collectionIdOrAlias: number | string): Promise<CollectionUserPermissions> {
+    return getCollectionUserPermissions
+      .execute(collectionIdOrAlias)
+      .then((jsCollectionUserPermissions) => jsCollectionUserPermissions)
   }
 }

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -31,7 +31,8 @@ import { DatasetDTO } from '../../domain/useCases/DTOs/DatasetDTO'
 import { DatasetDTOMapper } from '../mappers/DatasetDTOMapper'
 import { DatasetsWithCount } from '../../domain/models/DatasetsWithCount'
 import { VersionUpdateType } from '../../domain/models/VersionUpdateType'
-const defaultCollectionId = 'root'
+import { ROOT_COLLECTION_ALIAS } from '../../../collection/domain/models/Collection'
+
 const includeDeaccessioned = true
 type DatasetDetails = [JSDataset, string[], string, JSDatasetPermissions, JSDatasetLock[]]
 
@@ -195,7 +196,7 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
 
   create(
     dataset: DatasetDTO,
-    collectionId = defaultCollectionId
+    collectionId = ROOT_COLLECTION_ALIAS
   ): Promise<{ persistentId: string }> {
     return createDataset
       .execute(DatasetDTOMapper.toJSDatasetDTO(dataset), collectionId)

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -15,7 +15,6 @@ import {
   getFileDownloadCount,
   getFileUserPermissions,
   uploadFile as jsUploadFile,
-  addUploadedFileToDataset,
   ReadError
 } from '@iqss/dataverse-client-javascript'
 import { FileCriteria } from '../domain/models/FileCriteria'
@@ -306,7 +305,8 @@ export class FileJSDataverseRepository implements FileRepository {
     return new Promise<void>(() => {})
   }
 
-  addUploadedFile(datasetId: number | string, file: FileHolder, storageId: string): Promise<void> {
-    return addUploadedFileToDataset.execute(datasetId, file.file, storageId)
+  addUploadedFile(_datasetId: number | string, _file: FileHolder): Promise<void> {
+    return new Promise<void>(() => {})
+    // return addUploadedFilesToDataset.execute(datasetId, file.file)
   }
 }

--- a/src/sections/Route.enum.ts
+++ b/src/sections/Route.enum.ts
@@ -1,3 +1,5 @@
+import { ROOT_COLLECTION_ALIAS } from '../collection/domain/models/Collection'
+
 export enum Route {
   HOME = '/',
   SIGN_UP = '/dataverseuser.xhtml?editMode=CREATE&redirectPage=%2Fdataverse.xhtml',
@@ -14,5 +16,5 @@ export enum Route {
 
 export const RouteWithParams = {
   CREATE_COLLECTION: (ownerCollectionId?: string) =>
-    `/collections/${ownerCollectionId ?? 'root'}/create`
+    `/collections/${ownerCollectionId ?? ROOT_COLLECTION_ALIAS}/create`
 }

--- a/src/sections/collection/Collection.tsx
+++ b/src/sections/collection/Collection.tsx
@@ -14,6 +14,7 @@ import { CollectionSkeleton } from './CollectionSkeleton'
 import { CollectionInfo } from './CollectionInfo'
 import { Trans, useTranslation } from 'react-i18next'
 import { useScrollTop } from '../../shared/hooks/useScrollTop'
+import { useGetCollectionUserPermissions } from '../../shared/hooks/useGetCollectionUserPermissions'
 
 interface CollectionProps {
   repository: CollectionRepository
@@ -35,6 +36,16 @@ export function Collection({
   useScrollTop()
   const { user } = useSession()
   const { collection, isLoading } = useCollection(repository, id)
+  const { collectionUserPermissions } = useGetCollectionUserPermissions({
+    collectionIdOrAlias: id,
+    collectionRepository: repository
+  })
+
+  const canUserAddCollection = Boolean(collectionUserPermissions?.canAddCollection)
+  const canUserAddDataset = Boolean(collectionUserPermissions?.canAddDataset)
+
+  const showAddDataActions = user && (canUserAddCollection || canUserAddDataset)
+
   const { t } = useTranslation('collection')
 
   if (!isLoading && !collection) {
@@ -67,9 +78,13 @@ export function Collection({
                 />
               </Alert>
             )}
-            {user && (
+            {showAddDataActions && (
               <div className={styles.container}>
-                <AddDataActionsButton collectionId={id} />
+                <AddDataActionsButton
+                  collectionId={id}
+                  canAddCollection={canUserAddCollection}
+                  canAddDataset={canUserAddDataset}
+                />
               </div>
             )}
           </>

--- a/src/sections/collection/CollectionFactory.tsx
+++ b/src/sections/collection/CollectionFactory.tsx
@@ -4,6 +4,7 @@ import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repos
 import { useLocation, useSearchParams } from 'react-router-dom'
 import { CollectionJSDataverseRepository } from '../../collection/infrastructure/repositories/CollectionJSDataverseRepository'
 import { INFINITE_SCROLL_ENABLED } from './config'
+import { ROOT_COLLECTION_ALIAS } from '../../collection/domain/models/Collection'
 
 const datasetRepository = new DatasetJSDataverseRepository()
 const repository = new CollectionJSDataverseRepository()
@@ -17,7 +18,7 @@ function CollectionWithSearchParams() {
   const [searchParams] = useSearchParams()
   const location = useLocation()
   const page = searchParams.get('page') ? parseInt(searchParams.get('page') as string) : undefined
-  const id = searchParams.get('id') ? (searchParams.get('id') as string) : 'root'
+  const id = searchParams.get('id') ? (searchParams.get('id') as string) : ROOT_COLLECTION_ALIAS
   const state = location.state as { created: boolean } | undefined
   const created = state?.created ?? false
 

--- a/src/sections/create-collection/CreateCollection.tsx
+++ b/src/sections/create-collection/CreateCollection.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Alert } from '@iqss/dataverse-design-system'
 import { useCollection } from '../collection/useCollection'
 import { CollectionRepository } from '../../collection/domain/repositories/CollectionRepository'
 import { useLoading } from '../loading/LoadingContext'
@@ -10,6 +11,7 @@ import { CollectionForm, CollectionFormData } from './collection-form/Collection
 import { SeparationLine } from '../shared/layout/SeparationLine/SeparationLine'
 import { PageNotFound } from '../page-not-found/PageNotFound'
 import { CreateCollectionSkeleton } from './CreateCollectionSkeleton'
+import { useGetCollectionUserPermissions } from '../../shared/hooks/useGetCollectionUserPermissions'
 
 interface CreateCollectionProps {
   ownerCollectionId: string
@@ -29,18 +31,36 @@ export function CreateCollection({
     ownerCollectionId
   )
 
+  const { collectionUserPermissions, isLoading: isLoadingCollectionUserPermissions } =
+    useGetCollectionUserPermissions({
+      collectionIdOrAlias: ownerCollectionId,
+      collectionRepository: collectionRepository
+    })
+
+  const canUserAddCollection = Boolean(collectionUserPermissions?.canAddCollection)
+
   useEffect(() => {
-    if (!isLoadingCollection) {
+    if (!isLoadingCollection && !isLoadingCollectionUserPermissions) {
       setIsLoading(false)
     }
-  }, [isLoading, isLoadingCollection, setIsLoading])
+  }, [isLoading, isLoadingCollection, isLoadingCollectionUserPermissions, setIsLoading])
 
   if (!isLoadingCollection && !collection) {
     return <PageNotFound />
   }
 
-  if (isLoadingCollection || !collection) {
+  if (isLoadingCollection || isLoadingCollectionUserPermissions || !collection) {
     return <CreateCollectionSkeleton />
+  }
+
+  if (collectionUserPermissions && !canUserAddCollection) {
+    return (
+      <div className="pt-4" data-testid="not-allowed-to-create-collection-alert">
+        <Alert variant="danger" dismissible={false}>
+          {t('notAllowedToCreateCollection')}
+        </Alert>
+      </div>
+    )
   }
 
   const formDefaultValues: CollectionFormData = {

--- a/src/sections/create-collection/CreateCollectionFactory.tsx
+++ b/src/sections/create-collection/CreateCollectionFactory.tsx
@@ -2,6 +2,7 @@ import { ReactElement } from 'react'
 import { useParams } from 'react-router-dom'
 import { CollectionJSDataverseRepository } from '../../collection/infrastructure/repositories/CollectionJSDataverseRepository'
 import { CreateCollection } from './CreateCollection'
+import { ROOT_COLLECTION_ALIAS } from '../../collection/domain/models/Collection'
 
 const collectionRepository = new CollectionJSDataverseRepository()
 
@@ -12,9 +13,7 @@ export class CreateCollectionFactory {
 }
 
 function CreateCollectionWithParams() {
-  const { ownerCollectionId = 'root' } = useParams<{ ownerCollectionId: string }>()
-
-  // TODO:ME What roles can create a collection, what checks to do?
+  const { ownerCollectionId = ROOT_COLLECTION_ALIAS } = useParams<{ ownerCollectionId: string }>()
 
   return (
     <CreateCollection

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -11,6 +11,7 @@ import { DatasetMetadataForm } from '../shared/form/DatasetMetadataForm'
 import { useGetCollectionUserPermissions } from '../../shared/hooks/useGetCollectionUserPermissions'
 import { CollectionRepository } from '../../collection/domain/repositories/CollectionRepository'
 import { useLoading } from '../loading/LoadingContext'
+import { ROOT_COLLECTION_ALIAS } from '../../collection/domain/models/Collection'
 
 interface CreateDatasetProps {
   datasetRepository: DatasetRepository
@@ -23,7 +24,7 @@ export function CreateDataset({
   datasetRepository,
   metadataBlockInfoRepository,
   collectionRepository,
-  collectionId = 'root'
+  collectionId = ROOT_COLLECTION_ALIAS
 }: CreateDatasetProps) {
   const { t } = useTranslation('createDataset')
   const { isModalOpen, hideModal } = useNotImplementedModal()

--- a/src/sections/create-dataset/CreateDataset.tsx
+++ b/src/sections/create-dataset/CreateDataset.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { Alert } from '@iqss/dataverse-design-system'
 import { type DatasetRepository } from '../../dataset/domain/repositories/DatasetRepository'
 import { type MetadataBlockInfoRepository } from '../../metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
 import { SeparationLine } from '../shared/layout/SeparationLine/SeparationLine'
@@ -6,20 +8,48 @@ import { HostCollectionForm } from './HostCollectionForm/HostCollectionForm'
 import { NotImplementedModal } from '../not-implemented/NotImplementedModal'
 import { useNotImplementedModal } from '../not-implemented/NotImplementedModalContext'
 import { DatasetMetadataForm } from '../shared/form/DatasetMetadataForm'
+import { useGetCollectionUserPermissions } from '../../shared/hooks/useGetCollectionUserPermissions'
+import { CollectionRepository } from '../../collection/domain/repositories/CollectionRepository'
+import { useLoading } from '../loading/LoadingContext'
 
 interface CreateDatasetProps {
   datasetRepository: DatasetRepository
   metadataBlockInfoRepository: MetadataBlockInfoRepository
+  collectionRepository: CollectionRepository
   collectionId?: string
 }
 
 export function CreateDataset({
   datasetRepository,
   metadataBlockInfoRepository,
+  collectionRepository,
   collectionId = 'root'
 }: CreateDatasetProps) {
   const { t } = useTranslation('createDataset')
   const { isModalOpen, hideModal } = useNotImplementedModal()
+  const { setIsLoading } = useLoading()
+
+  const { collectionUserPermissions, isLoading: isLoadingCollectionUserPermissions } =
+    useGetCollectionUserPermissions({
+      collectionIdOrAlias: collectionId,
+      collectionRepository: collectionRepository
+    })
+
+  const canUserAddDataset = Boolean(collectionUserPermissions?.canAddDataset)
+
+  useEffect(() => {
+    setIsLoading(isLoadingCollectionUserPermissions)
+  }, [isLoadingCollectionUserPermissions, setIsLoading])
+
+  if (collectionUserPermissions && !canUserAddDataset) {
+    return (
+      <div className="pt-4" data-testid="not-allowed-to-create-dataset-alert">
+        <Alert variant="danger" dismissible={false}>
+          {t('notAllowedToCreateDataset')}
+        </Alert>
+      </div>
+    )
+  }
 
   return (
     <>

--- a/src/sections/create-dataset/CreateDatasetFactory.tsx
+++ b/src/sections/create-dataset/CreateDatasetFactory.tsx
@@ -4,9 +4,11 @@ import { CreateDataset } from './CreateDataset'
 import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
 import { MetadataBlockInfoJSDataverseRepository } from '../../metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
 import { NotImplementedModalProvider } from '../not-implemented/NotImplementedModalProvider'
+import { CollectionJSDataverseRepository } from '../../collection/infrastructure/repositories/CollectionJSDataverseRepository'
 
 const datasetRepository = new DatasetJSDataverseRepository()
 const metadataBlockInfoRepository = new MetadataBlockInfoJSDataverseRepository()
+const collectionRepository = new CollectionJSDataverseRepository()
 
 export class CreateDatasetFactory {
   static create(): ReactElement {
@@ -26,6 +28,7 @@ function CreateDatasetWithSearchParams() {
     <CreateDataset
       datasetRepository={datasetRepository}
       metadataBlockInfoRepository={metadataBlockInfoRepository}
+      collectionRepository={collectionRepository}
       collectionId={collectionId}
     />
   )

--- a/src/sections/layout/header/Header.tsx
+++ b/src/sections/layout/header/Header.tsx
@@ -1,24 +1,14 @@
 import dataverse_logo from '../../../assets/dataverse_brand_icon.svg'
 import { useTranslation } from 'react-i18next'
 import { Navbar } from '@iqss/dataverse-design-system'
-import { Route, RouteWithParams } from '../../Route.enum'
+import { Route } from '../../Route.enum'
 import { useSession } from '../../session/SessionContext'
-import { Link, useNavigate } from 'react-router-dom'
 import { BASE_URL } from '../../../config'
+import { LoggedInHeaderActions } from './LoggedInHeaderActions'
 
-const currentPage = 0
 export function Header() {
   const { t } = useTranslation('header')
-  const { user, logout } = useSession()
-  const navigate = useNavigate()
-
-  const onLogoutClick = () => {
-    void logout().then(() => {
-      navigate(currentPage)
-    })
-  }
-
-  const createCollectionRoute = RouteWithParams.CREATE_COLLECTION()
+  const { user } = useSession()
 
   return (
     <Navbar
@@ -28,21 +18,7 @@ export function Header() {
         logoImgSrc: dataverse_logo
       }}>
       {user ? (
-        <>
-          <Navbar.Dropdown title={t('navigation.addData')} id="dropdown-addData">
-            <Navbar.Dropdown.Item as={Link} to={createCollectionRoute}>
-              {t('navigation.newCollection')}
-            </Navbar.Dropdown.Item>
-            <Navbar.Dropdown.Item as={Link} to={Route.CREATE_DATASET}>
-              {t('navigation.newDataset')}
-            </Navbar.Dropdown.Item>
-          </Navbar.Dropdown>
-          <Navbar.Dropdown title={user.displayName} id="dropdown-user">
-            <Navbar.Dropdown.Item href="#" onClick={onLogoutClick}>
-              {t('logOut')}
-            </Navbar.Dropdown.Item>
-          </Navbar.Dropdown>
-        </>
+        <LoggedInHeaderActions user={user} />
       ) : (
         <>
           <Navbar.Link href={`${BASE_URL}${Route.LOG_IN}`}>{t('logIn')}</Navbar.Link>
@@ -52,5 +28,3 @@ export function Header() {
     </Navbar>
   )
 }
-
-// TODO: AddData Dropdown item needs proper permissions checking, see Spike #318

--- a/src/sections/layout/header/Header.tsx
+++ b/src/sections/layout/header/Header.tsx
@@ -5,6 +5,9 @@ import { Route } from '../../Route.enum'
 import { useSession } from '../../session/SessionContext'
 import { BASE_URL } from '../../../config'
 import { LoggedInHeaderActions } from './LoggedInHeaderActions'
+import { CollectionJSDataverseRepository } from '../../../collection/infrastructure/repositories/CollectionJSDataverseRepository'
+
+const collectionRepository = new CollectionJSDataverseRepository()
 
 export function Header() {
   const { t } = useTranslation('header')
@@ -18,7 +21,7 @@ export function Header() {
         logoImgSrc: dataverse_logo
       }}>
       {user ? (
-        <LoggedInHeaderActions user={user} />
+        <LoggedInHeaderActions user={user} collectionRepository={collectionRepository} />
       ) : (
         <>
           <Navbar.Link href={`${BASE_URL}${Route.LOG_IN}`}>{t('logIn')}</Navbar.Link>

--- a/src/sections/layout/header/LoggedInHeaderActions.tsx
+++ b/src/sections/layout/header/LoggedInHeaderActions.tsx
@@ -6,6 +6,7 @@ import { useSession } from '../../session/SessionContext'
 import { Route, RouteWithParams } from '../../Route.enum'
 import { User } from '../../../users/domain/models/User'
 import { CollectionRepository } from '../../../collection/domain/repositories/CollectionRepository'
+import { ROOT_COLLECTION_ALIAS } from '../../../collection/domain/models/Collection'
 
 const currentPage = 0
 
@@ -23,7 +24,7 @@ export const LoggedInHeaderActions = ({
   const navigate = useNavigate()
 
   const { collectionUserPermissions } = useGetCollectionUserPermissions({
-    collectionIdOrAlias: 'root',
+    collectionIdOrAlias: ROOT_COLLECTION_ALIAS,
     collectionRepository: collectionRepository
   })
 

--- a/src/sections/layout/header/LoggedInHeaderActions.tsx
+++ b/src/sections/layout/header/LoggedInHeaderActions.tsx
@@ -2,24 +2,27 @@ import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router-dom'
 import { Navbar } from '@iqss/dataverse-design-system'
 import { useGetCollectionUserPermissions } from '../../../shared/hooks/useGetCollectionUserPermissions'
-import { CollectionJSDataverseRepository } from '../../../collection/infrastructure/repositories/CollectionJSDataverseRepository'
 import { useSession } from '../../session/SessionContext'
 import { Route, RouteWithParams } from '../../Route.enum'
 import { User } from '../../../users/domain/models/User'
+import { CollectionRepository } from '../../../collection/domain/repositories/CollectionRepository'
 
-const collectionRepository = new CollectionJSDataverseRepository()
 const currentPage = 0
 
 interface LoggedInHeaderActionsProps {
   user: User
+  collectionRepository: CollectionRepository
 }
 
-export const LoggedInHeaderActions = ({ user }: LoggedInHeaderActionsProps) => {
+export const LoggedInHeaderActions = ({
+  user,
+  collectionRepository
+}: LoggedInHeaderActionsProps) => {
   const { t } = useTranslation('header')
   const { logout } = useSession()
   const navigate = useNavigate()
 
-  const { collectionUserPermissions, error, isLoading } = useGetCollectionUserPermissions({
+  const { collectionUserPermissions } = useGetCollectionUserPermissions({
     collectionIdOrAlias: 'root',
     collectionRepository: collectionRepository
   })
@@ -32,18 +35,22 @@ export const LoggedInHeaderActions = ({ user }: LoggedInHeaderActionsProps) => {
 
   const createCollectionRoute = RouteWithParams.CREATE_COLLECTION()
 
-  // TODO:ME Check if user can create collection on root
-  // TODO:ME Check if user can create dataset on root
-
-  // TODO:Me disable buttons if can not
+  const canUserAddCollectionToRoot = Boolean(collectionUserPermissions?.canAddCollection)
+  const canUserAddDatasetToRoot = Boolean(collectionUserPermissions?.canAddDataset)
 
   return (
     <>
       <Navbar.Dropdown title={t('navigation.addData')} id="dropdown-addData">
-        <Navbar.Dropdown.Item as={Link} to={createCollectionRoute}>
+        <Navbar.Dropdown.Item
+          as={Link}
+          to={createCollectionRoute}
+          disabled={!canUserAddCollectionToRoot}>
           {t('navigation.newCollection')}
         </Navbar.Dropdown.Item>
-        <Navbar.Dropdown.Item as={Link} to={Route.CREATE_DATASET}>
+        <Navbar.Dropdown.Item
+          as={Link}
+          to={Route.CREATE_DATASET}
+          disabled={!canUserAddDatasetToRoot}>
           {t('navigation.newDataset')}
         </Navbar.Dropdown.Item>
       </Navbar.Dropdown>

--- a/src/sections/layout/header/LoggedInHeaderActions.tsx
+++ b/src/sections/layout/header/LoggedInHeaderActions.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next'
+import { Link, useNavigate } from 'react-router-dom'
+import { Navbar } from '@iqss/dataverse-design-system'
+import { useGetCollectionUserPermissions } from '../../../shared/hooks/useGetCollectionUserPermissions'
+import { CollectionJSDataverseRepository } from '../../../collection/infrastructure/repositories/CollectionJSDataverseRepository'
+import { useSession } from '../../session/SessionContext'
+import { Route, RouteWithParams } from '../../Route.enum'
+import { User } from '../../../users/domain/models/User'
+
+const collectionRepository = new CollectionJSDataverseRepository()
+const currentPage = 0
+
+interface LoggedInHeaderActionsProps {
+  user: User
+}
+
+export const LoggedInHeaderActions = ({ user }: LoggedInHeaderActionsProps) => {
+  const { t } = useTranslation('header')
+  const { logout } = useSession()
+  const navigate = useNavigate()
+
+  const { collectionUserPermissions, error, isLoading } = useGetCollectionUserPermissions({
+    collectionIdOrAlias: 'root',
+    collectionRepository: collectionRepository
+  })
+
+  const onLogoutClick = () => {
+    void logout().then(() => {
+      navigate(currentPage)
+    })
+  }
+
+  const createCollectionRoute = RouteWithParams.CREATE_COLLECTION()
+
+  // TODO:ME Check if user can create collection on root
+  // TODO:ME Check if user can create dataset on root
+
+  // TODO:Me disable buttons if can not
+
+  return (
+    <>
+      <Navbar.Dropdown title={t('navigation.addData')} id="dropdown-addData">
+        <Navbar.Dropdown.Item as={Link} to={createCollectionRoute}>
+          {t('navigation.newCollection')}
+        </Navbar.Dropdown.Item>
+        <Navbar.Dropdown.Item as={Link} to={Route.CREATE_DATASET}>
+          {t('navigation.newDataset')}
+        </Navbar.Dropdown.Item>
+      </Navbar.Dropdown>
+      <Navbar.Dropdown title={user.displayName} id="dropdown-user">
+        <Navbar.Dropdown.Item href="#" onClick={onLogoutClick}>
+          {t('logOut')}
+        </Navbar.Dropdown.Item>
+      </Navbar.Dropdown>
+    </>
+  )
+}

--- a/src/sections/shared/add-data-actions/AddDataActionsButton.tsx
+++ b/src/sections/shared/add-data-actions/AddDataActionsButton.tsx
@@ -8,9 +8,15 @@ import styles from './AddDataActionsButton.module.scss'
 
 interface AddDataActionsButtonProps {
   collectionId?: string
+  canAddCollection: boolean
+  canAddDataset: boolean
 }
 
-export default function AddDataActionsButton({ collectionId }: AddDataActionsButtonProps) {
+export default function AddDataActionsButton({
+  collectionId,
+  canAddCollection,
+  canAddDataset
+}: AddDataActionsButtonProps) {
   const { t } = useTranslation('header')
 
   const createDatasetRoute = collectionId
@@ -25,10 +31,10 @@ export default function AddDataActionsButton({ collectionId }: AddDataActionsBut
       title={t('navigation.addData')}
       variant="secondary"
       icon={<PlusLg className={styles.icon} />}>
-      <Dropdown.Item to={createCollectionRoute} as={Link}>
+      <Dropdown.Item to={createCollectionRoute} as={Link} disabled={!canAddCollection}>
         {t('navigation.newCollection')}
       </Dropdown.Item>
-      <Dropdown.Item to={createDatasetRoute} as={Link}>
+      <Dropdown.Item to={createDatasetRoute} as={Link} disabled={!canAddDataset}>
         {t('navigation.newDataset')}
       </Dropdown.Item>
     </DropdownButton>

--- a/src/shared/hooks/useGetCollectionUserPermissions.ts
+++ b/src/shared/hooks/useGetCollectionUserPermissions.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { CollectionRepository } from '../../collection/domain/repositories/CollectionRepository'
+import { CollectionUserPermissions } from '@iqss/dataverse-client-javascript'
+import { getCollectionUserPermissions } from '../../collection/domain/useCases/getCollectionUserPermissions'
+
+interface Props {
+  collectionIdOrAlias: string | number
+  collectionRepository: CollectionRepository
+}
+
+interface UseGetCollectionUserPermissions {
+  collectionUserPermissions: CollectionUserPermissions | null
+  error: string | null
+  isLoading: boolean
+}
+
+export const useGetCollectionUserPermissions = ({
+  collectionIdOrAlias,
+  collectionRepository
+}: Props): UseGetCollectionUserPermissions => {
+  const [collectionUserPermissions, setCollectionUserPermissions] =
+    useState<CollectionUserPermissions | null>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleGetCollectionUserPermissions = async () => {
+      setIsLoading(true)
+      try {
+        const userPermissionsOnCollection: CollectionUserPermissions =
+          await getCollectionUserPermissions(collectionRepository, collectionIdOrAlias)
+
+        setCollectionUserPermissions(userPermissionsOnCollection)
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error && err.message
+            ? err.message
+            : 'Something went wrong getting the user permissions on this collection. Try again later.'
+        setError(errorMessage)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    void handleGetCollectionUserPermissions()
+  }, [collectionIdOrAlias, collectionRepository])
+
+  return {
+    collectionUserPermissions,
+    error,
+    isLoading
+  }
+}

--- a/src/stories/collection/CollectionLoadingMockRepository.ts
+++ b/src/stories/collection/CollectionLoadingMockRepository.ts
@@ -1,4 +1,4 @@
-import { CollectionDTO } from '@iqss/dataverse-client-javascript'
+import { CollectionDTO, CollectionUserPermissions } from '@iqss/dataverse-client-javascript'
 import { Collection } from '../../collection/domain/models/Collection'
 import { CollectionMockRepository } from './CollectionMockRepository'
 
@@ -7,6 +7,9 @@ export class CollectionLoadingMockRepository extends CollectionMockRepository {
     return new Promise(() => {})
   }
   create(_collection: CollectionDTO, _hostCollection?: string): Promise<number> {
+    return new Promise(() => {})
+  }
+  getUserPermissions(_collectionIdOrAlias: number | string): Promise<CollectionUserPermissions> {
     return new Promise(() => {})
   }
 }

--- a/src/stories/collection/CollectionMockRepository.ts
+++ b/src/stories/collection/CollectionMockRepository.ts
@@ -3,6 +3,7 @@ import { CollectionMother } from '../../../tests/component/collection/domain/mod
 import { Collection } from '../../collection/domain/models/Collection'
 import { FakerHelper } from '../../../tests/component/shared/FakerHelper'
 import { CollectionDTO } from '../../collection/domain/useCases/DTOs/CollectionDTO'
+import { CollectionUserPermissions } from '../../collection/domain/models/CollectionUserPermissions'
 
 export class CollectionMockRepository implements CollectionRepository {
   getById(_id: string): Promise<Collection> {
@@ -16,6 +17,13 @@ export class CollectionMockRepository implements CollectionRepository {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(1)
+      }, FakerHelper.loadingTimout())
+    })
+  }
+  getUserPermissions(_collectionIdOrAlias: number | string): Promise<CollectionUserPermissions> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve(CollectionMother.createUserPermissions())
       }, FakerHelper.loadingTimout())
     })
   }

--- a/src/stories/create-collection/CreateCollection.stories.tsx
+++ b/src/stories/create-collection/CreateCollection.stories.tsx
@@ -6,6 +6,9 @@ import { WithLoggedInUser } from '../WithLoggedInUser'
 import { CollectionMockRepository } from '../collection/CollectionMockRepository'
 import { CollectionLoadingMockRepository } from '../collection/CollectionLoadingMockRepository'
 import { NoCollectionMockRepository } from '../collection/NoCollectionMockRepository'
+import { CollectionMother } from '../../../tests/component/collection/domain/models/CollectionMother'
+import { FakerHelper } from '../../../tests/component/shared/FakerHelper'
+import { ROOT_COLLECTION_ALIAS } from '../../collection/domain/models/Collection'
 
 const meta: Meta<typeof CreateCollection> = {
   title: 'Pages/Create Collection',
@@ -23,7 +26,7 @@ export const Default: Story = {
   render: () => (
     <CreateCollection
       collectionRepository={new CollectionMockRepository()}
-      ownerCollectionId="root"
+      ownerCollectionId={ROOT_COLLECTION_ALIAS}
     />
   )
 }
@@ -31,7 +34,7 @@ export const Loading: Story = {
   render: () => (
     <CreateCollection
       collectionRepository={new CollectionLoadingMockRepository()}
-      ownerCollectionId="root"
+      ownerCollectionId={ROOT_COLLECTION_ALIAS}
     />
   )
 }
@@ -40,7 +43,29 @@ export const OwnerCollectionNotFound: Story = {
   render: () => (
     <CreateCollection
       collectionRepository={new NoCollectionMockRepository()}
-      ownerCollectionId="root"
+      ownerCollectionId={ROOT_COLLECTION_ALIAS}
+    />
+  )
+}
+
+const collectionRepositoryWithoutPermissionsToCreateCollection = new CollectionMockRepository()
+collectionRepositoryWithoutPermissionsToCreateCollection.getUserPermissions = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(
+        CollectionMother.createUserPermissions({
+          canAddCollection: false
+        })
+      )
+    }, FakerHelper.loadingTimout())
+  })
+}
+
+export const NotAllowedToAddCollection: Story = {
+  render: () => (
+    <CreateCollection
+      collectionRepository={collectionRepositoryWithoutPermissionsToCreateCollection}
+      ownerCollectionId={ROOT_COLLECTION_ALIAS}
     />
   )
 }

--- a/src/stories/create-dataset/CreateDataset.stories.tsx
+++ b/src/stories/create-dataset/CreateDataset.stories.tsx
@@ -7,6 +7,9 @@ import { MetadataBlockInfoMockRepository } from '../shared-mock-repositories/met
 import { MetadataBlockInfoMockLoadingRepository } from '../shared-mock-repositories/metadata-block-info/MetadataBlockInfoMockLoadingRepository'
 import { NotImplementedModalProvider } from '../../sections/not-implemented/NotImplementedModalProvider'
 import { WithLoggedInUser } from '../WithLoggedInUser'
+import { CollectionMockRepository } from '../collection/CollectionMockRepository'
+import { FakerHelper } from '../../../tests/component/shared/FakerHelper'
+import { CollectionMother } from '../../../tests/component/collection/domain/models/CollectionMother'
 
 const meta: Meta<typeof CreateDataset> = {
   title: 'Pages/Create Dataset',
@@ -26,6 +29,7 @@ export const Default: Story = {
       <CreateDataset
         datasetRepository={new DatasetMockRepository()}
         metadataBlockInfoRepository={new MetadataBlockInfoMockRepository()}
+        collectionRepository={new CollectionMockRepository()}
       />
     </NotImplementedModalProvider>
   )
@@ -36,6 +40,30 @@ export const Loading: Story = {
     <CreateDataset
       datasetRepository={new DatasetMockRepository()}
       metadataBlockInfoRepository={new MetadataBlockInfoMockLoadingRepository()}
+      collectionRepository={new CollectionMockRepository()}
+    />
+  )
+}
+
+const collectionRepositoryWithoutPermissionsToCreateDataset = new CollectionMockRepository()
+collectionRepositoryWithoutPermissionsToCreateDataset.getUserPermissions = () => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(
+        CollectionMother.createUserPermissions({
+          canAddDataset: false
+        })
+      )
+    }, FakerHelper.loadingTimout())
+  })
+}
+
+export const NotAllowedToAddDataset: Story = {
+  render: () => (
+    <CreateDataset
+      datasetRepository={new DatasetMockRepository()}
+      metadataBlockInfoRepository={new MetadataBlockInfoMockRepository()}
+      collectionRepository={collectionRepositoryWithoutPermissionsToCreateDataset}
     />
   )
 }

--- a/src/stories/shared/add-data-actions/AddDataActionsButton.stories.tsx
+++ b/src/stories/shared/add-data-actions/AddDataActionsButton.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { WithI18next } from '../../WithI18next'
 import AddDataActionsButton from '../../../sections/shared/add-data-actions/AddDataActionsButton'
+import { ROOT_COLLECTION_ALIAS } from '../../../collection/domain/models/Collection'
 
 const meta: Meta<typeof AddDataActionsButton> = {
   title: 'Sections/Shared/AddDataActions/AddDataActionsButton',
@@ -12,5 +13,27 @@ export default meta
 type Story = StoryObj<typeof AddDataActionsButton>
 
 export const Default: Story = {
-  render: () => <AddDataActionsButton />
+  render: () => (
+    <AddDataActionsButton collectionId={ROOT_COLLECTION_ALIAS} canAddCollection canAddDataset />
+  )
+}
+
+export const NotAllowedToAddCollection: Story = {
+  render: () => (
+    <AddDataActionsButton
+      collectionId={ROOT_COLLECTION_ALIAS}
+      canAddCollection={false}
+      canAddDataset={true}
+    />
+  )
+}
+
+export const NotAllowedToAddDataset: Story = {
+  render: () => (
+    <AddDataActionsButton
+      collectionId={ROOT_COLLECTION_ALIAS}
+      canAddCollection={true}
+      canAddDataset={false}
+    />
+  )
 }

--- a/tests/component/collection/domain/models/CollectionMother.ts
+++ b/tests/component/collection/domain/models/CollectionMother.ts
@@ -2,6 +2,7 @@ import { Collection } from '../../../../../src/collection/domain/models/Collecti
 import { faker } from '@faker-js/faker'
 import { FakerHelper } from '../../../shared/FakerHelper'
 import { UpwardHierarchyNodeMother } from '../../../shared/hierarchy/domain/models/UpwardHierarchyNodeMother'
+import { CollectionUserPermissions } from '../../../../../src/collection/domain/models/CollectionUserPermissions'
 
 export class CollectionMother {
   static create(props?: Partial<Collection>): Collection {
@@ -64,5 +65,20 @@ export class CollectionMother {
     return CollectionMother.createWithOnlyRequiredFields({
       affiliation: FakerHelper.affiliation()
     })
+  }
+
+  static createUserPermissions(
+    props?: Partial<CollectionUserPermissions>
+  ): CollectionUserPermissions {
+    return {
+      canAddCollection: true,
+      canAddDataset: true,
+      canViewUnpublishedCollection: true,
+      canEditCollection: true,
+      canManageCollectionPermissions: true,
+      canPublishCollection: true,
+      canDeleteCollection: true,
+      ...props
+    }
   }
 }

--- a/tests/component/sections/create-dataset/CreateDataset.spec.tsx
+++ b/tests/component/sections/create-dataset/CreateDataset.spec.tsx
@@ -3,11 +3,14 @@ import { DatasetRepository } from '../../../../src/dataset/domain/repositories/D
 import { MetadataBlockInfoRepository } from '../../../../src/metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
 import { MetadataBlockInfoMother } from '../../metadata-block-info/domain/models/MetadataBlockInfoMother'
 import { NotImplementedModalProvider } from '../../../../src/sections/not-implemented/NotImplementedModalProvider'
-import { FileRepository } from '../../../../src/files/domain/repositories/FileRepository'
+import { CollectionRepository } from '../../../../src/collection/domain/repositories/CollectionRepository'
+import { CollectionMother } from '../../collection/domain/models/CollectionMother'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
 const metadataBlockInfoRepository: MetadataBlockInfoRepository = {} as MetadataBlockInfoRepository
-const fileRepository: FileRepository = {} as FileRepository
+
+const collectionRepository: CollectionRepository = {} as CollectionRepository
+const userPermissionsMock = CollectionMother.createUserPermissions()
 
 const collectionMetadataBlocksInfo =
   MetadataBlockInfoMother.getByCollectionIdDisplayedOnCreateTrue()
@@ -18,6 +21,8 @@ describe('Create Dataset', () => {
     metadataBlockInfoRepository.getDisplayedOnCreateByCollectionId = cy
       .stub()
       .resolves(collectionMetadataBlocksInfo)
+
+    collectionRepository.getUserPermissions = cy.stub().resolves(userPermissionsMock)
   })
 
   it('renders the Host Collection Form for root collection', () => {
@@ -25,6 +30,7 @@ describe('Create Dataset', () => {
       <CreateDataset
         datasetRepository={datasetRepository}
         metadataBlockInfoRepository={metadataBlockInfoRepository}
+        collectionRepository={collectionRepository}
       />
     )
     cy.findByText(/^Host Collection/i).should('exist')
@@ -38,6 +44,7 @@ describe('Create Dataset', () => {
           datasetRepository={datasetRepository}
           collectionId={'test-collectionId'}
           metadataBlockInfoRepository={metadataBlockInfoRepository}
+          collectionRepository={collectionRepository}
         />
       </NotImplementedModalProvider>
     )
@@ -49,5 +56,33 @@ describe('Create Dataset', () => {
       .then(() => {
         cy.findByText('Not Implemented').should('exist')
       })
+  })
+
+  it('should show alert error message when user is not allowed to create a dataset within the collection', () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(
+      CollectionMother.createUserPermissions({
+        canAddDataset: false
+      })
+    )
+
+    cy.customMount(
+      <CreateDataset
+        datasetRepository={datasetRepository}
+        metadataBlockInfoRepository={metadataBlockInfoRepository}
+        collectionRepository={collectionRepository}
+      />
+    )
+    cy.findAllByTestId('not-allowed-to-create-dataset-alert').should('exist')
+  })
+
+  it('should not show alert error message when user is allowed to create a dataset within the collection', () => {
+    cy.customMount(
+      <CreateDataset
+        datasetRepository={datasetRepository}
+        metadataBlockInfoRepository={metadataBlockInfoRepository}
+        collectionRepository={collectionRepository}
+      />
+    )
+    cy.findAllByTestId('not-allowed-to-create-dataset-alert').should('not.exist')
   })
 })

--- a/tests/component/sections/layout/header/LoggedInHeaderActions.spec.tsx
+++ b/tests/component/sections/layout/header/LoggedInHeaderActions.spec.tsx
@@ -1,0 +1,96 @@
+import { UserMother } from '../../../users/domain/models/UserMother'
+import { LoggedInHeaderActions } from '../../../../../src/sections/layout/header/LoggedInHeaderActions'
+import { CollectionRepository } from '../../../../../src/collection/domain/repositories/CollectionRepository'
+import { CollectionMother } from '../../../collection/domain/models/CollectionMother'
+
+const testUser = UserMother.create()
+const collectionRepository: CollectionRepository = {} as CollectionRepository
+const userPermissionsMock = CollectionMother.createUserPermissions()
+
+describe('LoggedInHeaderActions', () => {
+  it('shows New Collection button disabled if user has no permissions to create collection on Root', () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(
+      CollectionMother.createUserPermissions({
+        canAddCollection: false
+      })
+    )
+
+    cy.customMount(
+      <LoggedInHeaderActions user={testUser} collectionRepository={collectionRepository} />
+    )
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Collection' })
+      .should('be.visible')
+      .should('have.attr', 'aria-disabled', 'true')
+  })
+
+  it('shows New Collection button enabled if user has permissions to create collection on Root', () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(userPermissionsMock)
+
+    cy.customMount(
+      <LoggedInHeaderActions user={testUser} collectionRepository={collectionRepository} />
+    )
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Collection' })
+      .should('be.visible')
+      .should('not.have.attr', 'aria-disabled', 'false')
+  })
+
+  it('shows New Dataset button disabled if user has no permissions to create dataset on Root', () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(
+      CollectionMother.createUserPermissions({
+        canAddDataset: false
+      })
+    )
+
+    cy.customMount(
+      <LoggedInHeaderActions user={testUser} collectionRepository={collectionRepository} />
+    )
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Dataset' })
+      .should('be.visible')
+      .should('have.attr', 'aria-disabled', 'true')
+  })
+
+  it('shows New Dataset button enabled if user has permissions to create dataset on Root', () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(userPermissionsMock)
+
+    cy.customMount(
+      <LoggedInHeaderActions user={testUser} collectionRepository={collectionRepository} />
+    )
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Dataset' })
+      .should('be.visible')
+      .should('not.have.attr', 'aria-disabled', 'false')
+  })
+
+  it('shows both New Collection and New Dataset buttons enabled if user has permissions to create both on Root', () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(userPermissionsMock)
+
+    cy.customMount(
+      <LoggedInHeaderActions user={testUser} collectionRepository={collectionRepository} />
+    )
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Collection' })
+      .should('be.visible')
+      .should('not.have.attr', 'aria-disabled', 'false')
+    cy.findByRole('link', { name: 'New Dataset' })
+      .should('be.visible')
+      .should('not.have.attr', 'aria-disabled', 'false')
+  })
+})

--- a/tests/component/sections/shared/add-data-actions/AddDataActionsButton.spec.tsx
+++ b/tests/component/sections/shared/add-data-actions/AddDataActionsButton.spec.tsx
@@ -2,7 +2,7 @@ import AddDataActionsButton from '../../../../../src/sections/shared/add-data-ac
 
 describe('AddDataActionsButton', () => {
   it('renders the button', () => {
-    cy.customMount(<AddDataActionsButton />)
+    cy.customMount(<AddDataActionsButton canAddCollection={true} canAddDataset={true} />)
 
     cy.findByRole('button', { name: /Add Data/i }).should('exist')
     cy.findByRole('button', { name: /Add Data/ }).click()
@@ -11,7 +11,7 @@ describe('AddDataActionsButton', () => {
   })
 
   it('renders the new dataset button with the correct generated link', () => {
-    cy.customMount(<AddDataActionsButton />)
+    cy.customMount(<AddDataActionsButton canAddCollection={true} canAddDataset={true} />)
 
     cy.findByRole('button', { name: /Add Data/i }).click()
     cy.findByText('New Dataset')
@@ -21,11 +21,61 @@ describe('AddDataActionsButton', () => {
 
   it('renders the new dataset button with the correct generated link', () => {
     const collectionId = 'some-collection-id'
-    cy.customMount(<AddDataActionsButton collectionId={collectionId} />)
+    cy.customMount(
+      <AddDataActionsButton
+        collectionId={collectionId}
+        canAddCollection={true}
+        canAddDataset={true}
+      />
+    )
 
     cy.findByRole('button', { name: /Add Data/i }).click()
     cy.findByText('New Dataset')
       .should('be.visible')
       .should('have.attr', 'href', `/datasets/create?collectionId=${collectionId}`)
+  })
+
+  it('shows New Collection button enabled if user has permissions to create collection', () => {
+    cy.customMount(<AddDataActionsButton canAddCollection={true} canAddDataset={true} />)
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Collection' })
+      .should('be.visible')
+      .should('not.have.attr', 'aria-disabled', 'false')
+  })
+
+  it('shows New Dataset button enabled if user has permissions to create dataset', () => {
+    cy.customMount(<AddDataActionsButton canAddCollection={true} canAddDataset={true} />)
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Dataset' })
+      .should('be.visible')
+      .should('not.have.attr', 'aria-disabled', 'true')
+  })
+
+  it('shows New Collection button disabled if user does not have permissions to create collection', () => {
+    cy.customMount(<AddDataActionsButton canAddCollection={false} canAddDataset={true} />)
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Collection' })
+      .should('be.visible')
+      .should('have.attr', 'aria-disabled', 'true')
+  })
+
+  it('shows New Dataset button disabled if user does not have permissions to create dataset', () => {
+    cy.customMount(<AddDataActionsButton canAddCollection={true} canAddDataset={false} />)
+
+    cy.findByRole('button', { name: /Add Data/i }).as('addDataBtn')
+    cy.get('@addDataBtn').should('exist')
+    cy.get('@addDataBtn').click()
+    cy.findByRole('link', { name: 'New Dataset' })
+      .should('be.visible')
+      .should('have.attr', 'aria-disabled', 'true')
   })
 })

--- a/tests/component/shared/hooks/useGetCollectionUserPermissions.spec.ts
+++ b/tests/component/shared/hooks/useGetCollectionUserPermissions.spec.ts
@@ -1,0 +1,77 @@
+import { act, renderHook } from '@testing-library/react'
+import { CollectionRepository } from '../../../../src/collection/domain/repositories/CollectionRepository'
+import { CollectionMother } from '../../collection/domain/models/CollectionMother'
+import { useGetCollectionUserPermissions } from '../../../../src/shared/hooks/useGetCollectionUserPermissions'
+
+const collectionRepository: CollectionRepository = {} as CollectionRepository
+const userPermissionsMock = CollectionMother.createUserPermissions()
+
+describe('useGetAllMetadataBlocksInfo', () => {
+  it('should return metadataBlockDisplayFormatInfo correctly', async () => {
+    collectionRepository.getUserPermissions = cy.stub().resolves(userPermissionsMock)
+
+    const { result } = renderHook(() =>
+      useGetCollectionUserPermissions({
+        collectionRepository,
+        collectionIdOrAlias: 'root'
+      })
+    )
+
+    await act(() => {
+      expect(result.current.isLoading).to.deep.equal(true)
+      return expect(result.current.collectionUserPermissions).to.deep.equal(null)
+    })
+
+    await act(() => {
+      expect(result.current.isLoading).to.deep.equal(false)
+
+      return expect(result.current.collectionUserPermissions).to.deep.equal(userPermissionsMock)
+    })
+  })
+
+  describe('Error handling', () => {
+    it('should return correct error message when there is an error type catched', async () => {
+      collectionRepository.getUserPermissions = cy.stub().rejects(new Error('Error message'))
+
+      const { result } = renderHook(() =>
+        useGetCollectionUserPermissions({
+          collectionRepository,
+          collectionIdOrAlias: 'root'
+        })
+      )
+
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(true)
+        return expect(result.current.error).to.deep.equal(null)
+      })
+
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(false)
+        return expect(result.current.error).to.deep.equal('Error message')
+      })
+    })
+
+    it('should return correct error message when there is not an error type catched', async () => {
+      collectionRepository.getUserPermissions = cy.stub().rejects('Error message')
+
+      const { result } = renderHook(() =>
+        useGetCollectionUserPermissions({
+          collectionRepository,
+          collectionIdOrAlias: 'root'
+        })
+      )
+
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(true)
+        return expect(result.current.error).to.deep.equal(null)
+      })
+
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(false)
+        return expect(result.current.error).to.deep.equal(
+          'Something went wrong getting the user permissions on this collection. Try again later.'
+        )
+      })
+    })
+  })
+})

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -3,6 +3,7 @@ import { DataverseApiHelper } from '../DataverseApiHelper'
 import { FileData } from '../files/FileHelper'
 import { DatasetLockReason } from '../../../../src/dataset/domain/models/Dataset'
 import { TestsUtils } from '../TestsUtils'
+import { ROOT_COLLECTION_ALIAS } from '../../../../src/collection/domain/models/Collection'
 
 export interface DatasetResponse {
   persistentId: string
@@ -16,7 +17,7 @@ export interface DatasetFileResponse {
 }
 
 export class DatasetHelper extends DataverseApiHelper {
-  static async create(collectionId = 'root'): Promise<DatasetResponse> {
+  static async create(collectionId = ROOT_COLLECTION_ALIAS): Promise<DatasetResponse> {
     return this.request<DatasetResponse>(
       `/dataverses/${collectionId}/datasets`,
       'POST',
@@ -43,14 +44,17 @@ export class DatasetHelper extends DataverseApiHelper {
       throw error
     }
   }
-  static async createAndPublish(collectionId = 'root'): Promise<DatasetResponse> {
+  static async createAndPublish(collectionId = ROOT_COLLECTION_ALIAS): Promise<DatasetResponse> {
     const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.publish(datasetResponse.persistentId)
     await TestsUtils.waitForNoLocks(datasetResponse.persistentId)
     return datasetResponse
   }
 
-  static async createMany(amount: number, collectionId = 'root'): Promise<DatasetResponse[]> {
+  static async createMany(
+    amount: number,
+    collectionId = ROOT_COLLECTION_ALIAS
+  ): Promise<DatasetResponse[]> {
     const datasets = []
     for (let i = 0; i < amount; i++) {
       const datasetResponse = await this.create(collectionId)
@@ -136,14 +140,17 @@ export class DatasetHelper extends DataverseApiHelper {
 
   static async createWithFiles(
     filesData: FileData[],
-    collectionId = 'root'
+    collectionId = ROOT_COLLECTION_ALIAS
   ): Promise<DatasetResponse> {
     const datasetResponse = await this.create(collectionId)
     const files = await this.uploadFiles(datasetResponse.persistentId, filesData)
     return { ...datasetResponse, files: files }
   }
 
-  static async createWithFile(fileData: FileData, collectionId = 'root'): Promise<DatasetResponse> {
+  static async createWithFile(
+    fileData: FileData,
+    collectionId = ROOT_COLLECTION_ALIAS
+  ): Promise<DatasetResponse> {
     const datasetResponse = await this.create(collectionId)
     const file = await this.uploadFile(datasetResponse.persistentId, fileData)
     return { ...datasetResponse, file: file }
@@ -151,7 +158,7 @@ export class DatasetHelper extends DataverseApiHelper {
 
   static async createWithFileAndPublish(
     fileData: FileData,
-    collectionId = 'root'
+    collectionId = ROOT_COLLECTION_ALIAS
   ): Promise<DatasetResponse> {
     const datasetResponse = await DatasetHelper.createWithFile(fileData, collectionId)
     await DatasetHelper.publish(datasetResponse.persistentId)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Checks user permissions to create a Collection & create a Dataset on a specific collection, if the user doesn't have permissions neither to create a collection or a dataset, the Add Data dropdown inside the Collection page will not appear; if it has permissions to create a collection or dataset it will be visible with the proper buttons enabled or disabled in it.
- Checks user permissions to create a Collection inside the Create Collection page.
- Checks user permissions to create a Dataset inside the Create Dataset page.
- Check user permissions on the root collection to enable or disabled buttons inside the Add Data drop-down located in the application header.

**Which issue(s) this PR closes**:

Closes #434 

**Special notes for your reviewer**:
I have also changed the alias 'root' used in several components for an exported constant, to avoid mistakes and improve reusability, as it is done in js-dataverse.
E2E test `navigates to the collection page after submitting a valid form` is failing, will be ok after merging [PR 169](https://github.com/IQSS/dataverse-client-javascript/pull/169) from js-dataverse and also [PR 451](https://github.com/IQSS/dataverse-frontend/pull/451) from this repo.

**Suggestions on how to test this**:

1. Create a Collection and a Dataset in the JSF version with User A, publish both Collection and Dataset.
2. With User A, Navigate to that collection and check that you are able to see the Add Data dropdown with both the New Collection and New Dataset buttons enabled in it, click on both buttons and check that you can successfully the create dataset form and the create collection form.
3. Create another user "B" in the JSF version.
4. Navigate in the SPA to the Collection created from user A, and the Add Data dropdown shouldn't be visible.
5. Log in with user "A" and navigate to the created Collection in JSF, click Edit => Permissions, go to Users Groups and assign roles to user "B" as Dataset Creator to be able to add datasets to that Collection.
6. Log in with user "B" and navigate to that collection in the SPA and check that in the Add Data dropdown you have only the New Dataset button enabled.
7. Log out from user B, Log in with user A and navigate again to that Collection and assign a different role (Curator for example), so user B will be able to Add Dataset and Add Collection.
8. Again log in with user A and navigate to that collection in the SPA and check that in the Add Data dropdown you have both the New Collecction and the New Dataset buttons enabled.

**Does this PR introduce a user interface change? If mockups are available, please link/include them here**:
<img width="1004" alt="Screenshot 2024-08-16 at 15 56 54" src="https://github.com/user-attachments/assets/741818b0-36cf-4677-9656-bf998800805c">
<img width="998" alt="Screenshot 2024-08-16 at 15 56 30" src="https://github.com/user-attachments/assets/9f389148-fa36-450d-89c7-0b7dcfe67256">


**Is there a release notes update needed for this change?**:
No

**Additional documentation**:
No
