### PR TITLE
Fix Edit collection page type errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.6",
+        "@iqss/dataverse-client-javascript": "2.0.0-alpha.8",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3674,9 +3674,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.6",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.6/bf29f454055e33b7ec6d539090450b5774cd7e70",
-      "integrity": "sha512-2f3aF1U8brIQhCBFa0IopIhnmS7CYNZnAqIZz2YKHw4xc81PLtmIkHWZoJkv912jmLYwqqqtlJXF044yLQn7ww==",
+      "version": "2.0.0-alpha.8",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.8/bb548a68f074bec8b7a87f5d98f0fd03b87d07fb",
+      "integrity": "sha512-g1I1BfdoGUfohwQYPDwM2DHVYPBK+B4oHLO7twmPQDhZiWNTkMz34rbOxzA8ZUst22oxJj8rhuF5CqIO1YOBrw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "react-router-dom": "6.23.1",
         "react-topbar-progress-indicator": "4.1.1",
         "sass": "1.58.1",
-        "typescript": "4.9.5",
+        "typescript": "5.7.2",
         "use-deep-compare": "1.2.1",
         "vite-plugin-istanbul": "4.0.1",
         "web-vitals": "2.1.4"
@@ -3699,6 +3699,18 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/@iqss/dataverse-client-javascript/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/@iqss/dataverse-design-system": {
@@ -42060,15 +42072,15 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typescript-memoize": {
@@ -44541,6 +44553,18 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "packages/design-system/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "start": "vite --base=/spa",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "npm run lint:eslint && npm run lint:stylelint && npm run lint:prettier",
+    "lint": "npm run typecheck && npm run lint:eslint && npm run lint:stylelint && npm run lint:prettier",
     "lint:fix": "eslint --fix --ext .ts,.tsx ./src --ignore-path .gitignore . && stylelint --fix **/*.scss && prettier . --write",
     "lint:eslint": "eslint --ignore-path .gitignore .",
     "lint:stylelint": "stylelint **/*.scss ",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "react-router-dom": "6.23.1",
     "react-topbar-progress-indicator": "4.1.1",
     "sass": "1.58.1",
-    "typescript": "4.9.5",
+    "typescript": "5.7.2",
     "use-deep-compare": "1.2.1",
     "vite-plugin-istanbul": "4.0.1",
     "web-vitals": "2.1.4"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.6",
+    "@iqss/dataverse-client-javascript": "2.0.0-alpha.8",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds a typecheck script to the lint script.
It also updates Typescript to the latest version so it can Types Union Props that was causing the error.

## Which issue(s) this PR closes:

- Closes #570 

## Suggestions on how to test this:
**Step 1: Run the Development Environment**
1. Execute `npm i`.
2. Navigate with `cd packages/design-system && npm i && npm run build`.
3. Return with `cd ../../`.
4. Ensure you have a `.env` file similar to `.env.example`, with the variable `VITE_DATAVERSE_BACKEND_URL=http://localhost:8000`.
5. Navigate with `cd dev-env`.
6. Start the environment using `./run-env.sh unstable`.
7. To verify the environment, visit <http://localhost:8000> and check your local Dataverse installation.

**Step 2: Test the fix**
Change something in the code that will throw a type error and then run `npm run lint` to validate that shows the error.

