### PR TITLE
536 remove the hard coded part in getbyprivateurltoken in datasetjsdataverserepo

### DIFF
--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -200,23 +200,36 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       getDatasetSummaryFieldNames.execute(),
       getPrivateUrlDatasetCitation.execute(privateUrlToken)
     ])
-      .then(([jsDataset, summaryFieldsNames, citation]: [JSDataset, string[], string]) =>
-        JSDatasetMapper.toDataset(
+      .then(async ([jsDataset, summaryFieldsNames, citation]: [JSDataset, string[], string]) => {
+        const [permissions, locks, originalSize, archivalSize] = await Promise.all([
+          getDatasetUserPermissions.execute(jsDataset.id),
+          getDatasetLocks.execute(jsDataset.id),
+          getDatasetFilesTotalDownloadSize.execute(
+            jsDataset.id,
+            DatasetNonNumericVersion.DRAFT,
+            FileDownloadSizeMode.ORIGINAL,
+            undefined,
+            includeDeaccessioned
+          ),
+          getDatasetFilesTotalDownloadSize.execute(
+            jsDataset.id,
+            DatasetNonNumericVersion.DRAFT,
+            FileDownloadSizeMode.ARCHIVAL,
+            undefined,
+            includeDeaccessioned
+          )
+        ])
+
+        return JSDatasetMapper.toDataset(
           jsDataset,
           citation,
           summaryFieldsNames,
-          {
-            canEditDataset: true,
-            canPublishDataset: true,
-            canManageDatasetPermissions: true,
-            canDeleteDatasetDraft: true,
-            canViewUnpublishedDataset: true
-          }, // TODO Connect with JS dataset permissions for privateUrl when it is available in js-dataverse
-          [], // TODO Connect with JS dataset locks for privateUrl when it is available in js-dataverse
-          0, // TODO Connect with JS dataset filesTotalDownloadSize for privateUrl when it is available in js-dataverse
-          0 // TODO Connect with JS dataset filesTotalDownloadSize for privateUrl when it is available in js-dataverse
+          permissions,
+          locks,
+          originalSize,
+          archivalSize
         )
-      )
+      })
       .catch((error: ReadError) => {
         throw new Error(error.message)
       })


### PR DESCRIPTION
## What this PR does / why we need it:
It was a todo task waiting for the implementation of getbyprivateurltoken from js-dataverse side. Since the implementation is done, we are able to remove some hard-coded part with the results from api.

## Which issue(s) this PR closes:

- Closes #536 

## Special notes for your reviewer:

## Suggestions on how to test this:
Run the e2e test for DatasetJSDataverseRepository

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No
## Is there a release notes update needed for this change?:
No
## Additional documentation:
