### PR TITLE
Pre populate depositor name and date of deposit on dataset creation

### DIFF
--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/index.tsx
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/index.tsx
@@ -2,16 +2,17 @@ import { MouseEvent, useEffect, useMemo, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { FieldErrors, FormProvider, useForm } from 'react-hook-form'
-import { useSession } from '../../../../session/SessionContext'
+import { useSession } from '@/sections/session/SessionContext'
 import { Accordion, Alert, Button } from '@iqss/dataverse-design-system'
-import { type DatasetRepository } from '../../../../../dataset/domain/repositories/DatasetRepository'
-import { type MetadataBlockInfo } from '../../../../../metadata-block-info/domain/models/MetadataBlockInfo'
+import { type DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
+import { type MetadataBlockInfo } from '@/metadata-block-info/domain/models/MetadataBlockInfo'
 import { type DatasetMetadataFormValues } from '../MetadataFieldsHelper'
 import { type DatasetMetadataFormMode } from '..'
 import { SubmissionStatus, useSubmitDataset } from '../useSubmitDataset'
 import { MetadataBlockFormFields } from './MetadataBlockFormFields'
 import { RequiredFieldText } from '../../RequiredFieldText/RequiredFieldText'
-import { SeparationLine } from '../../../layout/SeparationLine/SeparationLine'
+import { SeparationLine } from '@/sections/shared/layout/SeparationLine/SeparationLine'
+import { DateHelper } from '@/shared/helpers/DateHelper'
 import styles from './index.module.scss'
 
 interface FormProps {
@@ -64,6 +65,9 @@ export const MetadataForm = ({
       setValue('citation.datasetContact.0.datasetContactEmail', user.email, {
         shouldValidate: true
       })
+      setValue('citation.depositor', displayName)
+      setValue('citation.dateOfDeposit', DateHelper.toISO8601Format(new Date()))
+
       if (user.affiliation) {
         setValue('citation.datasetContact.0.datasetContactAffiliation', user.affiliation)
         setValue('citation.author.0.authorAffiliation', user.affiliation)

--- a/src/shared/helpers/DateHelper.ts
+++ b/src/shared/helpers/DateHelper.ts
@@ -20,4 +20,8 @@ export class DateHelper {
       day: '2-digit'
     })
   }
+
+  static toISO8601Format(date: Date): string {
+    return date.toISOString().split('T')[0]
+  }
 }

--- a/tests/component/metadata-block-info/domain/models/MetadataBlockInfoMother.ts
+++ b/tests/component/metadata-block-info/domain/models/MetadataBlockInfoMother.ts
@@ -513,6 +513,37 @@ export class MetadataBlockInfoMother {
             displayOrder: 34,
             typeClass: 'primitive',
             displayOnCreate: true
+          },
+          depositor: {
+            name: 'depositor',
+            displayName: 'Depositor',
+            displayOnCreate: true,
+            title: 'Depositor',
+            type: 'TEXT',
+            typeClass: 'primitive',
+            watermark: '1) FamilyName, GivenName or 2) Organization',
+            description:
+              'The entity, such as a person or organization, that deposited the Dataset in the repository',
+            multiple: false,
+            isControlledVocabulary: false,
+            displayFormat: '',
+            displayOrder: 58,
+            isRequired: false
+          },
+          dateOfDeposit: {
+            name: 'dateOfDeposit',
+            displayName: 'Deposit Date',
+            displayOnCreate: true,
+            title: 'Deposit Date',
+            type: 'DATE',
+            typeClass: 'primitive',
+            watermark: 'YYYY-MM-DD',
+            description: 'The date when the Dataset was deposited into the repository',
+            multiple: false,
+            isControlledVocabulary: false,
+            displayFormat: '',
+            displayOrder: 59,
+            isRequired: false
           }
         }
       },

--- a/tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
+++ b/tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
@@ -1,9 +1,10 @@
-import { MetadataBlockName } from '../../../../../src/dataset/domain/models/Dataset'
-import { DatasetRepository } from '../../../../../src/dataset/domain/repositories/DatasetRepository'
-import { TypeMetadataFieldOptions } from '../../../../../src/metadata-block-info/domain/models/MetadataBlockInfo'
-import { MetadataBlockInfoRepository } from '../../../../../src/metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
-import { DatasetMetadataForm } from '../../../../../src/sections/shared/form/DatasetMetadataForm'
-import { UserRepository } from '../../../../../src/users/domain/repositories/UserRepository'
+import { DateHelper } from '@/shared/helpers/DateHelper'
+import { MetadataBlockName } from '@/dataset/domain/models/Dataset'
+import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
+import { TypeMetadataFieldOptions } from '@/metadata-block-info/domain/models/MetadataBlockInfo'
+import { MetadataBlockInfoRepository } from '@/metadata-block-info/domain/repositories/MetadataBlockInfoRepository'
+import { DatasetMetadataForm } from '@/sections/shared/form/DatasetMetadataForm'
+import { UserRepository } from '@/users/domain/repositories/UserRepository'
 import { DatasetMother } from '../../../dataset/domain/models/DatasetMother'
 import { MetadataBlockInfoMother } from '../../../metadata-block-info/domain/models/MetadataBlockInfoMother'
 import { UserMother } from '../../../users/domain/models/UserMother'
@@ -1446,6 +1447,8 @@ describe('DatasetMetadataForm', () => {
 
   it('pre-fills the form with user data', () => {
     const displayName = `${testUser.lastName}, ${testUser.firstName}`
+    const expectedDepositDate = DateHelper.toISO8601Format(new Date())
+
     cy.mountAuthenticated(
       <DatasetMetadataForm
         mode="create"
@@ -1475,6 +1478,8 @@ describe('DatasetMetadataForm', () => {
         cy.findByLabelText(/^Affiliation/i).should('have.value', testUser.affiliation)
       })
     cy.findByLabelText(/^E-mail/i).should('have.value', testUser.email)
+    cy.findByLabelText(/^Depositor/i).should('have.value', displayName)
+    cy.findByLabelText(/^Deposit Date/i).should('have.value', expectedDepositDate)
   })
 
   it('shows the skeleton while loading', () => {


### PR DESCRIPTION
## What this PR does / why we need it:
Prepopulates deposit name and deposit date on dataset creation form.

## Which issue(s) this PR closes:

- Closes #510 

## Suggestions on how to test this:
**Step 1: Run the Development Environment**
1. Execute `npm i`.
2. Navigate with `cd packages/design-system && npm run build`.
3. Return with `cd ../../`.
4. Ensure you have a `.env` file similar to `.env.example`, with the variable `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000`.
5. Navigate with `cd dev-env`.
6. Start the environment using `./run-env.sh unstable`.
7. To verify the environment, visit <http://localhost:8000> and check your local Dataverse installation.

**Step 2: Test the feature**

1. Go to the view to create a new dataset.
2. Depositor Name field should be pre-filled with user name and Deposit Date with the current date.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
N/A
