### PR TITLE
Add missing forceReplace param when replacing a file

### DIFF
--- a/src/files/domain/models/FileTypeToFriendlyTypeMap.ts
+++ b/src/files/domain/models/FileTypeToFriendlyTypeMap.ts
@@ -195,6 +195,7 @@ const MimeTypeDisplay: Record<string, string> = {
   'application/photoshop': 'Photoshop Image',
   'image/vnd.adobe.photoshop': 'Photoshop Image',
   'application/x-photoshop': 'Photoshop Image',
+  'image/webp': 'WebP Image',
   // Audio
   'audio/x-aiff': 'AIFF Audio',
   'audio/mp3': 'MP3 Audio',

--- a/src/files/infrastructure/mappers/UploadedFileDTOMapper.ts
+++ b/src/files/infrastructure/mappers/UploadedFileDTOMapper.ts
@@ -11,7 +11,8 @@ export class UploadedFileDTOMapper {
     storageId: string,
     checksumValue: string,
     checksumType: FixityAlgorithm,
-    fileType: string
+    fileType: string,
+    forceReplace?: boolean
   ): UploadedFileDTO {
     return {
       fileName: fileName,
@@ -22,7 +23,8 @@ export class UploadedFileDTOMapper {
       storageId: storageId,
       checksumValue: checksumValue,
       checksumType: checksumType,
-      mimeType: fileType === '' ? 'application/octet-stream' : fileType // some browsers (e.g., chromium for .java files) fail to detect the mime type for some files and leave the fileType as an empty string, we use the default value 'application/octet-stream' in that case
+      mimeType: fileType === '' ? 'application/octet-stream' : fileType, // some browsers (e.g., chromium for .java files) fail to detect the mime type for some files and leave the fileType as an empty string, we use the default value 'application/octet-stream' in that case,
+      ...(forceReplace && { forceReplace: true })
     }
   }
 }

--- a/src/sections/shared/file-uploader/useReplaceFile.ts
+++ b/src/sections/shared/file-uploader/useReplaceFile.ts
@@ -28,7 +28,8 @@ export const useReplaceFile = (fileRepository: FileRepository): UseReplaceFileRe
       newFileInfo.storageId,
       newFileInfo.checksumValue,
       newFileInfo.checksumAlgorithm,
-      newFileInfo.fileType
+      newFileInfo.fileType,
+      true
     )
 
     try {


### PR DESCRIPTION
## What this PR does / why we need it:
I forgot to send `forceReplace` param to true when replacing a file with a file that has different mime type.
At some point I added it but then I removed to test something.
This PR fix what is happening now on beta if you try to replace lets say a JPG file with a PNG file.


## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No
## Is there a release notes update needed for this change?:
No
## Additional documentation:
No