### PR TITLE
436 prefill name for author and point of contact should be familyname givenname format

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,7 +143,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Cypress screenshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: cypress-screenshots

--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/index.tsx
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/index.tsx
@@ -58,8 +58,9 @@ export const MetadataForm = ({
   useEffect(() => {
     // Only on create mode, lets prefill specific fields with user data
     if (mode === 'create' && user) {
-      setValue('citation.author.0.authorName', user.displayName)
-      setValue('citation.datasetContact.0.datasetContactName', user.displayName)
+      const displayName = `${user.lastName}, ${user.firstName}`
+      setValue('citation.author.0.authorName', displayName)
+      setValue('citation.datasetContact.0.datasetContactName', displayName)
       setValue('citation.datasetContact.0.datasetContactEmail', user.email, {
         shouldValidate: true
       })

--- a/tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
+++ b/tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
@@ -1445,6 +1445,7 @@ describe('DatasetMetadataForm', () => {
   })
 
   it('pre-fills the form with user data', () => {
+    const displayName = `${testUser.lastName}, ${testUser.firstName}`
     cy.mountAuthenticated(
       <DatasetMetadataForm
         mode="create"
@@ -1456,7 +1457,7 @@ describe('DatasetMetadataForm', () => {
     cy.findByText('Author')
       .closest('.row')
       .within(() => {
-        cy.findByLabelText(/^Name/i).should('have.value', testUser.displayName)
+        cy.findByLabelText(/^Name/i).should('have.value', displayName)
       })
     cy.findByText('Author')
       .closest('.row')
@@ -1466,7 +1467,7 @@ describe('DatasetMetadataForm', () => {
     cy.findByText('Point of Contact')
       .closest('.row')
       .within(() => {
-        cy.findByLabelText(/^Name/i).should('have.value', testUser.displayName)
+        cy.findByLabelText(/^Name/i).should('have.value', displayName)
       })
     cy.findByText('Point of Contact')
       .closest('.row')


### PR DESCRIPTION
## What this PR does / why we need it:
The pre-filled author and point of contact name format should be aligned with the watermark and JSF. It changes from **First Name Last Name** to **Last Name, First Name** in Create Dataset page.

## Which issue(s) this PR closes:

- Closes #436 

## Special notes for your reviewer:

## Suggestions on how to test this:
Please check if the pre-filled Author name and Point of contact name is in the right format **Last Name, First Name**, in Create Dataset page.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
<img width="1339" alt="Screenshot 2024-09-13 at 2 00 55 PM" src="https://github.com/user-attachments/assets/69e04b63-90f6-46ee-b83b-56e8e4912ecb">

## Is there a release notes update needed for this change?:
No

## Additional documentation:
