### PR TITLE
File upload: alert when a file could not be added for upload

### DIFF
--- a/public/locales/en/uploadDatasetFiles.json
+++ b/public/locales/en/uploadDatasetFiles.json
@@ -60,5 +60,8 @@
     "selectTags": "Select tags to add",
     "saveChanges": "Save Changes",
     "cancelChanges": "Cancel Changes"
+  },
+  "alerts": {
+    "fileNameNotUnique": "File {{name}} was already added and is ignored"
   }
 }

--- a/src/sections/upload-dataset-files/FileUploader.tsx
+++ b/src/sections/upload-dataset-files/FileUploader.tsx
@@ -4,6 +4,8 @@ import { ChangeEventHandler, DragEventHandler, useEffect, useRef, useState } fro
 import { Plus, X } from 'react-bootstrap-icons'
 import { FileUploadTools, FileUploaderState } from '../../files/domain/models/FileUploadState'
 import styles from './FileUploader.module.scss'
+import { AlertVariant } from '@iqss/dataverse-design-system/src/lib/components/alert/AlertVariant'
+import { useTranslation } from 'react-i18next'
 
 export interface FileUploaderProps {
   upload: (files: File[]) => void
@@ -13,6 +15,7 @@ export interface FileUploaderProps {
   fileUploaderState: FileUploaderState
   cancelUpload: (file: File) => void
   cleanFileState: (file: File) => void
+  addAlert: (variant: AlertVariant, message: string) => void
 }
 
 export function FileUploader({
@@ -22,11 +25,13 @@ export function FileUploader({
   selectText,
   fileUploaderState,
   cancelUpload,
-  cleanFileState
+  cleanFileState,
+  addAlert
 }: FileUploaderProps) {
   const theme = useTheme()
   const [files, setFiles] = useState<File[]>([])
   const [bgColor, setBackgroundColor] = useState(theme.color.primaryTextColor)
+  const { t } = useTranslation('uploadDatasetFiles')
 
   const addFiles = (selectedFiles: FileList | null) => {
     if (selectedFiles && selectedFiles.length > 0) {
@@ -45,6 +50,8 @@ export function FileUploader({
   const addFile = (file: File) => {
     if (!files.some((x) => FileUploadTools.key(x) === FileUploadTools.key(file))) {
       setFiles((oldFiles) => [...oldFiles, file])
+    } else {
+      addAlert('danger', t('alerts.fileNameNotUnique', { name: FileUploadTools.key(file) }))
     }
   }
 

--- a/src/sections/upload-dataset-files/UploadDatasetFiles.tsx
+++ b/src/sections/upload-dataset-files/UploadDatasetFiles.tsx
@@ -10,9 +10,17 @@ import { FileUploadState, FileUploadTools } from '../../files/domain/models/File
 import { uploadFile } from '../../files/domain/useCases/uploadFile'
 import { UploadedFiles } from './uploaded-files-list/UploadedFiles'
 import { addUploadedFile, addUploadedFiles } from '../../files/domain/useCases/addUploadedFiles'
+import { Alert } from '@iqss/dataverse-design-system'
+import { AlertVariant } from '@iqss/dataverse-design-system/src/lib/components/alert/AlertVariant'
 
 interface UploadDatasetFilesProps {
   fileRepository: FileRepository
+}
+
+interface FileUploadAlert {
+  key: string
+  variant: AlertVariant
+  message: string
 }
 
 export const UploadDatasetFiles = ({ fileRepository: fileRepository }: UploadDatasetFilesProps) => {
@@ -22,6 +30,13 @@ export const UploadDatasetFiles = ({ fileRepository: fileRepository }: UploadDat
   const [fileUploaderState, setState] = useState(FileUploadTools.createNewState([]))
   const [uploadingToCancelMap, setUploadingToCancelMap] = useState(new Map<string, () => void>())
   const [semaphore, setSemaphore] = useState(new Set<string>())
+  const [alerts, setAlerts] = useState<FileUploadAlert[]>([])
+  let i = 0
+  const addAlert = (variant: AlertVariant, message: string) =>
+    setAlerts((current) => [
+      ...current,
+      { key: (i++).toString(), variant: variant, message: message }
+    ])
 
   const sleep = (delay: number) => new Promise((res) => setTimeout(res, delay))
   const limit = 6
@@ -169,6 +184,11 @@ export const UploadDatasetFiles = ({ fileRepository: fileRepository }: UploadDat
             actionItemText={t('breadcrumbActionItem')}
           />
           <article>
+            {alerts.map((alert) => (
+              <Alert variant={alert.variant} key={alert.key}>
+                {alert.message}
+              </Alert>
+            ))}
             <FileUploader
               upload={upload}
               cancelTitle={t('cancel')}
@@ -177,6 +197,7 @@ export const UploadDatasetFiles = ({ fileRepository: fileRepository }: UploadDat
               fileUploaderState={fileUploaderState}
               cancelUpload={cancelUpload}
               cleanFileState={cleanFileState}
+              addAlert={addAlert}
             />
             <UploadedFiles
               fileUploadState={fileUploaderState.uploaded}


### PR DESCRIPTION
## What this PR does / why we need it:
With each upload, all files need to have a unique combination of the label (directory) and the file name. Until now, when adding the same file (as already present in the list of files to be added at the bottom of the file upload page), it is silently ignored and is not uploaded. This PR adds an alert on the top of the page when this happens to notify the user that the file could not be added.

Note that you can still add the same file multiple times to the dataset by uploading them one by one. The upload page does not check the file names of the files already present in the dataset. When the same file is uploaded again, it is handled in the standard way by the Dataverse API and gets the "-1" suffix, e.g., after adding "test.json" twice, you will have two files in the dataset: "test.json" and "test-1.json".

## Which issue(s) this PR closes:

- Closes #467

## Special notes for your reviewer:

## Suggestions on how to test this:
Add the same file for upload twice, when adding second time (and the previously added files is still in the list of the files to be added at the bottom of the upload page), an alert should be shown (and the file is not added second time).

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
