### PR TITLE
Add time tag to the date and change some date format to YYYY-MM-DD

### DIFF
--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
@@ -7,10 +7,7 @@ export function FileDate({ date }: { date: FileDateModel }) {
   return (
     <div>
       <span>
-        <time>
-          {t(`table.date.${date.type}`)}
-          {DateHelper.toDisplayFormat(date.date)}
-        </time>
+        {t(`table.date.${date.type}`)} <time>{DateHelper.toDisplayFormat(date.date)}</time>
       </span>
     </div>
   )

--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
@@ -1,13 +1,17 @@
-import { FileDate as FileDateModel } from '../../../../../../../files/domain/models/FileMetadata'
 import { useTranslation } from 'react-i18next'
+import { FileDate as FileDateModel } from '../../../../../../../files/domain/models/FileMetadata'
 import { DateHelper } from '../../../../../../../shared/helpers/DateHelper'
 
 export function FileDate({ date }: { date: FileDateModel }) {
   const { t } = useTranslation('files')
+
   return (
     <div>
       <span>
-        {t(`table.date.${date.type}`)} <time>{DateHelper.toDisplayFormat(date.date)}</time>
+        {t(`table.date.${date.type}`)}{' '}
+        <time dateTime={DateHelper.toDisplayFormat(date.date)}>
+          {DateHelper.toDisplayFormat(date.date)}
+        </time>
       </span>
     </div>
   )

--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
@@ -9,7 +9,7 @@ export function FileDate({ date }: { date: FileDateModel }) {
     <div>
       <span>
         {t(`table.date.${date.type}`)}{' '}
-        <time dateTime={DateHelper.toDisplayFormat(date.date)}>
+        <time dateTime={DateHelper.toISO8601Format(date.date)}>
           {DateHelper.toDisplayFormat(date.date)}
         </time>
       </span>

--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDate.tsx
@@ -2,14 +2,15 @@ import { FileDate as FileDateModel } from '../../../../../../../files/domain/mod
 import { useTranslation } from 'react-i18next'
 import { DateHelper } from '../../../../../../../shared/helpers/DateHelper'
 
-// TODO: use time tag with dateTime attr https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
-
 export function FileDate({ date }: { date: FileDateModel }) {
   const { t } = useTranslation('files')
   return (
     <div>
       <span>
-        {t(`table.date.${date.type}`)} {DateHelper.toDisplayFormat(date.date)}
+        <time>
+          {t(`table.date.${date.type}`)}
+          {DateHelper.toDisplayFormat(date.date)}
+        </time>
       </span>
     </div>
   )

--- a/src/sections/file/file-embargo/FileEmbargoDate.tsx
+++ b/src/sections/file/file-embargo/FileEmbargoDate.tsx
@@ -25,11 +25,7 @@ export function FileEmbargoDate({
       <span>
         {t(embargoTypeOfDate(embargo.isActive, datasetPublishingStatus))}{' '}
         <time
-          dateTime={
-            format === 'YYYY-MM-DD'
-              ? DateHelper.toISO8601Format(embargo.dateAvailable)
-              : DateHelper.toDisplayFormat(embargo.dateAvailable)
-          }
+          dateTime={DateHelper.toISO8601Format(embargo.dateAvailable)}
           data-testid="embargo-date">
           {format === 'YYYY-MM-DD'
             ? DateHelper.toISO8601Format(embargo.dateAvailable)

--- a/src/sections/file/file-embargo/FileEmbargoDate.tsx
+++ b/src/sections/file/file-embargo/FileEmbargoDate.tsx
@@ -24,7 +24,13 @@ export function FileEmbargoDate({
     <div>
       <span>
         {t(embargoTypeOfDate(embargo.isActive, datasetPublishingStatus))}{' '}
-        <time data-testid="embargo-date">
+        <time
+          dateTime={
+            format === 'YYYY-MM-DD'
+              ? DateHelper.toISO8601Format(embargo.dateAvailable)
+              : DateHelper.toDisplayFormat(embargo.dateAvailable)
+          }
+          data-testid="embargo-date">
           {format === 'YYYY-MM-DD'
             ? DateHelper.toISO8601Format(embargo.dateAvailable)
             : DateHelper.toDisplayFormat(embargo.dateAvailable)}

--- a/src/sections/file/file-embargo/FileEmbargoDate.tsx
+++ b/src/sections/file/file-embargo/FileEmbargoDate.tsx
@@ -26,9 +26,11 @@ export function FileEmbargoDate({
     <div>
       <span>
         {t(embargoTypeOfDate(embargo.isActive, datasetPublishingStatus))}{' '}
-        {format === 'YYYY-MM-DD'
-          ? DateHelper.toDisplayFormatYYYYMMDD(embargo.dateAvailable)
-          : DateHelper.toDisplayFormat(embargo.dateAvailable)}
+        <time>
+          {format === 'YYYY-MM-DD'
+            ? DateHelper.toISO8601Format(embargo.dateAvailable)
+            : DateHelper.toDisplayFormat(embargo.dateAvailable)}
+        </time>
       </span>
     </div>
   )

--- a/src/sections/file/file-embargo/FileEmbargoDate.tsx
+++ b/src/sections/file/file-embargo/FileEmbargoDate.tsx
@@ -12,7 +12,7 @@ interface FileEmbargoDateProps {
 export function FileEmbargoDate({
   embargo,
   datasetPublishingStatus,
-  format = 'short'
+  format = 'YYYY-MM-DD'
 }: FileEmbargoDateProps) {
   const { t } = useTranslation('files')
 
@@ -20,13 +20,11 @@ export function FileEmbargoDate({
     return <></>
   }
 
-  // TODO: use time tag with dateTime attr https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time
-
   return (
     <div>
       <span>
         {t(embargoTypeOfDate(embargo.isActive, datasetPublishingStatus))}{' '}
-        <time>
+        <time data-testid="embargo-date">
           {format === 'YYYY-MM-DD'
             ? DateHelper.toISO8601Format(embargo.dateAvailable)
             : DateHelper.toDisplayFormat(embargo.dateAvailable)}

--- a/src/sections/file/file-metadata/FileMetadata.tsx
+++ b/src/sections/file/file-metadata/FileMetadata.tsx
@@ -97,16 +97,18 @@ export function FileMetadata({
             <Col sm={3}>
               <strong>{t('metadata.fields.depositDate')}</strong>
             </Col>
-            {/* TODO: use time tag with dateTime attr https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time */}
-            <Col>{DateHelper.toDisplayFormatYYYYMMDD(metadata.depositDate)}</Col>
+            <Col>
+              <time>{DateHelper.toISO8601Format(metadata.depositDate)}</time>
+            </Col>
           </Row>
           {metadata.publicationDate && (
             <Row className={styles.row}>
               <Col sm={3}>
                 <strong>{t('metadata.fields.metadataReleaseDate')}</strong>
               </Col>
-              {/* TODO: use time tag with dateTime attr https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time */}
-              <Col>{DateHelper.toDisplayFormatYYYYMMDD(metadata.publicationDate)}</Col>
+              <Col>
+                <time>{DateHelper.toISO8601Format(metadata.publicationDate)}</time>
+              </Col>
             </Row>
           )}
           {(metadata.publicationDate || metadata.embargo) && (
@@ -114,7 +116,6 @@ export function FileMetadata({
               <Col sm={3}>
                 <strong>{t('metadata.fields.publicationDate')}</strong>
               </Col>
-              {/* TODO: use time tag with dateTime attr https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time */}
               <Col>
                 {metadata.embargo ? (
                   <FileEmbargoDate
@@ -123,7 +124,7 @@ export function FileMetadata({
                     format="YYYY-MM-DD"
                   />
                 ) : (
-                  DateHelper.toDisplayFormatYYYYMMDD(metadata.publicationDate)
+                  <time>{DateHelper.toISO8601Format(metadata.depositDate)}</time>
                 )}
               </Col>
             </Row>

--- a/src/sections/file/file-metadata/FileMetadata.tsx
+++ b/src/sections/file/file-metadata/FileMetadata.tsx
@@ -1,14 +1,14 @@
+import { Trans, useTranslation } from 'react-i18next'
 import { Accordion, Col, Row } from '@iqss/dataverse-design-system'
 import { FilePreview } from '../file-preview/FilePreview'
 import { FileLabels } from '../file-labels/FileLabels'
-import styles from './FileMetadata.module.scss'
 import { DateHelper } from '../../../shared/helpers/DateHelper'
 import { FileEmbargoDate } from '../file-embargo/FileEmbargoDate'
 import { BASE_URL } from '../../../config'
-import { Trans, useTranslation } from 'react-i18next'
 import { FileMetadata as FileMetadataModel } from '../../../files/domain/models/FileMetadata'
 import { FilePermissions } from '../../../files/domain/models/FilePermissions'
 import { DatasetPublishingStatus } from '../../../dataset/domain/models/Dataset'
+import styles from './FileMetadata.module.scss'
 
 interface FileMetadataProps {
   name: string
@@ -24,6 +24,7 @@ export function FileMetadata({
   datasetPublishingStatus
 }: FileMetadataProps) {
   const { t } = useTranslation('file')
+
   return (
     <Accordion defaultActiveKey="0">
       <Accordion.Item eventKey="0">
@@ -98,7 +99,9 @@ export function FileMetadata({
               <strong>{t('metadata.fields.depositDate')}</strong>
             </Col>
             <Col>
-              <time>{DateHelper.toISO8601Format(metadata.depositDate)}</time>
+              <time dateTime={DateHelper.toISO8601Format(metadata.depositDate)}>
+                {DateHelper.toISO8601Format(metadata.depositDate)}
+              </time>
             </Col>
           </Row>
           {metadata.publicationDate && (
@@ -107,7 +110,9 @@ export function FileMetadata({
                 <strong>{t('metadata.fields.metadataReleaseDate')}</strong>
               </Col>
               <Col>
-                <time>{DateHelper.toISO8601Format(metadata.publicationDate)}</time>
+                <time dateTime={DateHelper.toISO8601Format(metadata.publicationDate)}>
+                  {DateHelper.toISO8601Format(metadata.publicationDate)}
+                </time>
               </Col>
             </Row>
           )}
@@ -124,10 +129,11 @@ export function FileMetadata({
                     format="YYYY-MM-DD"
                   />
                 ) : (
-                  <time>
-                    {metadata.publicationDate &&
-                      DateHelper.toISO8601Format(metadata.publicationDate)}
-                  </time>
+                  metadata.publicationDate && (
+                    <time dateTime={DateHelper.toISO8601Format(metadata.publicationDate)}>
+                      {DateHelper.toISO8601Format(metadata.publicationDate)}
+                    </time>
+                  )
                 )}
               </Col>
             </Row>

--- a/src/sections/file/file-metadata/FileMetadata.tsx
+++ b/src/sections/file/file-metadata/FileMetadata.tsx
@@ -124,7 +124,9 @@ export function FileMetadata({
                     format="YYYY-MM-DD"
                   />
                 ) : (
-                  <time>{DateHelper.toISO8601Format(metadata.depositDate)}</time>
+                  metadata.publicationDate && (
+                    <time>DateHelper.toISO8601Format(metadata.publicationDate)</time>
+                  )
                 )}
               </Col>
             </Row>

--- a/src/sections/file/file-metadata/FileMetadata.tsx
+++ b/src/sections/file/file-metadata/FileMetadata.tsx
@@ -124,9 +124,10 @@ export function FileMetadata({
                     format="YYYY-MM-DD"
                   />
                 ) : (
-                  metadata.publicationDate && (
-                    <time>DateHelper.toISO8601Format(metadata.publicationDate)</time>
-                  )
+                  <time>
+                    {metadata.publicationDate &&
+                      DateHelper.toISO8601Format(metadata.publicationDate)}
+                  </time>
                 )}
               </Col>
             </Row>

--- a/tests/component/sections/dataset/dataset-files/files-table/files-info/file-info-cell/file-info-data/FileDate.spec.tsx
+++ b/tests/component/sections/dataset/dataset-files/files-table/files-info/file-info-cell/file-info-data/FileDate.spec.tsx
@@ -8,6 +8,7 @@ describe('FileDate', () => {
     const date = { type: FileDateType.PUBLISHED, date: fileDate }
     cy.customMount(<FileDate date={date} />)
     const dateString = DateHelper.toDisplayFormat(fileDate)
-    cy.findByText(`Published ` + dateString).should('exist')
+    cy.findByText(`Published`).should('exist')
+    cy.get('time').should('have.text', dateString)
   })
 })

--- a/tests/component/sections/file/file-embargo/FileEmbargoDate.spec.tsx
+++ b/tests/component/sections/file/file-embargo/FileEmbargoDate.spec.tsx
@@ -8,14 +8,7 @@ describe('FileEmbargoDate', () => {
     const embargo = FileEmbargoMother.create({ dateAvailable: embargoDate })
     const status = DatasetPublishingStatus.RELEASED
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-    const dateString = embargoDate.toLocaleDateString(
-      Intl.DateTimeFormat().resolvedOptions().locale,
-      {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric'
-      }
-    )
+    const dateString = embargoDate.toISOString().split('T')[0]
     cy.findByText(`Embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
   })
@@ -26,14 +19,8 @@ describe('FileEmbargoDate', () => {
     const status = DatasetPublishingStatus.RELEASED
 
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-    const dateString = embargoDate.toLocaleDateString(
-      Intl.DateTimeFormat().resolvedOptions().locale,
-      {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric'
-      }
-    )
+    const dateString = embargoDate.toISOString().split('T')[0]
+
     cy.findByText(`Was embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
   })
@@ -44,14 +31,8 @@ describe('FileEmbargoDate', () => {
     const status = DatasetPublishingStatus.DRAFT
 
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-    const dateString = embargoDate.toLocaleDateString(
-      Intl.DateTimeFormat().resolvedOptions().locale,
-      {
-        year: 'numeric',
-        month: 'short',
-        day: 'numeric'
-      }
-    )
+    const dateString = embargoDate.toISOString().split('T')[0]
+
     cy.findByText(`Draft: will be embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
   })

--- a/tests/component/sections/file/file-embargo/FileEmbargoDate.spec.tsx
+++ b/tests/component/sections/file/file-embargo/FileEmbargoDate.spec.tsx
@@ -16,7 +16,8 @@ describe('FileEmbargoDate', () => {
         day: 'numeric'
       }
     )
-    cy.findByText(`Embargoed until ` + dateString).should('exist')
+    cy.findByText(`Embargoed until`).should('exist')
+    cy.get('time').should('have.text', dateString)
   })
 
   it('renders the until embargo date when embargo is not active and the file is not released', () => {
@@ -33,7 +34,8 @@ describe('FileEmbargoDate', () => {
         day: 'numeric'
       }
     )
-    cy.findByText(`Was embargoed until ` + dateString).should('exist')
+    cy.findByText(`Was embargoed until`).should('exist')
+    cy.get('time').should('have.text', dateString)
   })
 
   it('renders the draft until embargo date when embargo is active and the file is not released', () => {
@@ -50,7 +52,8 @@ describe('FileEmbargoDate', () => {
         day: 'numeric'
       }
     )
-    cy.findByText(`Draft: will be embargoed until ` + dateString).should('exist')
+    cy.findByText(`Draft: will be embargoed until`).should('exist')
+    cy.get('time').should('have.text', dateString)
   })
 
   it('renders an empty fragment when embargo is undefined', () => {
@@ -58,7 +61,6 @@ describe('FileEmbargoDate', () => {
     const status = DatasetPublishingStatus.RELEASED
 
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-
     cy.findByText(/Draft: will be embargoed until/).should('not.exist')
     cy.findByText(/Embargoed until/).should('not.exist')
     cy.findByText(/Was embargoed until/).should('not.exist')
@@ -68,17 +70,12 @@ describe('FileEmbargoDate', () => {
     const embargoDate = new Date('2123-09-18')
     const embargo = FileEmbargoMother.create({ dateAvailable: embargoDate })
     const status = DatasetPublishingStatus.RELEASED
+
     cy.customMount(
       <FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} format="YYYY-MM-DD" />
     )
-    const dateString = embargoDate.toLocaleDateString(
-      Intl.DateTimeFormat().resolvedOptions().locale,
-      {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-      }
-    )
-    cy.findByText(`Embargoed until ` + dateString).should('exist')
+    const dateString = embargoDate.toISOString().split('T')[0]
+    cy.findByText(`Embargoed until`).should('exist')
+    cy.get('time').should('have.text', dateString)
   })
 })

--- a/tests/component/sections/file/file-embargo/FileEmbargoDate.spec.tsx
+++ b/tests/component/sections/file/file-embargo/FileEmbargoDate.spec.tsx
@@ -1,6 +1,7 @@
 import { FileEmbargoDate } from '../../../../../src/sections/file/file-embargo/FileEmbargoDate'
 import { DatasetPublishingStatus } from '../../../../../src/dataset/domain/models/Dataset'
 import { FileEmbargoMother } from '../../../files/domain/models/FileMetadataMother'
+import { DateHelper } from '../../../../../src/shared/helpers/DateHelper'
 
 describe('FileEmbargoDate', () => {
   it('renders the embargo date when embargo exists', () => {
@@ -8,7 +9,7 @@ describe('FileEmbargoDate', () => {
     const embargo = FileEmbargoMother.create({ dateAvailable: embargoDate })
     const status = DatasetPublishingStatus.RELEASED
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-    const dateString = embargoDate.toISOString().split('T')[0]
+    const dateString = DateHelper.toISO8601Format(embargoDate)
     cy.findByText(`Embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
   })
@@ -19,7 +20,7 @@ describe('FileEmbargoDate', () => {
     const status = DatasetPublishingStatus.RELEASED
 
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-    const dateString = embargoDate.toISOString().split('T')[0]
+    const dateString = DateHelper.toISO8601Format(embargoDate)
 
     cy.findByText(`Was embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
@@ -31,7 +32,7 @@ describe('FileEmbargoDate', () => {
     const status = DatasetPublishingStatus.DRAFT
 
     cy.customMount(<FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} />)
-    const dateString = embargoDate.toISOString().split('T')[0]
+    const dateString = DateHelper.toISO8601Format(embargoDate)
 
     cy.findByText(`Draft: will be embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
@@ -55,7 +56,7 @@ describe('FileEmbargoDate', () => {
     cy.customMount(
       <FileEmbargoDate embargo={embargo} datasetPublishingStatus={status} format="YYYY-MM-DD" />
     )
-    const dateString = embargoDate.toISOString().split('T')[0]
+    const dateString = DateHelper.toISO8601Format(embargoDate)
     cy.findByText(`Embargoed until`).should('exist')
     cy.get('time').should('have.text', dateString)
   })

--- a/tests/component/sections/file/file-metadata/FileMetadata.spec.tsx
+++ b/tests/component/sections/file/file-metadata/FileMetadata.spec.tsx
@@ -216,7 +216,7 @@ describe('FileMetadata', () => {
     )
 
     cy.findByText('Deposit Date').should('exist')
-    cy.findByText(DateHelper.toDisplayFormatYYYYMMDD(file.metadata.depositDate)).should('exist')
+    cy.findByText(DateHelper.toISO8601Format(file.metadata.depositDate)).should('exist')
   })
 
   it('renders the file Metadata Release Date', () => {
@@ -231,9 +231,11 @@ describe('FileMetadata', () => {
     )
 
     cy.findByText('Metadata Release Date').should('exist')
-    cy.findAllByText(
-      DateHelper.toDisplayFormatYYYYMMDD(metadataWithPublicationDate.publicationDate)
-    ).should('exist')
+    if (metadataWithPublicationDate.publicationDate) {
+      cy.findAllByText(
+        DateHelper.toISO8601Format(metadataWithPublicationDate.publicationDate)
+      ).should('exist')
+    }
   })
 
   it('does not render the file Metadata Release Date if the publication date does not exist', () => {
@@ -262,9 +264,11 @@ describe('FileMetadata', () => {
     )
 
     cy.findByText('Publication Date').should('exist')
-    cy.findAllByText(
-      DateHelper.toDisplayFormatYYYYMMDD(metadataWithPublicationDate.publicationDate)
-    ).should('exist')
+    if (metadataWithPublicationDate.publicationDate) {
+      cy.findAllByText(
+        DateHelper.toISO8601Format(metadataWithPublicationDate.publicationDate)
+      ).should('exist')
+    }
   })
 
   it('renders the file Publication Date with embargo', () => {
@@ -280,11 +284,11 @@ describe('FileMetadata', () => {
     )
 
     cy.findByText('Publication Date').should('exist')
-    cy.findByText(
-      `Embargoed until ${DateHelper.toDisplayFormatYYYYMMDD(
-        metadataWithPublicationDateEmbargoed.embargo?.dateAvailable
-      )}`
-    ).should('exist')
+    if (metadataWithPublicationDateEmbargoed.publicationDate) {
+      cy.findAllByText(
+        DateHelper.toISO8601Format(metadataWithPublicationDateEmbargoed.publicationDate)
+      ).should('exist')
+    }
   })
 
   it('does not render the file Publication Date if the publication date and embargo do not exist', () => {

--- a/tests/component/sections/file/file-metadata/FileMetadata.spec.tsx
+++ b/tests/component/sections/file/file-metadata/FileMetadata.spec.tsx
@@ -214,9 +214,8 @@ describe('FileMetadata', () => {
         datasetPublishingStatus={file.datasetVersion.publishingStatus}
       />
     )
-
     cy.findByText('Deposit Date').should('exist')
-    cy.findByText(DateHelper.toISO8601Format(file.metadata.depositDate)).should('exist')
+    cy.get('time').contains(DateHelper.toISO8601Format(file.metadata.depositDate)).should('exist')
   })
 
   it('renders the file Metadata Release Date', () => {

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -479,8 +479,8 @@ describe('Dataset', () => {
     })
 
     it('loads the embargoed files', () => {
-      const utcDate = moment.utc().startOf('day').add(100, 'years').toDate()
-      const expectedDate = DateHelper.toDisplayFormat(utcDate)
+      const utcDate = moment.utc().startOf('day').add(100, 'years')
+      const expectedDate = utcDate.toISOString().split('T')[0]
 
       cy.wrap(
         DatasetHelper.createWithFiles(FileHelper.createMany(1)).then((dataset) =>

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -8,6 +8,7 @@ import { FileHelper } from '../../../shared/files/FileHelper'
 import moment from 'moment-timezone'
 import { CollectionHelper } from '../../../shared/collection/CollectionHelper'
 import { FILES_TAB_INFINITE_SCROLL_ENABLED } from '../../../../../src/sections/dataset/config'
+import { DateHelper } from '../../../../../src/shared/helpers/DateHelper'
 
 type Dataset = {
   datasetVersion: { metadataBlocks: { citation: { fields: { value: string }[] } } }
@@ -478,8 +479,8 @@ describe('Dataset', () => {
     })
 
     it('loads the embargoed files', () => {
-      const utcDate = moment.utc().startOf('day').add(100, 'years')
-      const expectedDate = utcDate.toISOString().split('T')[0]
+      const utcDate = moment.utc().startOf('day').add(100, 'years').toDate()
+      const expectedDate = DateHelper.toDisplayFormat(utcDate)
 
       cy.wrap(
         DatasetHelper.createWithFiles(FileHelper.createMany(1)).then((dataset) =>

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -478,57 +478,39 @@ describe('Dataset', () => {
     })
 
     it('loads the embargoed files', () => {
-      cy.window().then((win) => {
-        // Get the browser's locale from the window object
-        const browserLocale = win.navigator.language
+      const utcDate = moment.utc().startOf('day').add(100, 'years')
+      const expectedDate = utcDate.toISOString().split('T')[0]
 
-        // Create a moment object in UTC and set the time to 12 AM (midnight)
-        const utcDate = moment.utc().startOf('day')
-
-        // Add 100 years to the UTC date
-        utcDate.add(100, 'years')
-        const dateString = utcDate.format('YYYY-MM-DD')
-
-        // Use the browser's locale to format the date using Intl.DateTimeFormat
-        const options: Intl.DateTimeFormatOptions = {
-          year: 'numeric',
-          month: 'short',
-          day: 'numeric'
-        }
-        const expectedDate = new Intl.DateTimeFormat(browserLocale, options).format(
-          utcDate.toDate()
-        )
-
-        cy.wrap(
-          DatasetHelper.createWithFiles(FileHelper.createMany(1)).then((dataset) =>
-            DatasetHelper.embargoFiles(
-              dataset.persistentId,
-              [dataset.files ? dataset.files[0].id : 0],
-              dateString
-            )
+      cy.wrap(
+        DatasetHelper.createWithFiles(FileHelper.createMany(1)).then((dataset) =>
+          DatasetHelper.embargoFiles(
+            dataset.persistentId,
+            [dataset.files ? dataset.files[0].id : 0],
+            expectedDate
           )
         )
-          .its('persistentId')
-          .then((persistentId: string) => {
-            cy.wait(1500) // Wait for the files to be embargoed
+      )
+        .its('persistentId')
+        .then((persistentId: string) => {
+          cy.wait(1500) // Wait for the files to be embargoed
 
-            cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
+          cy.visit(`/spa/datasets?persistentId=${persistentId}&version=${DRAFT_PARAM}`)
 
-            cy.wait(1500) // Wait for the files to be loaded
+          cy.wait(1500) // Wait for the files to be loaded
 
-            cy.findByText('Files').should('exist')
+          cy.findByText('Files').should('exist')
 
-            cy.findByText(/Deposited/).should('exist')
-            cy.findByText(`Draft: will be embargoed until ${expectedDate}`).should('exist')
+          cy.findByText(/Deposited/).should('exist')
+          cy.findByText(`Draft: will be embargoed until`).should('exist')
+          cy.findByTestId('embargo-date').should('have.text', expectedDate)
 
-            cy.get('#edit-files-menu').should('exist')
+          cy.get('#edit-files-menu').should('exist')
 
-            cy.findByRole('button', { name: 'Access File' }).as('accessButton')
-            cy.get('@accessButton').should('exist')
-            cy.get('@accessButton').click()
-            cy.findByText('Embargoed').should('exist')
-          })
-      })
+          cy.findByRole('button', { name: 'Access File' }).as('accessButton')
+          cy.get('@accessButton').should('exist')
+          cy.get('@accessButton').click()
+          cy.findByText('Embargoed').should('exist')
+        })
     })
 
     it('applies filters to the Files Table in the correct order', () => {

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -8,7 +8,6 @@ import { FileHelper } from '../../../shared/files/FileHelper'
 import moment from 'moment-timezone'
 import { CollectionHelper } from '../../../shared/collection/CollectionHelper'
 import { FILES_TAB_INFINITE_SCROLL_ENABLED } from '../../../../../src/sections/dataset/config'
-import { DateHelper } from '../../../../../src/shared/helpers/DateHelper'
 
 type Dataset = {
   datasetVersion: { metadataBlocks: { citation: { fields: { value: string }[] } } }


### PR DESCRIPTION
## What this PR does / why we need it:
For solving some existing todos, add time tag to the date so as to provides semantic meaning to the content. The date attribute within the <time> tag allows you to provide a machine-readable format of the date and time, which can be useful for search engine optimization (SEO), calendar integration, and other purposes. Also, in order to keep constant with JSF, we need change some date format to YYYY-MM-DD as well.

## Which issue(s) this PR closes:


- Closes #533 

## Special notes for your reviewer:

## Suggestions on how to test this:
Step 1: Run the Development Environment

1. Execute npm i.
2. Navigate with cd packages/design-system && npm run build.
3. Return with cd ../../.
4. Ensure you have a .env file similar to .env.example, with the variable VITE_DATAVERSE_BACKEND_URL=http://localhost:8000/.
5. Navigate with cd dev-env.
6. Start the environment using ./run-env.sh unstable.
7. To verify the environment, visit http://localhost:8000/ and check your local Dataverse installation.

Step 2: check if the date run well and in a right format YYYY-MM-DD
1. log in to the dataverseAdmin account, so you could publish a dataset
2. create a new dataset by http://localhost:8000/spa/datasets/root/create 
3. click into the new dataset just created
4. upload a random file 
5. under "File Metadata", click the file title, "Deposit Date" should be shown in YYYY-MM-DD format.
6. publish the dataset 
7.under "File Metadata", click the file title, the filed "Deposit Date","Metadata Release Date", and "Publication Date" should be shown in YYYY-MM-DD format.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
