### PR TITLE
126 add error handling mechanism to the UI

### DIFF
--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -1,7 +1,6 @@
 import { RouteObject } from 'react-router-dom'
 import { Route } from '../sections/Route.enum'
 import { Layout } from '../sections/layout/Layout'
-import { PageNotFound } from '../sections/page-not-found/PageNotFound'
 import { DatasetFactory } from '../sections/dataset/DatasetFactory'
 import { CreateDatasetFactory } from '../sections/create-dataset/CreateDatasetFactory'
 import { FileFactory } from '../sections/file/FileFactory'
@@ -12,12 +11,13 @@ import { CreateCollectionFactory } from '../sections/create-collection/CreateCol
 import { AccountFactory } from '../sections/account/AccountFactory'
 import { ProtectedRoute } from './ProtectedRoute'
 import { HomepageFactory } from '../sections/homepage/HomepageFactory'
+import { ErrorPage } from '../sections/error-page/ErrorPage'
 
 export const routes: RouteObject[] = [
   {
     path: '/',
     element: <Layout />,
-    errorElement: <PageNotFound />,
+    errorElement: <ErrorPage />,
     children: [
       {
         path: Route.HOME,

--- a/src/router/routes.tsx
+++ b/src/router/routes.tsx
@@ -21,47 +21,58 @@ export const routes: RouteObject[] = [
     children: [
       {
         path: Route.HOME,
-        element: HomepageFactory.create()
+        element: HomepageFactory.create(),
+        errorElement: <ErrorPage />
       },
       {
         path: Route.COLLECTIONS_BASE,
-        element: CollectionFactory.create()
+        element: CollectionFactory.create(),
+        errorElement: <ErrorPage />
       },
       {
         path: Route.COLLECTIONS,
-        element: CollectionFactory.create()
+        element: CollectionFactory.create(),
+        errorElement: <ErrorPage />
       },
       {
         path: Route.DATASETS,
-        element: DatasetFactory.create()
+        element: DatasetFactory.create(),
+        errorElement: <ErrorPage />
       },
       {
         path: Route.FILES,
-        element: FileFactory.create()
+        element: FileFactory.create(),
+        errorElement: <ErrorPage />
       },
       // 🔐 Protected routes are only accessible to authenticated users
       {
         element: <ProtectedRoute />,
+        errorElement: <ErrorPage />,
         children: [
           {
             path: Route.CREATE_COLLECTION,
-            element: CreateCollectionFactory.create()
+            element: CreateCollectionFactory.create(),
+            errorElement: <ErrorPage />
           },
           {
             path: Route.CREATE_DATASET,
-            element: CreateDatasetFactory.create()
+            element: CreateDatasetFactory.create(),
+            errorElement: <ErrorPage />
           },
           {
             path: Route.UPLOAD_DATASET_FILES,
-            element: UploadDatasetFilesFactory.create()
+            element: UploadDatasetFilesFactory.create(),
+            errorElement: <ErrorPage />
           },
           {
             path: Route.EDIT_DATASET_METADATA,
-            element: EditDatasetMetadataFactory.create()
+            element: EditDatasetMetadataFactory.create(),
+            errorElement: <ErrorPage />
           },
           {
             path: Route.ACCOUNT,
-            element: AccountFactory.create()
+            element: AccountFactory.create(),
+            errorElement: <ErrorPage />
           }
         ]
       }

--- a/src/sections/error-page/ErrorPage.module.scss
+++ b/src/sections/error-page/ErrorPage.module.scss
@@ -1,0 +1,30 @@
+@use 'sass:color';
+@import 'node_modules/@iqss/dataverse-design-system/src/lib/assets/styles/design-tokens/colors.module';
+@import 'src/assets/variables';
+
+.section-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: $main-container-available-height;
+}
+
+.middle-search-cta-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding-block: 2rem;
+}
+
+.icon-layout {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding-block: 2rem;
+}

--- a/src/sections/error-page/ErrorPage.tsx
+++ b/src/sections/error-page/ErrorPage.tsx
@@ -1,0 +1,31 @@
+import { useTranslation } from 'react-i18next'
+import { useRouteError, Link } from 'react-router-dom'
+import styles from './ErrorPage.module.scss'
+import { useErrorLogger } from './useErrorLogger'
+import { ExclamationCircle } from 'react-bootstrap-icons'
+import { useTheme } from '@iqss/dataverse-design-system'
+
+export function ErrorPage() {
+  const { t } = useTranslation('ErrorPage')
+  const error = useRouteError()
+  useErrorLogger(error)
+  const theme = useTheme()
+
+  return (
+    <section className={styles['section-wrapper']}>
+      <div className={styles['middle-search-cta-wrapper']}>
+        <div className={styles['icon-layout']}>
+          <ExclamationCircle color={theme.color.dangerColor} size={62} />
+          <div aria-label="error-page">
+            <h1>Oops,</h1>
+            <h4>something went wrong...</h4>
+          </div>
+        </div>
+
+        <Link to="/" className="btn btn-secondary">
+          {t('Back to root collection')}
+        </Link>
+      </div>
+    </section>
+  )
+}

--- a/src/sections/error-page/ErrorPage.tsx
+++ b/src/sections/error-page/ErrorPage.tsx
@@ -23,7 +23,7 @@ export function ErrorPage() {
         </div>
 
         <Link to="/" className="btn btn-secondary">
-          {t('Back to root collection')}
+          {t('Back to Dataverse Homepage')}
         </Link>
       </div>
     </section>

--- a/src/sections/error-page/useErrorLogger.tsx
+++ b/src/sections/error-page/useErrorLogger.tsx
@@ -1,0 +1,21 @@
+import { useCallback, useEffect } from 'react'
+
+const loggedErrors = new Set<string>()
+
+export function useErrorLogger(error: Error | unknown): (error: Error) => void {
+  const logErrorOnce = useCallback((err: Error): void => {
+    const errorString = String(err)
+    if (!loggedErrors.has(errorString)) {
+      loggedErrors.add(errorString)
+      console.error('Error:', err.message)
+    }
+  }, [])
+
+  useEffect(() => {
+    if (error) {
+      logErrorOnce(error as Error)
+    }
+  }, [error, logErrorOnce])
+
+  return logErrorOnce
+}

--- a/src/sections/error-page/useErrorLogger.tsx
+++ b/src/sections/error-page/useErrorLogger.tsx
@@ -3,11 +3,11 @@ import { useCallback, useEffect } from 'react'
 const loggedErrors = new Set<string>()
 
 export function useErrorLogger(error: Error | unknown): (error: Error) => void {
-  const logErrorOnce = useCallback((err: Error): void => {
-    const errorString = String(err)
+  const logErrorOnce = useCallback((err: Error & { data?: unknown }): void => {
+    const errorString = String(err.data)
     if (!loggedErrors.has(errorString)) {
       loggedErrors.add(errorString)
-      console.error('Error:', err.message)
+      console.error('Error:', err)
     }
   }, [])
 

--- a/tests/component/sections/error-page/useErrorLogger.spec.tsx
+++ b/tests/component/sections/error-page/useErrorLogger.spec.tsx
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react'
+import { useErrorLogger } from '../../../../src/sections/error-page/useErrorLogger'
+
+describe('useErrorLogger', () => {
+  beforeEach(() => {
+    cy.window().then((win) => {
+      cy.stub(win.console, 'error').as('consoleError')
+    })
+  })
+
+  it('should only log the same errors once when multiple occur, and log different errors seperately', () => {
+    const error = new Error('Test error')
+
+    cy.window().then(() => {
+      const { rerender } = renderHook(
+        ({ error }: { error: Error | null }) => useErrorLogger(error),
+        { initialProps: { error } }
+      )
+      cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', 'Test error')
+
+      cy.then(() => {
+        rerender({ error })
+      })
+      cy.get('@consoleError').should('have.been.calledOnce')
+
+      const newError = new Error('Another error')
+      cy.then(() => {
+        rerender({ error: newError })
+      })
+
+      cy.get('@consoleError').should('have.been.calledWith', 'Error:', 'Another error')
+    })
+  })
+
+  it('should not log anything if no error is provided', () => {
+    cy.window().then(() => {
+      const { rerender } = renderHook(
+        ({ error }: { error: Error | null }) => useErrorLogger(error),
+        { initialProps: { error: null } }
+      )
+
+      cy.get('@consoleError').should('not.have.been.called')
+      cy.then(() => {
+        rerender({ error: null })
+      })
+      cy.get('@consoleError').should('not.have.been.called')
+    })
+  })
+
+  it('should be used to log errors manually only once for the same error, and log different errors seperately', () => {
+    cy.window().then(() => {
+      const { result } = renderHook(() => useErrorLogger(null))
+
+      cy.then(() => {
+        result.current(new Error('Manually logged error'))
+      })
+
+      cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', 'Manually logged error')
+
+      cy.then(() => {
+        result.current(new Error('Manually logged error'))
+      })
+
+      cy.get('@consoleError').should('have.been.calledOnce')
+
+      cy.then(() => {
+        result.current(new Error('Another manually logged error'))
+      })
+
+      cy.get('@consoleError').should(
+        'have.been.calledWith',
+        'Error:',
+        'Another manually logged error'
+      )
+    })
+  })
+})

--- a/tests/component/sections/error-page/useErrorLogger.spec.tsx
+++ b/tests/component/sections/error-page/useErrorLogger.spec.tsx
@@ -17,7 +17,6 @@ describe('useErrorLogger', () => {
         { initialProps: { error } }
       )
       cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', 'Test error')
-
       cy.then(() => {
         rerender({ error })
       })
@@ -38,7 +37,6 @@ describe('useErrorLogger', () => {
         ({ error }: { error: Error | null }) => useErrorLogger(error),
         { initialProps: { error: null } }
       )
-
       cy.get('@consoleError').should('not.have.been.called')
       cy.then(() => {
         rerender({ error: null })
@@ -50,23 +48,17 @@ describe('useErrorLogger', () => {
   it('should be used to log errors manually only once for the same error, and log different errors seperately', () => {
     cy.window().then(() => {
       const { result } = renderHook(() => useErrorLogger(null))
-
       cy.then(() => {
         result.current(new Error('Manually logged error'))
       })
-
       cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', 'Manually logged error')
-
       cy.then(() => {
         result.current(new Error('Manually logged error'))
       })
-
       cy.get('@consoleError').should('have.been.calledOnce')
-
       cy.then(() => {
         result.current(new Error('Another manually logged error'))
       })
-
       cy.get('@consoleError').should(
         'have.been.calledWith',
         'Error:',

--- a/tests/component/sections/error-page/useErrorLogger.spec.tsx
+++ b/tests/component/sections/error-page/useErrorLogger.spec.tsx
@@ -1,6 +1,14 @@
 import { renderHook } from '@testing-library/react'
 import { useErrorLogger } from '../../../../src/sections/error-page/useErrorLogger'
 
+interface RouterError {
+  status: number
+  statusText: string
+  internal: boolean
+  data: string
+  error: Error
+}
+
 describe('useErrorLogger', () => {
   beforeEach(() => {
     cy.window().then((win) => {
@@ -8,33 +16,44 @@ describe('useErrorLogger', () => {
     })
   })
 
-  it('should only log the same errors once when multiple occur, and log different errors seperately', () => {
-    const error = new Error('Test error')
+  it('should only log the same errors once when multiple occur, and log different errors separately', () => {
+    const testError = {
+      status: 404,
+      statusText: 'Not Found',
+      internal: true,
+      data: 'Test Error: Not Found',
+      error: new Error('Test Error')
+    }
+
+    const newError = {
+      status: 500,
+      statusText: 'Internal Server Error',
+      internal: true,
+      data: 'Error: Another error occurred',
+      error: new Error('Another error occurred')
+    }
 
     cy.window().then(() => {
       const { rerender } = renderHook(
-        ({ error }: { error: Error | null }) => useErrorLogger(error),
-        { initialProps: { error } }
+        ({ error }: { error: Error | RouterError | null }) => useErrorLogger(error),
+        { initialProps: { error: testError } }
       )
-      cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', 'Test error')
+      cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', testError)
       cy.then(() => {
-        rerender({ error })
+        rerender({ error: testError })
       })
       cy.get('@consoleError').should('have.been.calledOnce')
-
-      const newError = new Error('Another error')
       cy.then(() => {
         rerender({ error: newError })
       })
-
-      cy.get('@consoleError').should('have.been.calledWith', 'Error:', 'Another error')
+      cy.get('@consoleError').should('have.been.calledWith', 'Error:', newError)
     })
   })
 
   it('should not log anything if no error is provided', () => {
     cy.window().then(() => {
       const { rerender } = renderHook(
-        ({ error }: { error: Error | null }) => useErrorLogger(error),
+        ({ error }: { error: Error | RouterError | null }) => useErrorLogger(error),
         { initialProps: { error: null } }
       )
       cy.get('@consoleError').should('not.have.been.called')
@@ -45,25 +64,37 @@ describe('useErrorLogger', () => {
     })
   })
 
-  it('should be used to log errors manually only once for the same error, and log different errors seperately', () => {
+  it('should be used to log errors manually only once for the same error, and log different errors separately', () => {
+    const badRequestError = {
+      status: 400,
+      statusText: 'Bad Request',
+      internal: true,
+      data: 'Error: Manually logged error',
+      error: new Error('Manually logged error')
+    }
+
+    const newError = {
+      status: 500,
+      statusText: 'Internal Server Error',
+      internal: true,
+      data: 'Error: Another error occurred',
+      error: new Error('Another error occurred')
+    }
+
     cy.window().then(() => {
       const { result } = renderHook(() => useErrorLogger(null))
       cy.then(() => {
-        result.current(new Error('Manually logged error'))
+        return result.current(badRequestError.error)
       })
-      cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', 'Manually logged error')
+      cy.get('@consoleError').should('have.been.calledOnceWith', 'Error:', badRequestError.error)
       cy.then(() => {
-        result.current(new Error('Manually logged error'))
+        result.current(badRequestError.error)
       })
       cy.get('@consoleError').should('have.been.calledOnce')
       cy.then(() => {
-        result.current(new Error('Another manually logged error'))
+        result.current(newError.error)
       })
-      cy.get('@consoleError').should(
-        'have.been.calledWith',
-        'Error:',
-        'Another manually logged error'
-      )
+      cy.get('@consoleError').should('have.been.calledWith', 'Error:', newError.error)
     })
   })
 })


### PR DESCRIPTION
## What this PR does / why we need it:

In some cases, unexpected errors may occur in the application. To manage these effectively, we need a consistent error-handling mechanism in the UI. This not only ensures that error messages are displayed to users on the page but also enables developers to track errors by viewing detailed messages in the console.

## Which issue(s) this PR closes:

- Closes #126 

## Special notes for your reviewer:
The error page didn't do component test and e2e test.
Component test:  we log errors using the hook useRouteError, which must be used within a data router. However, the component test used memory router.
e2e test: we didn't find a way to throw an error in the test environment to trigger the page. Cypress always caught the errors we throw. 

## Suggestions on how to test this:
**Step 1: Run the Development Environment**

Execute npm i.
Navigate with cd packages/design-system && npm run build.
Return with cd ../../.
Ensure you have a .env file similar to .env.example, with the variable VITE_DATAVERSE_BACKEND_URL=http://localhost:8000.
Navigate with cd dev-env.
Start the environment using ./run-env.sh unstable.
To verify the environment, visit http://localhost:8000/ and check your local Dataverse installation.

**Step 2: Test the feature**
Since we could only test it manually, please edit some codes in Dataverse-frontend repository. 
1. Inside _dataverse-frontend/src/sections/homepage/Homepage.tsx_ or any other children routes, we could add a line **throw new Error('This is an error')** before returns. 
2. check if the error messages are printed in the console
3. check if the error page UI is shown correctly, with the header and footer

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
![image](https://github.com/user-attachments/assets/08e3fd11-1dd7-4fbd-a705-2a98ff66da08)

## Is there a release notes update needed for this change?:
No
## Additional documentation:
