### PR TITLE
Collection page: add dataset thumbnail to the item card

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-pr234.4321ffd",
+        "@iqss/dataverse-client-javascript": "2.0.0-alpha.13",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3674,9 +3674,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-pr234.4321ffd",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr234.4321ffd/37e1fd41eafde95dfb0994d625f6052a04a67c60",
-      "integrity": "sha512-pQmSvB3YufhJ8xLEfUiSeNpsbDCdWxB/8A20OwqKnq0gina2xtpzFT6ws//kv6xE3jlMFpRjVM7o+A+MMv+H1A==",
+      "version": "2.0.0-alpha.13",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.13/99f81ce18bdd855a54cd79520367516c28b262b8",
+      "integrity": "sha512-Giv/g1+6bFUTiVcwnzrJhdhWhyMd6gcXLnArN36kxAPrhoR0adRjUa8bevE41Vb5lASw56UoVF17XS/G9Uhj7A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.11",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr234.4321ffd",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3674,9 +3674,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.11",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.11/77723d5bcef1f38f1dcfa0fd195d2edc2baa7ed9",
-      "integrity": "sha512-KKgrCeKT9tplhRUxjzgaI2fg8X6OfH2DAnFzDdcFQpoJejwBH4BSbp4d58zG7WxrjRI+sP0Iw5A1o8fsc9TOqw==",
+      "version": "2.0.0-pr234.4321ffd",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr234.4321ffd/37e1fd41eafde95dfb0994d625f6052a04a67c60",
+      "integrity": "sha512-pQmSvB3YufhJ8xLEfUiSeNpsbDCdWxB/8A20OwqKnq0gina2xtpzFT6ws//kv6xE3jlMFpRjVM7o+A+MMv+H1A==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.11",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr234.4321ffd",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-pr234.4321ffd",
+    "@iqss/dataverse-client-javascript": "2.0.0-alpha.13",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/dataset/infrastructure/mappers/JSDatasetPreviewMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetPreviewMapper.ts
@@ -16,7 +16,7 @@ export class JSDatasetPreviewMapper {
       ),
       releaseOrCreateDate: JSDatasetPreviewMapper.toPreviewDate(jsDatasetPreview.versionInfo),
       description: jsDatasetPreview.description,
-      thumbnail: undefined, // TODO: get dataset thumbnail from Dataverse https://github.com/IQSS/dataverse-frontend/issues/203
+      thumbnail: jsDatasetPreview.imageUrl,
       publicationStatuses: jsDatasetPreview.publicationStatuses,
       parentCollectionName: jsDatasetPreview.parentCollectionName,
       parentCollectionAlias: jsDatasetPreview.parentCollectionAlias


### PR DESCRIPTION
## What this PR does / why we need it:
For Q4.2, the goal is to complete the missing information on the cards in collection page. There is no thumbnails to items so we need add them.

## Which issue(s) this PR closes:

- Closes #579 

## Special notes for your reviewer:
The tests are written already, so there is no test added. [DatasetCardThumbnail.spec.tsx](https://github.com/IQSS/dataverse-frontend/blob/develop/tests/component/sections/collection/collection-items-panel/dataset-card/DatasetCardThumbnail.spec.tsx)

package.json should be removed after js-dataverse version updated

## Suggestions on how to test this:
- create a dataset in SPA
- add a thumbnail from JSF
- test if the thumbnail for the dataset is shown in SPA

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
Yes, in collection page, if there is a thumbnail uploaded by user, then the dataset thumbnail should be shown.

## Is there a release notes update needed for this change?:
No
