### PR TITLE
API Token use cases integration for account page

### DIFF
--- a/src/sections/account/Account.tsx
+++ b/src/sections/account/Account.tsx
@@ -6,6 +6,11 @@ import { AccountHelper, AccountPanelTabKey } from './AccountHelper'
 import { ApiTokenSection } from './api-token-section/ApiTokenSection'
 import { BreadcrumbsGenerator } from '../shared/hierarchy/BreadcrumbsGenerator'
 import styles from './Account.module.scss'
+import {
+  DvObjectType,
+  UpwardHierarchyNode
+} from '../../shared/hierarchy/domain/models/UpwardHierarchyNode'
+import { ROOT_COLLECTION_ALIAS } from '../../collection/domain/models/Collection'
 import { ApiTokenInfoJSDataverseRepository } from '@/users/infrastructure/repositories/ApiTokenInfoJSDataverseRepository'
 
 const tabsKeys = AccountHelper.ACCOUNT_PANEL_TABS_KEYS

--- a/src/sections/account/Account.tsx
+++ b/src/sections/account/Account.tsx
@@ -6,11 +6,7 @@ import { AccountHelper, AccountPanelTabKey } from './AccountHelper'
 import { ApiTokenSection } from './api-token-section/ApiTokenSection'
 import { BreadcrumbsGenerator } from '../shared/hierarchy/BreadcrumbsGenerator'
 import styles from './Account.module.scss'
-import {
-  DvObjectType,
-  UpwardHierarchyNode
-} from '../../shared/hierarchy/domain/models/UpwardHierarchyNode'
-import { ROOT_COLLECTION_ALIAS } from '../../collection/domain/models/Collection'
+import { ApiTokenInfoJSDataverseRepository } from '@/users/infrastructure/repositories/ApiTokenInfoJSDataverseRepository'
 
 const tabsKeys = AccountHelper.ACCOUNT_PANEL_TABS_KEYS
 
@@ -21,6 +17,7 @@ interface AccountProps {
 export const Account = ({ defaultActiveTabKey }: AccountProps) => {
   const { t } = useTranslation('account')
   const { setIsLoading } = useLoading()
+  const repository = new ApiTokenInfoJSDataverseRepository()
 
   const rootHierarchy = new UpwardHierarchyNode(
     'Root',
@@ -55,7 +52,7 @@ export const Account = ({ defaultActiveTabKey }: AccountProps) => {
         </Tabs.Tab>
         <Tabs.Tab eventKey={tabsKeys.apiToken} title={t('tabs.apiToken')}>
           <div className={styles['tab-container']}>
-            <ApiTokenSection />
+            <ApiTokenSection repository={repository} />
           </div>
         </Tabs.Tab>
       </Tabs>

--- a/src/sections/account/api-token-section/ApiTokenSection.tsx
+++ b/src/sections/account/api-token-section/ApiTokenSection.tsx
@@ -2,19 +2,77 @@ import { Trans, useTranslation } from 'react-i18next'
 import { Button } from '@iqss/dataverse-design-system'
 import accountStyles from '../Account.module.scss'
 import styles from './ApiTokenSection.module.scss'
+import { useEffect, useState } from 'react'
+import { Alert } from '@iqss/dataverse-design-system'
+import { TokenInfo } from '@/users/domain/models/TokenInfo'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+import ApiTokenSectionSkeleton from './ApiTokenSectionSkeleton'
+import { useGetApiToken } from './useGetCurrentApiToken'
+import { useRecreateApiToken } from './useRecreateApiToken'
+import { useRevokeApiToken } from './useRevokeApiToken'
+interface ApiTokenSectionProps {
+  repository: ApiTokenInfoRepository
+}
 
-export const ApiTokenSection = () => {
+export const ApiTokenSection = ({ repository }: ApiTokenSectionProps) => {
   const { t } = useTranslation('account', { keyPrefix: 'apiToken' })
+  const [currentApiTokenInfo, setCurrentApiTokenInfo] = useState<TokenInfo>()
 
-  // TODO: When we have the use cases we need to mock stub to unit test this with or without token
-  const apiToken = '999fff-666rrr-this-is-not-a-real-token-123456'
-  const expirationDate = '2025-09-04'
+  const { error, apiTokenInfo, isLoading } = useGetApiToken(repository)
+
+  const getError =
+    error !== 'There was an error when reading the resource. Reason was: [404] Token not found.'
+      ? error
+      : null
+
+  useEffect(() => {
+    setCurrentApiTokenInfo(apiTokenInfo)
+  }, [apiTokenInfo])
+
+  const {
+    initiateRecreateToken,
+    isRecreating,
+    error: recreatingError,
+    apiTokenInfo: updatedTokenInfo
+  } = useRecreateApiToken(repository)
+
+  useEffect(() => {
+    if (updatedTokenInfo) {
+      setCurrentApiTokenInfo(updatedTokenInfo)
+    }
+  }, [updatedTokenInfo])
+
+  const handleCreateToken = () => {
+    initiateRecreateToken()
+  }
+
+  const { revokeToken, isRevoking, error: revokingError } = useRevokeApiToken(repository)
+
+  const handleRevokeToken = async () => {
+    await revokeToken()
+    setCurrentApiTokenInfo({
+      apiToken: '',
+      expirationDate: ''
+    })
+  }
 
   const copyToClipboard = () => {
-    navigator.clipboard.writeText(apiToken).catch(
+    navigator.clipboard.writeText(apiTokenInfo.apiToken).catch(
       /* istanbul ignore next */ (error) => {
         console.error('Failed to copy text:', error)
       }
+    )
+  }
+
+  if (isLoading || isRecreating || isRevoking) {
+    return <ApiTokenSectionSkeleton data-testid="loadingSkeleton" />
+  }
+
+  if (getError || recreatingError || revokingError) {
+    return (
+      <Alert variant="danger" dismissible={false}>
+        {getError || recreatingError || revokingError}
+      </Alert>
     )
   }
 
@@ -35,22 +93,25 @@ export const ApiTokenSection = () => {
           }}
         />
       </p>
-      {apiToken ? (
+      {currentApiTokenInfo?.apiToken ? (
         <>
           <p className={styles['exp-date']}>
-            {t('expirationDate')} <time dateTime={expirationDate}>{expirationDate}</time>
+            {t('expirationDate')}{' '}
+            <time data-testid="expiration-date" dateTime={currentApiTokenInfo.expirationDate}>
+              {currentApiTokenInfo.expirationDate}
+            </time>
           </p>
           <div className={styles['api-token']}>
-            <code data-testid="api-token">{apiToken}</code>
+            <code data-testid="api-token">{currentApiTokenInfo.apiToken}</code>
           </div>
           <div className={styles['btns-wrapper']} role="group">
             <Button variant="secondary" onClick={copyToClipboard}>
               {t('copyToClipboard')}
             </Button>
-            <Button variant="secondary" disabled>
+            <Button variant="secondary" onClick={handleCreateToken}>
               {t('recreateToken')}
             </Button>
-            <Button variant="secondary" disabled>
+            <Button variant="secondary" onClick={handleRevokeToken}>
               {t('revokeToken')}
             </Button>
           </div>
@@ -60,8 +121,8 @@ export const ApiTokenSection = () => {
           <div className={styles['api-token']}>
             <code data-testid="api-token">{t('notCreatedApiToken')}</code>
           </div>
-          <div className={styles['btns-wrapper']} role="group">
-            <Button variant="secondary" disabled>
+          <div className={styles['btns-wrapper']} data-testid="noApiToken" role="group">
+            <Button data-testid="createApi" variant="secondary" onClick={handleCreateToken}>
               {t('createToken')}
             </Button>
           </div>

--- a/src/sections/account/api-token-section/ApiTokenSectionSkeleton.tsx
+++ b/src/sections/account/api-token-section/ApiTokenSectionSkeleton.tsx
@@ -1,0 +1,51 @@
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
+import 'react-loading-skeleton/dist/skeleton.css'
+import { Trans, useTranslation } from 'react-i18next'
+import accountStyles from '../Account.module.scss'
+import { Button } from '@iqss/dataverse-design-system'
+import styles from './ApiTokenSection.module.scss'
+
+const ApiTokenSectionSkeleton = () => {
+  const { t } = useTranslation('account', { keyPrefix: 'apiToken' })
+
+  return (
+    <>
+      <p className={accountStyles['helper-text']}>
+        <Trans
+          t={t}
+          i18nKey="helperText"
+          components={{
+            anchor: (
+              <a
+                href="http://guides.dataverse.org/en/latest/api"
+                target="_blank"
+                rel="noreferrer"
+              />
+            )
+          }}
+        />
+      </p>
+      <SkeletonTheme>
+        <div data-testid="loadingSkeleton">
+          <p className={styles['exp-date']}>
+            {t('expirationDate')}{' '}
+            <time data-testid="expiration-date">
+              <Skeleton width={100} />
+            </time>
+          </p>
+          <div className={styles['api-token']}>
+            <code data-testid="api-token">
+              <Skeleton width={350} />
+            </code>
+          </div>
+          <div className={styles['btns-wrapper']} role="group">
+            <Button variant="secondary">{t('copyToClipboard')}</Button>
+            <Button variant="secondary">{t('recreateToken')}</Button>
+            <Button variant="secondary">{t('revokeToken')}</Button>
+          </div>
+        </div>
+      </SkeletonTheme>
+    </>
+  )
+}
+export default ApiTokenSectionSkeleton

--- a/src/sections/account/api-token-section/useGetCurrentApiToken.tsx
+++ b/src/sections/account/api-token-section/useGetCurrentApiToken.tsx
@@ -1,0 +1,43 @@
+import { useState, useEffect, useCallback } from 'react'
+import { TokenInfo } from '@/users/domain/models/TokenInfo'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+import { getCurrentApiToken } from '@/users/domain/useCases/getCurrentApiToken'
+
+interface UseGetApiTokenResult {
+  apiTokenInfo: TokenInfo
+  isLoading: boolean
+  error: string | null
+}
+
+export const useGetApiToken = (repository: ApiTokenInfoRepository): UseGetApiTokenResult => {
+  const [apiTokenInfo, setApiTokenInfo] = useState<TokenInfo>({
+    apiToken: '',
+    expirationDate: ''
+  })
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchTokenInfo = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      const tokenInfo = await getCurrentApiToken(repository)
+      setApiTokenInfo({
+        apiToken: tokenInfo.apiToken,
+        expirationDate: tokenInfo.expirationDate
+      })
+      setError(null)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch API token.'
+      console.error(errorMessage)
+      setError(errorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [repository])
+
+  useEffect(() => {
+    void fetchTokenInfo()
+  }, [fetchTokenInfo])
+
+  return { error, apiTokenInfo, isLoading }
+}

--- a/src/sections/account/api-token-section/useRecreateApiToken.tsx
+++ b/src/sections/account/api-token-section/useRecreateApiToken.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react'
+import { recreateApiToken } from '@/users/domain/useCases/recreateApiToken'
+import { TokenInfo } from '@/users/domain/models/TokenInfo'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+
+interface UseRecreateApiTokenResult {
+  initiateRecreateToken: () => void
+  isRecreating: boolean
+  error: string | null
+  apiTokenInfo: TokenInfo | null
+}
+
+export const useRecreateApiToken = (
+  repository: ApiTokenInfoRepository
+): UseRecreateApiTokenResult => {
+  const [isRecreating, setIsRecreating] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+  const [apiTokenInfo, setApiTokenInfo] = useState<TokenInfo | null>(null)
+  const [shouldRecreate, setShouldRecreate] = useState<boolean>(false)
+
+  const initiateRecreateToken = () => {
+    setShouldRecreate(true)
+  }
+
+  useEffect(() => {
+    const recreateToken = async () => {
+      setIsRecreating(true)
+      setError(null)
+
+      try {
+        const newTokenInfo = await recreateApiToken(repository)
+        setApiTokenInfo(newTokenInfo)
+      } catch (err) {
+        console.error('Error recreating token:', err)
+        setError('Failed to recreate API token.')
+      } finally {
+        setIsRecreating(false)
+        setShouldRecreate(false)
+      }
+    }
+    if (shouldRecreate) {
+      void recreateToken()
+    }
+  }, [shouldRecreate, repository])
+
+  return { initiateRecreateToken, isRecreating, error, apiTokenInfo }
+}

--- a/src/sections/account/api-token-section/useRevokeApiToken.tsx
+++ b/src/sections/account/api-token-section/useRevokeApiToken.tsx
@@ -1,0 +1,30 @@
+import { useState, useCallback } from 'react'
+import { revokeApiToken } from '@/users/domain/useCases/revokeApiToken'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+
+interface UseRevokeApiTokenResult {
+  revokeToken: () => Promise<void>
+  isRevoking: boolean
+  error: string | null
+}
+
+export const useRevokeApiToken = (repository: ApiTokenInfoRepository): UseRevokeApiTokenResult => {
+  const [isRevoking, setIsRevoking] = useState<boolean>(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const revokeToken = useCallback(async () => {
+    setIsRevoking(true)
+    setError(null)
+
+    try {
+      await revokeApiToken(repository)
+    } catch (err) {
+      console.error('There was an error revoking Api token:', err)
+      setError('Failed to revoke API token.')
+    } finally {
+      setIsRevoking(false)
+    }
+  }, [repository])
+
+  return { revokeToken, isRevoking, error }
+}

--- a/src/shared/helpers/DateHelper.ts
+++ b/src/shared/helpers/DateHelper.ts
@@ -20,4 +20,7 @@ export class DateHelper {
       day: '2-digit'
     })
   }
+  static toISO8601Format(date: Date): string {
+    return date.toISOString().split('T')[0]
+  }
 }

--- a/src/users/domain/models/TokenInfo.ts
+++ b/src/users/domain/models/TokenInfo.ts
@@ -1,0 +1,4 @@
+export interface TokenInfo {
+  apiToken: string
+  expirationDate: string
+}

--- a/src/users/domain/repositories/ApiTokenInfoRepository.tsx
+++ b/src/users/domain/repositories/ApiTokenInfoRepository.tsx
@@ -1,0 +1,7 @@
+import { TokenInfo } from '../.././domain/models/TokenInfo'
+
+export interface ApiTokenInfoRepository {
+  getCurrentApiToken(): Promise<TokenInfo>
+  recreateApiToken(): Promise<TokenInfo>
+  deleteApiToken(): Promise<void>
+}

--- a/src/users/domain/useCases/getCurrentApiToken.ts
+++ b/src/users/domain/useCases/getCurrentApiToken.ts
@@ -1,0 +1,6 @@
+import { TokenInfo } from '../models/TokenInfo'
+import { ApiTokenInfoRepository } from '../repositories/ApiTokenInfoRepository'
+
+export function getCurrentApiToken(apiTokenRepository: ApiTokenInfoRepository): Promise<TokenInfo> {
+  return apiTokenRepository.getCurrentApiToken()
+}

--- a/src/users/domain/useCases/recreateApiToken.ts
+++ b/src/users/domain/useCases/recreateApiToken.ts
@@ -1,0 +1,6 @@
+import { TokenInfo } from '../models/TokenInfo'
+import { ApiTokenInfoRepository } from '../repositories/ApiTokenInfoRepository'
+
+export function recreateApiToken(apiTokenRepository: ApiTokenInfoRepository): Promise<TokenInfo> {
+  return apiTokenRepository.recreateApiToken()
+}

--- a/src/users/domain/useCases/revokeApiToken.ts
+++ b/src/users/domain/useCases/revokeApiToken.ts
@@ -1,0 +1,5 @@
+import { ApiTokenInfoRepository } from '../repositories/ApiTokenInfoRepository'
+
+export function revokeApiToken(apiTokenRepository: ApiTokenInfoRepository): Promise<void> {
+  return apiTokenRepository.deleteApiToken()
+}

--- a/src/users/infrastructure/repositories/ApiTokenInfoJSDataverseRepository.tsx
+++ b/src/users/infrastructure/repositories/ApiTokenInfoJSDataverseRepository.tsx
@@ -1,0 +1,37 @@
+import { TokenInfo } from '../../domain/models/TokenInfo'
+import { ApiTokenInfoRepository } from '../../domain/repositories/ApiTokenInfoRepository'
+import { DateHelper } from '@/shared/helpers/DateHelper'
+import {
+  getCurrentApiToken,
+  recreateCurrentApiToken,
+  deleteCurrentApiToken
+} from '@iqss/dataverse-client-javascript'
+
+interface ApiTokenInfoPayload {
+  apiToken: string
+  expirationDate: Date
+}
+
+export class ApiTokenInfoJSDataverseRepository implements ApiTokenInfoRepository {
+  getCurrentApiToken(): Promise<TokenInfo> {
+    return getCurrentApiToken.execute().then((apiTokenInfo: ApiTokenInfoPayload) => {
+      return {
+        apiToken: apiTokenInfo.apiToken,
+        expirationDate: DateHelper.toISO8601Format(apiTokenInfo.expirationDate)
+      }
+    })
+  }
+
+  recreateApiToken(): Promise<TokenInfo> {
+    return recreateCurrentApiToken.execute().then((apiTokenInfo: ApiTokenInfoPayload) => {
+      return {
+        apiToken: apiTokenInfo.apiToken,
+        expirationDate: DateHelper.toISO8601Format(apiTokenInfo.expirationDate)
+      }
+    })
+  }
+
+  deleteApiToken(): Promise<void> {
+    return deleteCurrentApiToken.execute()
+  }
+}

--- a/tests/component/sections/account/ApiTokenSection.spec.tsx
+++ b/tests/component/sections/account/ApiTokenSection.spec.tsx
@@ -1,8 +1,37 @@
 import { ApiTokenSection } from '../../../../src/sections/account/api-token-section/ApiTokenSection'
-
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
 describe('ApiTokenSection', () => {
+  const mockApiTokenInfo = {
+    apiToken: 'mocked-api',
+    expirationDate: '2024-12-31'
+  }
+  const newMockApiTokenInfo = {
+    apiToken: 'new-mocked-api',
+    expirationDate: '2025-12-31'
+  }
+
+  let apiTokenRepository: ApiTokenInfoRepository
+
   beforeEach(() => {
-    cy.mountAuthenticated(<ApiTokenSection />)
+    apiTokenRepository = {
+      getCurrentApiToken: cy.stub().resolves(mockApiTokenInfo),
+      recreateApiToken: cy.stub().resolves(mockApiTokenInfo),
+      deleteApiToken: cy.stub().resolves()
+    }
+    cy.mountAuthenticated(<ApiTokenSection repository={apiTokenRepository} />)
+  })
+
+  it('should show the loading skeleton while fetching the token', () => {
+    // Simulate a delayed API response
+    apiTokenRepository.getCurrentApiToken = cy.stub().callsFake(() => {
+      return Cypress.Promise.delay(500).then(() => mockApiTokenInfo)
+    })
+
+    cy.mount(<ApiTokenSection repository={apiTokenRepository} />)
+    cy.get('[data-testid="loadingSkeleton"]').should('exist') // Verify loading skeleton exists
+
+    cy.wait(500) // Wait for the delay to finish
+    cy.get('[data-testid="loadingSkeleton"]').should('not.exist') // Verify skeleton is gone
   })
 
   it('should copy the api token to the clipboard', () => {
@@ -20,5 +49,27 @@ describe('ApiTokenSection', () => {
     })
   })
 
-  // TODO: When we get the api token from the use case, we could mock the response and test more things.
+  it('should fetch and display the current API token', () => {
+    cy.get('[data-testid="api-token"]').should('contain.text', mockApiTokenInfo.apiToken)
+    cy.get('[data-testid="expiration-date"]').should(
+      'contain.text',
+      mockApiTokenInfo.expirationDate
+    )
+  })
+
+  it('should recreate and display a new API token', () => {
+    apiTokenRepository.recreateApiToken = cy.stub().resolves(newMockApiTokenInfo)
+    cy.get('button').contains('Recreate Token').click()
+    cy.get('[data-testid="api-token"]').should('contain.text', newMockApiTokenInfo.apiToken)
+    cy.get('[data-testid="expiration-date"]').should(
+      'contain.text',
+      newMockApiTokenInfo.expirationDate
+    )
+  })
+
+  it('should revoke the API token and show the create token state when there is no api token', () => {
+    cy.get('button').contains('Revoke Token').click()
+    cy.get('[data-testid="noApiToken"]').should('exist')
+    cy.get('button').contains('Create Token').should('exist')
+  })
 })

--- a/tests/component/sections/account/useGetApiTokenInfo.spec.tsx
+++ b/tests/component/sections/account/useGetApiTokenInfo.spec.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+import { useGetApiToken } from '@/sections/account/api-token-section/useGetCurrentApiToken'
+import { TokenInfo } from '@/users/domain/models/TokenInfo'
+
+describe('useGetApiToken', () => {
+  let apiTokenInfoRepository: ApiTokenInfoRepository
+
+  const mockTokenInfo: TokenInfo = {
+    apiToken: 'mocked-api-token',
+    expirationDate: '2024-12-31'
+  }
+
+  beforeEach(() => {
+    apiTokenInfoRepository = {} as ApiTokenInfoRepository
+  })
+
+  it('should return the API token correctly', async () => {
+    apiTokenInfoRepository.getCurrentApiToken = cy.stub().resolves(mockTokenInfo)
+
+    const { result } = renderHook(() => useGetApiToken(apiTokenInfoRepository))
+    await act(() => {
+      expect(result.current.isLoading).to.equal(true)
+      expect(result.current.error).to.equal(null)
+      return expect(result.current.apiTokenInfo).to.deep.equal({
+        apiToken: '',
+        expirationDate: ''
+      })
+    })
+
+    await act(() => {
+      expect(result.current.isLoading).to.equal(false)
+      expect(result.current.error).to.equal(null)
+      return expect(result.current.apiTokenInfo).to.deep.equal(mockTokenInfo)
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('should handle error correctly when an error is thrown', async () => {
+      apiTokenInfoRepository.getCurrentApiToken = cy.stub().rejects(new Error('API Error'))
+
+      const { result } = renderHook(() => useGetApiToken(apiTokenInfoRepository))
+
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(true)
+        return expect(result.current.error).to.equal(null)
+      })
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(false)
+        return expect(result.current.error).to.equal('API Error')
+      })
+    })
+
+    it('should return correct error message when there is not an error type catched', async () => {
+      apiTokenInfoRepository.getCurrentApiToken = cy.stub().rejects('Error message')
+
+      const { result } = renderHook(() => useGetApiToken(apiTokenInfoRepository))
+
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(true)
+        return expect(result.current.error).to.equal(null)
+      })
+      await act(() => {
+        expect(result.current.isLoading).to.deep.equal(false)
+        return expect(result.current.error).to.deep.equal('Failed to fetch API token.')
+      })
+    })
+  })
+})

--- a/tests/component/sections/account/useRecreateApiTokenInfo.spec.tsx
+++ b/tests/component/sections/account/useRecreateApiTokenInfo.spec.tsx
@@ -1,0 +1,96 @@
+import { act, renderHook } from '@testing-library/react'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+import { useRecreateApiToken } from '@/sections/account/api-token-section/useRecreateApiToken'
+import { TokenInfo } from '@/users/domain/models/TokenInfo'
+
+describe('useRecreateApiToken', () => {
+  let apiTokenInfoRepository: ApiTokenInfoRepository
+
+  const mockTokenInfo: TokenInfo = {
+    apiToken: 'new-mocked-api-token',
+    expirationDate: '2024-12-31'
+  }
+
+  beforeEach(() => {
+    apiTokenInfoRepository = {} as ApiTokenInfoRepository
+  })
+
+  it('should return the API token correctly', async () => {
+    apiTokenInfoRepository.recreateApiToken = cy.stub().resolves(mockTokenInfo)
+
+    const { result } = renderHook(() => useRecreateApiToken(apiTokenInfoRepository))
+
+    expect(result.current.isRecreating).to.equal(false)
+    expect(result.current.error).to.equal(null)
+    expect(result.current.apiTokenInfo).to.deep.equal(null)
+
+    act(() => {
+      result.current.initiateRecreateToken()
+    })
+
+    await act(() => {
+      expect(result.current.isRecreating).to.equal(true)
+      expect(result.current.error).to.equal(null)
+      return expect(result.current.apiTokenInfo).to.equal(null)
+    })
+
+    await act(() => {
+      expect(result.current.isRecreating).to.equal(false)
+      expect(result.current.error).to.equal(null)
+      return expect(result.current.apiTokenInfo).to.deep.equal(mockTokenInfo)
+    })
+  })
+
+  describe('Error Handling', () => {
+    it('should handle error correctly when an error is thrown', async () => {
+      const errorMessage = 'Failed to recreate API token.'
+      apiTokenInfoRepository.recreateApiToken = cy.stub().rejects(new Error(errorMessage))
+
+      const { result } = renderHook(() => useRecreateApiToken(apiTokenInfoRepository))
+
+      expect(result.current.isRecreating).to.equal(false)
+      expect(result.current.error).to.equal(null)
+      expect(result.current.apiTokenInfo).to.equal(null)
+
+      act(() => {
+        result.current.initiateRecreateToken()
+      })
+
+      await act(() => {
+        expect(result.current.isRecreating).to.equal(true)
+        return expect(result.current.error).to.equal(null)
+      })
+
+      await act(() => {
+        expect(result.current.isRecreating).to.equal(false)
+        expect(result.current.error).to.equal('Failed to recreate API token.')
+        return expect(result.current.apiTokenInfo).to.equal(null)
+      })
+    })
+
+    it('should return correct error message when there is not an error type catched', async () => {
+      apiTokenInfoRepository.recreateApiToken = cy.stub().rejects('Unexpected error message')
+
+      const { result } = renderHook(() => useRecreateApiToken(apiTokenInfoRepository))
+
+      expect(result.current.isRecreating).to.equal(false)
+      expect(result.current.error).to.equal(null)
+      expect(result.current.apiTokenInfo).to.equal(null)
+
+      act(() => {
+        result.current.initiateRecreateToken()
+      })
+
+      await act(() => {
+        expect(result.current.isRecreating).to.equal(true)
+        return expect(result.current.error).to.equal(null)
+      })
+
+      await act(() => {
+        expect(result.current.isRecreating).to.equal(false)
+        expect(result.current.error).to.equal('Failed to recreate API token.')
+        return expect(result.current.apiTokenInfo).to.equal(null)
+      })
+    })
+  })
+})

--- a/tests/component/sections/account/useRevokeApiTokenInfo.spec.tsx
+++ b/tests/component/sections/account/useRevokeApiTokenInfo.spec.tsx
@@ -1,0 +1,56 @@
+import { act, renderHook } from '@testing-library/react'
+import { ApiTokenInfoRepository } from '@/users/domain/repositories/ApiTokenInfoRepository'
+import { useRevokeApiToken } from '@/sections/account/api-token-section/useRevokeApiToken'
+
+describe('useRevokeApiToken', () => {
+  let apiTokenInfoRepository: ApiTokenInfoRepository
+
+  beforeEach(() => {
+    apiTokenInfoRepository = {} as ApiTokenInfoRepository
+  })
+
+  it('should revoke the API token successfully', async () => {
+    apiTokenInfoRepository.deleteApiToken = cy.stub().resolves()
+
+    const { result } = renderHook(() => useRevokeApiToken(apiTokenInfoRepository))
+
+    expect(result.current.isRevoking).to.equal(false)
+    expect(result.current.error).to.equal(null)
+
+    await act(async () => {
+      await result.current.revokeToken()
+    })
+
+    expect(result.current.isRevoking).to.equal(false)
+    expect(result.current.error).to.equal(null)
+  })
+
+  describe('Error Handling', () => {
+    it('should handle error correctly when an error is thrown', async () => {
+      const errorMessage = 'API token revocation failed.'
+      apiTokenInfoRepository.deleteApiToken = cy.stub().rejects(new Error(errorMessage))
+
+      const { result } = renderHook(() => useRevokeApiToken(apiTokenInfoRepository))
+
+      await act(async () => {
+        await result.current.revokeToken()
+      })
+
+      expect(result.current.isRevoking).to.equal(false)
+      expect(result.current.error).to.equal('Failed to revoke API token.')
+    })
+
+    it('should handle non-error rejection gracefully', async () => {
+      apiTokenInfoRepository.deleteApiToken = cy.stub().rejects('Unexpected error')
+
+      const { result } = renderHook(() => useRevokeApiToken(apiTokenInfoRepository))
+
+      await act(async () => {
+        await result.current.revokeToken()
+      })
+
+      expect(result.current.isRevoking).to.equal(false)
+      expect(result.current.error).to.equal('Failed to revoke API token.')
+    })
+  })
+})

--- a/tests/e2e-integration/integration/account/ApiTokenInfoJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/account/ApiTokenInfoJSDataverseRepository.spec.ts
@@ -1,0 +1,36 @@
+import chai from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { ApiTokenInfoJSDataverseRepository } from '../../../../src/users/infrastructure/repositories/ApiTokenInfoJSDataverseRepository'
+
+import { TestsUtils } from '../../shared/TestsUtils'
+
+chai.use(chaiAsPromised)
+const expect = chai.expect
+
+const apiTokenInfoRepository = new ApiTokenInfoJSDataverseRepository()
+describe('API Token Info JSDataverse Repository', () => {
+  before(() => TestsUtils.setup())
+  beforeEach(() => TestsUtils.login())
+
+  it('create or recreate the API token and return the new token info', async () => {
+    const recreatedTokenInfo = await apiTokenInfoRepository.recreateApiToken()
+    if (!recreatedTokenInfo) {
+      throw new Error('Failed to recreate API token')
+    }
+    expect(recreatedTokenInfo).to.have.property('apiToken').that.is.a('string')
+    expect(recreatedTokenInfo).to.have.property('expirationDate').that.is.a('string')
+  })
+
+  it('fetche the current API token', async () => {
+    const tokenInfo = await apiTokenInfoRepository.getCurrentApiToken()
+    if (!tokenInfo) {
+      throw new Error('API Token not found')
+    }
+    expect(tokenInfo).to.have.property('apiToken').that.is.a('string')
+    expect(tokenInfo).to.have.property('expirationDate').that.is.a('string')
+  })
+
+  it('revoke the API token', async () => {
+    await expect(apiTokenInfoRepository.deleteApiToken()).to.be.fulfilled
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:
Integrate the API Token account page UI with the new Api token management use cases

-  Read current API token
-  Recreate API Token
-  Revoke API Token

## Which issue(s) this PR closes:

- Closes #505 #506 

## Special notes for your reviewer:

## Suggestions on how to test this:
Step 1: Run the Development Environment
1. Execute npm i.
2. Navigate with cd packages/design-system && npm run build.
3. Return with cd ../../.
4. Ensure you have a .env file similar to .env.example, with the variable VITE_DATAVERSE_BACKEND_URL=http://localhost:8000.
5. Navigate with cd dev-env.
6. Start the environment using ./run-env.sh unstable.
7. To verify the environment, visit http://localhost:8000/ and check your local Dataverse installation.

Step 2: Test the feature
1. Go to http://localhost:8000/spa/account?tab=apiToken
2. test recreate button, which should gives a new api token, and an expiration date with the right format. Refresh to test if the result is consistent 
3. test revoke button, which should revoke the api token, and then show the page said "no api token available". Refresh to test if the result is consistent 
4. test the create button in the page, which should gives you a new api token and back to another page. Refresh to test if the result is consistent 

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
![image](https://github.com/user-attachments/assets/555edc15-2f60-4834-b853-49b7aff714bf)
![image](https://github.com/user-attachments/assets/24589ca6-d8ce-4b51-b980-a3e27669dc42)

## Is there a release notes update needed for this change?:

## Additional documentation:
