### PR TITLE
Remove the skip from e2e test for getByPersistentId, so the test case could be included

### DIFF
--- a/src/sections/dataset/dataset-action-buttons/link-dataset-button/LinkDatasetButton.tsx
+++ b/src/sections/dataset/dataset-action-buttons/link-dataset-button/LinkDatasetButton.tsx
@@ -12,7 +12,6 @@ export function LinkDatasetButton({ dataset }: LinkDatasetButtonProps) {
   const { t } = useTranslation('dataset')
   const { user } = useSession()
   const handleClick = () => {
-    // TODO - Implement upload files
     showModal()
   }
   const { showModal } = useNotImplementedModal()

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -336,6 +336,7 @@ describe('Dataset JSDataverse Repository', () => {
       const datasetExpected = datasetData(dataset.persistentId, dataset.version.id)
 
       expect(dataset.version.title).to.deep.equal(datasetExpected.title)
+      expect(dataset.version.publishingStatus).to.equal(DatasetPublishingStatus.DEACCESSIONED)
     })
   })
 

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -322,8 +322,7 @@ describe('Dataset JSDataverse Repository', () => {
     })
   })
 
-  it.skip('gets the dataset by persistentId when the dataset is deaccessioned', async () => {
-    // TODO - Implement once the getDatasetCitation includes deaccessioned datasets
+  it('gets the dataset by persistentId when the dataset is deaccessioned', async () => {
     const datasetResponse = await DatasetHelper.create(collectionId)
 
     await DatasetHelper.publish(datasetResponse.persistentId)
@@ -339,6 +338,7 @@ describe('Dataset JSDataverse Repository', () => {
       expect(dataset.version.title).to.deep.equal(datasetExpected.title)
     })
   })
+
   it('gets the dataset by persistentId when is locked', async () => {
     const datasetResponse = await DatasetHelper.create(collectionId)
     await DatasetHelper.lock(datasetResponse.id, DatasetLockReason.FINALIZE_PUBLICATION)


### PR DESCRIPTION
## What this PR does / why we need it:
The test case of getByPersistentId should also work for deaccessioned datasets. The it.skip() should be removed because the JS dataverse has included deaccessioned api. 

## Which issue(s) this PR closes:

- Closes #535 

## Special notes for your reviewer:

## Suggestions on how to test this:
It would be fine if e2e test DatasetJSDataverseRepository running well with no error message.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
