### PR TITLE
use a semicolon as the separator when displaying multiple metadata field values

### DIFF
--- a/src/sections/dataset/dataset-metadata/dataset-metadata-fields/DatasetMetadataFieldValueFormatted.tsx
+++ b/src/sections/dataset/dataset-metadata/dataset-metadata-fields/DatasetMetadataFieldValueFormatted.tsx
@@ -58,7 +58,7 @@ export function metadataFieldValueToDisplayFormat(
   metadataFieldValue: DatasetMetadataFieldValueModel,
   metadataBlockInfo?: MetadataBlockInfoDisplayFormat
 ): string {
-  const separator = metadataBlockInfo?.fields[metadataFieldName]?.displayFormat ?? ''
+  const separator = ";"
 
   if (isArrayOfObjects(metadataFieldValue)) {
     return metadataFieldValue

--- a/tests/e2e-integration/e2e/sections/create-dataset/CreateDataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/create-dataset/CreateDataset.spec.tsx
@@ -33,6 +33,7 @@ describe('Create Dataset', () => {
         cy.findByLabelText('Toggle options menu').click({ force: true })
 
         cy.findByLabelText('Agricultural Sciences').click()
+        cy.findByLabelText('Arts and Humanities').click()
       })
     cy.findByText(/Save Dataset/i).click()
 
@@ -41,6 +42,7 @@ describe('Create Dataset', () => {
     cy.contains('This dataset has been created.').should('exist')
     cy.findByText(DatasetLabelValue.DRAFT).should('exist')
     cy.findByText(DatasetLabelValue.UNPUBLISHED).should('exist')
+    cy.contains('Agricultural Sciences; Arts and Humanities').should('exist')
   })
 
   it('navigates to the home if the user cancels the form', () => {


### PR DESCRIPTION
## What this PR does / why we need it:

Previously, there was no separator, as shown in the issue:

![Screenshot 2025-03-19 at 4 20 48 PM](https://github.com/user-attachments/assets/5742dd83-d706-43de-a4b1-820cca390048)

## Which issue(s) this PR closes:

- Closes #377

## Special notes for your reviewer:

As suggested in the issue, I removed any reliance on displayFormat from the TSV and simply hard-coded a semicolon.

## Suggestions on how to test this:

I tested "Subject" (and added a Cypress test for this) but it would be good to test other fields that can have multiple values.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

Yes, not the semicolon between subjects:

![Screenshot 2025-03-19 at 4 13 10 PM](https://github.com/user-attachments/assets/6e089384-b9f5-4d4f-a33d-4f9eef5d4507)

## Is there a release notes update needed for this change?:

No.

## Additional documentation:

None.