### PR TITLE
487 display current year for copyright in footer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Cypress screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -1,5 +1,5 @@
 {
-  "copyright": "Copyright © 2023, The President & Fellows of Harvard College | ",
+  "copyright": "Copyright © {{year}}, The President & Fellows of Harvard College | ",
   "privacyPolicy": "Privacy Policy",
   "poweredBy": "Powered by"
 }

--- a/src/sections/layout/footer/Footer.tsx
+++ b/src/sections/layout/footer/Footer.tsx
@@ -13,6 +13,7 @@ export function Footer({ dataverseInfoRepository }: FooterProps) {
   const { t } = useTranslation('footer')
   const { dataverseVersion } = useDataverseVersion(dataverseInfoRepository)
   const currentYear = new Date().getFullYear().toString()
+
   return (
     <footer className={styles.container}>
       <Container>

--- a/src/sections/layout/footer/Footer.tsx
+++ b/src/sections/layout/footer/Footer.tsx
@@ -12,14 +12,14 @@ interface FooterProps {
 export function Footer({ dataverseInfoRepository }: FooterProps) {
   const { t } = useTranslation('footer')
   const { dataverseVersion } = useDataverseVersion(dataverseInfoRepository)
-
+  const currentYear = new Date().getFullYear().toString()
   return (
     <footer className={styles.container}>
       <Container>
         <Row>
           <Col sm={8}>
             <p className={styles.copyright}>
-              {t('copyright')}
+              {t('copyright', { year: currentYear })}
               <a
                 href="https://dataverse.org/best-practices/harvard-dataverse-privacy-policy"
                 rel="noreferrer"

--- a/tests/component/sections/layout/footer/Footer.spec.tsx
+++ b/tests/component/sections/layout/footer/Footer.spec.tsx
@@ -7,10 +7,12 @@ import { Footer } from '../../../../../src/sections/layout/footer/Footer'
 describe('Footer component', () => {
   const sandbox: SinonSandbox = createSandbox()
   const testVersion = DataverseVersionMother.create()
+  const currentYear = new Date().getFullYear().toString()
 
   it('should render footer content', () => {
     cy.customMount(FooterMother.withDataverseVersion(sandbox, testVersion))
 
+    cy.contains(`Copyright © ${currentYear}`).should('exist')
     cy.findByText('Privacy Policy').should('exist')
     cy.findByAltText('The Dataverse Project logo').should('exist')
     cy.findByText(testVersion).should('exist')


### PR DESCRIPTION
## What this PR does / why we need it:
There is the _Copyright @ 2023_ hardcoded in the SPA footer, but it's expected the year 2023 could always be updated to current year.

## Which issue(s) this PR closes: 

- Closes #487 

## Special notes for your reviewer:

## Suggestions on how to test this:

- Check if the SPA pages always display the current year in the footer right behind _copyright @_

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
![image](https://github.com/user-attachments/assets/c5574928-acc4-4cdf-b462-89bc64556f10)

## Is there a release notes update needed for this change?:
No
## Additional documentation:
