### PR TITLE
Send only input levels that changed

### DIFF
--- a/src/sections/shared/form/EditCreateCollectionForm/CollectionFormHelper.ts
+++ b/src/sections/shared/form/EditCreateCollectionForm/CollectionFormHelper.ts
@@ -12,6 +12,7 @@ import {
 import { CollectionContact } from '@/collection/domain/models/CollectionContact'
 import {
   CollectionFormContactValue,
+  CollectionFormDirtyFields,
   CollectionFormMetadataBlocks,
   FormattedCollectionInputLevels,
   FormattedCollectionInputLevelsWithoutParentBlockName,
@@ -245,5 +246,20 @@ export class CollectionFormHelper {
     } else {
       return true
     }
+  }
+
+  public static getModifiedInputLevelValuesOnly(
+    inputLevelDirtyFields: CollectionFormDirtyFields['inputLevels'],
+    formCollectionInputLevels: FormattedCollectionInputLevels
+  ): FormattedCollectionInputLevels {
+    const modifiedValues: FormattedCollectionInputLevels = {}
+
+    for (const key in inputLevelDirtyFields) {
+      if (Object.hasOwn(inputLevelDirtyFields, key)) {
+        modifiedValues[key] = formCollectionInputLevels[key]
+      }
+    }
+
+    return modifiedValues
   }
 }

--- a/src/sections/shared/form/EditCreateCollectionForm/collection-form/CollectionForm.tsx
+++ b/src/sections/shared/form/EditCreateCollectionForm/collection-form/CollectionForm.tsx
@@ -53,7 +53,8 @@ export const CollectionForm = ({
     mode,
     collectionIdOrParentCollectionId,
     collectionRepository,
-    onSubmittedCollectionError
+    onSubmittedCollectionError,
+    form.formState.dirtyFields
   )
 
   function onSubmittedCollectionError() {

--- a/src/sections/shared/form/EditCreateCollectionForm/collection-form/useSubmitCollection.ts
+++ b/src/sections/shared/form/EditCreateCollectionForm/collection-form/useSubmitCollection.ts
@@ -1,7 +1,11 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { WriteError } from '@iqss/dataverse-client-javascript'
-import { CollectionFormData, CollectionFormValuesOnSubmit } from '../types'
+import {
+  CollectionFormData,
+  CollectionFormDirtyFields,
+  CollectionFormValuesOnSubmit
+} from '../types'
 import { CollectionRepository } from '@/collection/domain/repositories/CollectionRepository'
 import {
   EditCreateCollectionFormMode,
@@ -43,7 +47,8 @@ export function useSubmitCollection(
   mode: EditCreateCollectionFormMode,
   collectionIdOrParentCollectionId: string,
   collectionRepository: CollectionRepository,
-  onSubmitErrorCallback: () => void
+  onSubmitErrorCallback: () => void,
+  dirtyFields: CollectionFormDirtyFields
 ): UseSubmitCollectionReturnType {
   const navigate = useNavigate()
 
@@ -62,9 +67,14 @@ export function useSubmitCollection(
         formData[METADATA_BLOCKS_NAMES_GROUPER]
       )
 
+    const changedInputLevelsValues = CollectionFormHelper.getModifiedInputLevelValuesOnly(
+      dirtyFields.inputLevels,
+      formData[INPUT_LEVELS_GROUPER]
+    )
+
     const inputLevelsDTO = CollectionFormHelper.formatFormInputLevelsToInputLevelsDTO(
       metadataBlockNamesDTO,
-      formData[INPUT_LEVELS_GROUPER]
+      changedInputLevelsValues
     )
 
     const facetIdsDTO = formData.facetIds.map((facet) => facet.value)

--- a/src/sections/shared/form/EditCreateCollectionForm/types.ts
+++ b/src/sections/shared/form/EditCreateCollectionForm/types.ts
@@ -1,3 +1,4 @@
+import { type FieldNamesMarkedBoolean } from 'react-hook-form'
 import { CollectionStorage } from '@/collection/domain/useCases/DTOs/CollectionDTO'
 import {
   MetadataBlockInfo,
@@ -27,6 +28,8 @@ export type CollectionFormData = {
   [USE_FACETS_FROM_PARENT]: boolean
   facetIds: CollectionFormFacet[]
 }
+
+export type CollectionFormDirtyFields = FieldNamesMarkedBoolean<CollectionFormData>
 
 export type CollectionFormMetadataBlocks = Record<MetadataBlockName, boolean>
 

--- a/tests/component/sections/shared/edit-create-collection-form/CollectionFormHelper.spec.ts
+++ b/tests/component/sections/shared/edit-create-collection-form/CollectionFormHelper.spec.ts
@@ -9,6 +9,7 @@ import {
 import { CollectionFormHelper } from '@/sections/shared/form/EditCreateCollectionForm/CollectionFormHelper'
 import {
   CollectionFormContactValue,
+  CollectionFormDirtyFields,
   FormattedCollectionInputLevels,
   FormattedCollectionInputLevelsWithoutParentBlockName,
   MetadataFieldWithParentBlockInfo
@@ -585,6 +586,56 @@ describe('CollectionFormHelper', () => {
     const result = CollectionFormHelper.formatCollectionContactsToFormContacts(collectionContacts)
 
     expect(result).to.deep.equal([{ value: '' }])
+  })
+
+  it('gets the input levels values that were modified only', () => {
+    const collectionInputLevelsFormValues: FormattedCollectionInputLevels = {
+      title: {
+        include: true,
+        optionalOrRequired: 'required',
+        parentBlockName: 'citation' as MetadataBlockName
+      },
+      subtitle: {
+        include: false,
+        optionalOrRequired: 'optional',
+        parentBlockName: 'citation' as MetadataBlockName
+      },
+      foo: {
+        include: true,
+        optionalOrRequired: 'required',
+        parentBlockName: 'socialscience' as MetadataBlockName
+      },
+      bar: {
+        include: false,
+        optionalOrRequired: 'optional',
+        parentBlockName: 'socialscience' as MetadataBlockName
+      }
+    }
+
+    // This is what we expect from the form.formState.dirtyFields object from the react-hook-form library
+    // Only the input levels fields and their properties that were modified
+    const dirtyFields: CollectionFormDirtyFields['inputLevels'] = {
+      subtitle: { optionalOrRequired: true },
+      foo: { include: true }
+    }
+
+    const result = CollectionFormHelper.getModifiedInputLevelValuesOnly(
+      dirtyFields,
+      collectionInputLevelsFormValues
+    )
+
+    expect(result).to.deep.equal({
+      subtitle: {
+        include: false,
+        optionalOrRequired: 'optional',
+        parentBlockName: 'citation' as MetadataBlockName
+      },
+      foo: {
+        include: true,
+        optionalOrRequired: 'required',
+        parentBlockName: 'socialscience' as MetadataBlockName
+      }
+    })
   })
 
   describe('defineShouldCheckUseFromParent', () => {


### PR DESCRIPTION
## What this PR does / why we need it:
When creating a collection or an input level, we need to only send input levels that changed from its original value so we don't save unneeded data in db.

## Which issue(s) this PR closes:

- Closes #628 

## Suggestions on how to test this:
Check that create and edit collection functionality keeps working correctly.
This is just a change to send only the input levels that were modified from the original form value when editing or creating a collection.


## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
No