### PR TITLE
485 create dataset url

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -772,7 +772,7 @@ describe('Create Dataset', () => {
   })
 
   it('navigates to the new dataset after submitting a valid form', () => {
-    cy.visit('/spa/datasets/create')
+    cy.visit('/spa/datasets/root/create')
 
     cy.findByLabelText(/Title/i).type('Test Dataset Title')
     cy.findByLabelText(/Author Name/i).type('Test author name', { force: true })

--- a/src/sections/Route.enum.ts
+++ b/src/sections/Route.enum.ts
@@ -6,7 +6,7 @@ export enum Route {
   LOG_IN = '/loginpage.xhtml?redirectPage=%2Fdataverse.xhtml',
   LOG_OUT = '/',
   DATASETS = '/datasets',
-  CREATE_DATASET = '/datasets/create',
+  CREATE_DATASET = '/datasets/:collectionId/create',
   UPLOAD_DATASET_FILES = '/datasets/upload-files',
   EDIT_DATASET_METADATA = '/datasets/edit-metadata',
   FILES = '/files',
@@ -17,7 +17,9 @@ export enum Route {
 export const RouteWithParams = {
   COLLECTIONS: (collectionId?: string) => `/collections/${collectionId ?? 'root'}`,
   CREATE_COLLECTION: (ownerCollectionId?: string) =>
-    `/collections/${ownerCollectionId ?? ROOT_COLLECTION_ALIAS}/create`
+    `/collections/${ownerCollectionId ?? ROOT_COLLECTION_ALIAS}/create`,
+  CREATE_DATASET: (collectionId?: string) =>
+    `/datasets/${collectionId ?? ROOT_COLLECTION_ALIAS}/create`
 }
 
 export enum QueryParamKey {

--- a/src/sections/create-dataset/CreateDatasetFactory.tsx
+++ b/src/sections/create-dataset/CreateDatasetFactory.tsx
@@ -1,5 +1,5 @@
 import { ReactElement } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { CreateDataset } from './CreateDataset'
 import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
 import { MetadataBlockInfoJSDataverseRepository } from '../../metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
@@ -21,8 +21,7 @@ export class CreateDatasetFactory {
 }
 
 function CreateDatasetWithSearchParams() {
-  const [searchParams] = useSearchParams()
-  const collectionId = searchParams.get('collectionId') ?? undefined
+  const { collectionId } = useParams<{ collectionId: string }>()
 
   return (
     <CreateDataset

--- a/src/sections/layout/header/LoggedInHeaderActions.tsx
+++ b/src/sections/layout/header/LoggedInHeaderActions.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { Navbar } from '@iqss/dataverse-design-system'
 import { useGetCollectionUserPermissions } from '../../../shared/hooks/useGetCollectionUserPermissions'
 import { useSession } from '../../session/SessionContext'
-import { Route, RouteWithParams } from '../../Route.enum'
+import { RouteWithParams } from '../../Route.enum'
 import { User } from '../../../users/domain/models/User'
 import { CollectionRepository } from '../../../collection/domain/repositories/CollectionRepository'
 import { ROOT_COLLECTION_ALIAS } from '../../../collection/domain/models/Collection'
@@ -35,6 +35,7 @@ export const LoggedInHeaderActions = ({
   }
 
   const createCollectionRoute = RouteWithParams.CREATE_COLLECTION()
+  const createDatasetRoute = RouteWithParams.CREATE_DATASET()
 
   const canUserAddCollectionToRoot = Boolean(collectionUserPermissions?.canAddCollection)
   const canUserAddDatasetToRoot = Boolean(collectionUserPermissions?.canAddDataset)
@@ -48,10 +49,7 @@ export const LoggedInHeaderActions = ({
           disabled={!canUserAddCollectionToRoot}>
           {t('navigation.newCollection')}
         </Navbar.Dropdown.Item>
-        <Navbar.Dropdown.Item
-          as={Link}
-          to={Route.CREATE_DATASET}
-          disabled={!canUserAddDatasetToRoot}>
+        <Navbar.Dropdown.Item as={Link} to={createDatasetRoute} disabled={!canUserAddDatasetToRoot}>
           {t('navigation.newDataset')}
         </Navbar.Dropdown.Item>
       </Navbar.Dropdown>

--- a/src/sections/shared/add-data-actions/AddDataActionsButton.tsx
+++ b/src/sections/shared/add-data-actions/AddDataActionsButton.tsx
@@ -3,7 +3,7 @@ import { Dropdown } from 'react-bootstrap'
 import { Link } from 'react-router-dom'
 import { DropdownButton } from '@iqss/dataverse-design-system'
 import { PlusLg } from 'react-bootstrap-icons'
-import { Route, RouteWithParams } from '../../Route.enum'
+import { RouteWithParams } from '../../Route.enum'
 import styles from './AddDataActionsButton.module.scss'
 
 interface AddDataActionsButtonProps {
@@ -19,11 +19,8 @@ export default function AddDataActionsButton({
 }: AddDataActionsButtonProps) {
   const { t } = useTranslation('header')
 
-  const createDatasetRoute = collectionId
-    ? `${Route.CREATE_DATASET}?collectionId=${collectionId}`
-    : Route.CREATE_DATASET
-
   const createCollectionRoute = RouteWithParams.CREATE_COLLECTION(collectionId)
+  const createDatasetRoute = RouteWithParams.CREATE_DATASET(collectionId)
 
   return (
     <DropdownButton

--- a/tests/component/sections/shared/add-data-actions/AddDataActionsButton.spec.tsx
+++ b/tests/component/sections/shared/add-data-actions/AddDataActionsButton.spec.tsx
@@ -16,7 +16,7 @@ describe('AddDataActionsButton', () => {
     cy.findByRole('button', { name: /Add Data/i }).click()
     cy.findByText('New Dataset')
       .should('be.visible')
-      .should('have.attr', 'href', '/datasets/create')
+      .should('have.attr', 'href', '/datasets/root/create')
   })
 
   it('renders the new dataset button with the correct generated link for specified collectionId', () => {
@@ -32,7 +32,7 @@ describe('AddDataActionsButton', () => {
     cy.findByRole('button', { name: /Add Data/i }).click()
     cy.findByText('New Dataset')
       .should('be.visible')
-      .should('have.attr', 'href', `/datasets/create?collectionId=${collectionId}`)
+      .should('have.attr', 'href', `/datasets/${collectionId}/create`)
   })
 
   it('shows New Collection button enabled if user has permissions to create collection', () => {

--- a/tests/e2e-integration/e2e/sections/create-dataset/CreateDatasetForm.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/create-dataset/CreateDatasetForm.spec.tsx
@@ -11,13 +11,13 @@ describe('Create Dataset', () => {
   })
 
   it('visits the Create Dataset Page as a logged in user', () => {
-    cy.visit('/spa/datasets/create')
+    cy.visit('/spa/datasets/root/create')
 
     cy.findByRole('heading', { name: 'Create Dataset' }).should('exist')
   })
 
   it('navigates to the new dataset after submitting a valid form', () => {
-    cy.visit('/spa/datasets/create')
+    cy.visit('/spa/datasets/root/create')
 
     cy.findByLabelText(/^Title/i).type('Test Dataset Title', { force: true })
 
@@ -44,7 +44,7 @@ describe('Create Dataset', () => {
   })
 
   it('navigates to the home if the user cancels the form', () => {
-    cy.visit('/spa/datasets/create')
+    cy.visit('/spa/datasets/root/create')
 
     cy.findByText(/Cancel/i).click()
 


### PR DESCRIPTION
## What this PR does / why we need it:
We decided to modify the URL path for the 'create dataset' page to maintain consistency with the 'create collection' structure. 

The changes are as follows:
Old path: /spa/datasets/create?collectionId=[collectionId]
New path: /spa/datasets/[collectionId]/create

## Which issue(s) this PR closes:

- Closes #485 

## Special notes for your reviewer:

Originally, we have /spa/datasets/create could be accessible, but after updating, it wouldn't work.

## Suggestions on how to test this:
1. Click the header "Add Data" => "New Dataset", check if the url is correct
2. On the main page, click the button"+ Add Data" => "New Dataset", check if the url is correct

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No
## Is there a release notes update needed for this change?:
No
## Additional documentation:
The Developer_Guide doc changes, because this change relates to a testing example shown on the developer guide.
