### PR TITLE
Fix/528 Use fields from parent - Create Collection form behavior

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.2",
+        "@iqss/dataverse-client-javascript": "2.0.0-alpha.4",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3674,9 +3674,10 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.2",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.2/6f926581c976bbf8649053323e1c82a729d56706",
-      "integrity": "sha512-bJgGirBFr4gL+pVFz0zNAlMovxWHJMi9RCN9v6lnpkLU+fKHUTeMkEgQdGxoA0lI3V8cvA+e2xcpoi7/24vRKg==",
+      "version": "2.0.0-alpha.4",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.4/10ab7e0ed2a31a09b1b32d27521b96f84ef50f4f",
+      "integrity": "sha512-SJdkBIks+yjJxEVw8G7sf4YY2Bujl+8vOD+fZqt2qhIGmyPSlj9ld0APnYyoVX6lI8lGsREHZzYYjzeAmYfxhw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",
         "@types/turndown": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.2",
+    "@iqss/dataverse-client-javascript": "2.0.0-alpha.4",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/sections/create-collection/collection-form/metadata-fields-section/fields-from-parent-checkbox/FieldsFromParentCheckbox.tsx
+++ b/src/sections/create-collection/collection-form/metadata-fields-section/fields-from-parent-checkbox/FieldsFromParentCheckbox.tsx
@@ -2,7 +2,6 @@ import { ChangeEvent, useId, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Controller, UseControllerProps, useFormContext, useWatch } from 'react-hook-form'
 import { Form } from '@iqss/dataverse-design-system'
-import { MetadataBlockName } from '../../../../../metadata-block-info/domain/models/MetadataBlockInfo'
 import { ConfirmResetModificationsModal } from './ConfirmResetModificationsModal'
 import {
   CollectionFormData,
@@ -10,15 +9,6 @@ import {
   METADATA_BLOCKS_NAMES_GROUPER,
   USE_FIELDS_FROM_PARENT
 } from '../../CollectionForm'
-
-const ALL_INPUT_LEVEL_FIELDS = [
-  MetadataBlockName.CITATION,
-  MetadataBlockName.GEOSPATIAL,
-  MetadataBlockName.SOCIAL_SCIENCE,
-  MetadataBlockName.ASTROPHYSICS,
-  MetadataBlockName.BIOMEDICAL,
-  MetadataBlockName.JOURNAL
-]
 
 interface FieldsFromParentCheckboxProps {
   defaultValues: CollectionFormData
@@ -34,12 +24,11 @@ export const FieldsFromParentCheckbox = ({ defaultValues }: FieldsFromParentChec
   const handleContinueWithReset = () => {
     setValue(USE_FIELDS_FROM_PARENT, true)
 
-    // Reset metadata block names checboxes to the inital value
-    ALL_INPUT_LEVEL_FIELDS.forEach((blockName) => {
-      setValue(
-        `${METADATA_BLOCKS_NAMES_GROUPER}.${blockName}`,
-        defaultValues[METADATA_BLOCKS_NAMES_GROUPER][blockName]
-      )
+    const metadataBlockDefaultValues = Object.entries(defaultValues[METADATA_BLOCKS_NAMES_GROUPER])
+
+    // Reset metadata block names checkboxes to the inital value
+    metadataBlockDefaultValues.forEach(([blockName, blockInitialValue]) => {
+      setValue(`${METADATA_BLOCKS_NAMES_GROUPER}.${blockName}`, blockInitialValue)
     })
 
     // Reset input levels to the initial value

--- a/src/sections/create-collection/collection-form/useSubmitCollection.ts
+++ b/src/sections/create-collection/collection-form/useSubmitCollection.ts
@@ -8,7 +8,8 @@ import {
   CollectionFormData,
   CollectionFormValuesOnSubmit,
   INPUT_LEVELS_GROUPER,
-  METADATA_BLOCKS_NAMES_GROUPER
+  METADATA_BLOCKS_NAMES_GROUPER,
+  USE_FIELDS_FROM_PARENT
 } from './CollectionForm'
 import { RouteWithParams } from '../../Route.enum'
 import { JSDataverseWriteErrorHandler } from '../../../shared/helpers/JSDataverseWriteErrorHandler'
@@ -65,6 +66,8 @@ export function useSubmitCollection(
 
     const facetIdsDTO = formData.facetIds.map((facet) => facet.value)
 
+    const useFieldsFromParentChecked = formData[USE_FIELDS_FROM_PARENT]
+
     const newCollection: CollectionDTO = {
       name: formData.name,
       alias: formData.alias,
@@ -72,8 +75,8 @@ export function useSubmitCollection(
       affiliation: formData.affiliation,
       description: formData.description,
       contacts: contactsDTO,
-      metadataBlockNames: metadataBlockNamesDTO,
-      inputLevels: inputLevelsDTO,
+      metadataBlockNames: useFieldsFromParentChecked ? undefined : metadataBlockNamesDTO,
+      inputLevels: useFieldsFromParentChecked ? undefined : inputLevelsDTO,
       facetIds: facetIdsDTO
     }
 


### PR DESCRIPTION
## What this PR does / why we need it:

In the Create Collection form, when the user checks the “Use fields from [parent]” checkbox, we are now sending metadata block names and input levels as undefined to the js-dataverse use case.
This was tested also using the GHCR container image generated from https://github.com/IQSS/dataverse/pull/10985 PR and it works great.

## Which issue(s) this PR closes:

- Closes #539 

## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
No
