### PR TITLE
Fix Dataset Page showing draft version after deaccession

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.35",
+        "@iqss/dataverse-client-javascript": "2.0.0-alpha.37",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3683,9 +3683,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.35",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.35/cbc117e2b39537cbad05f75752ea2665da5c8ca4",
-      "integrity": "sha512-ZNlkwx1VmJRYbQOuGxiKXk9TKZxL0SGH/N/Y7zhQHihz26wjbfd3uuPwVZFogmIMNFYQDIXeVJtxv7jHaLc6Mg==",
+      "version": "2.0.0-alpha.37",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.37/7761cb0b560317a498b0f75673813d2397752460",
+      "integrity": "sha512-1G0uV467x84JO/2y13Zo8J+rgjoEYdyWuL4Qp+SvIfdYKlc4DZDxY0O4cCZK5NstNEP0u4SF4W2UslxO6SIcmA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.35",
+    "@iqss/dataverse-client-javascript": "2.0.0-alpha.37",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/dataset/domain/models/DatasetVersionDiff.ts
+++ b/src/dataset/domain/models/DatasetVersionDiff.ts
@@ -8,7 +8,7 @@ export interface DatasetVersionDiff {
   filesRemoved?: FileSummary[]
   fileChanges?: FileDiff[]
   filesReplaced?: FileReplacement[]
-  termsOfAccess?: FieldDiff[]
+  termsOfAccess?: { changed: FieldDiff[] }
 }
 
 export interface FileSummary {

--- a/src/dataset/domain/repositories/DatasetRepository.ts
+++ b/src/dataset/domain/repositories/DatasetRepository.ts
@@ -19,7 +19,8 @@ export interface DatasetRepository {
   getVersionDiff: (
     persistentId: string,
     oldVersion: string,
-    newVersion: string
+    newVersion: string,
+    includeDeaccessioned: boolean
   ) => Promise<DatasetVersionDiff>
 
   create: (dataset: DatasetDTO, collectionId: string) => Promise<{ persistentId: string }>

--- a/src/dataset/domain/useCases/getDatasetVersionDiff.ts
+++ b/src/dataset/domain/useCases/getDatasetVersionDiff.ts
@@ -5,10 +5,11 @@ export async function getDatasetVersionDiff(
   datasetRepository: DatasetRepository,
   persistentId: string,
   oldVersion: string,
-  newVersion: string
+  newVersion: string,
+  includeDeaccessioned: boolean
 ): Promise<DatasetVersionDiff | undefined> {
   return datasetRepository
-    .getVersionDiff(persistentId, oldVersion, newVersion)
+    .getVersionDiff(persistentId, oldVersion, newVersion, includeDeaccessioned)
     .catch((error: Error) => {
       throw new Error(error.message)
     })

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -6,8 +6,9 @@ import {
   DatasetMetadataFields as JSDatasetMetadataFields,
   DatasetUserPermissions as JSDatasetPermissions,
   DatasetVersionDiff as JSDatasetVersionDiff,
-  DvObjectOwnerNode as JSUpwardHierarchyNode,
-  DatasetVersionSummaryInfo as JSDatasetVersionSummaryInfo
+  DatasetVersionState,
+  DatasetVersionSummaryInfo as JSDatasetVersionSummaryInfo,
+  DvObjectOwnerNode as JSUpwardHierarchyNode
 } from '@iqss/dataverse-client-javascript'
 import { DatasetVersionDiff } from '../../domain/models/DatasetVersionDiff'
 import {
@@ -132,7 +133,8 @@ export class JSDatasetMapper {
       return false
     }
     const required =
-      ((datasetVersionDiff.filesAdded && datasetVersionDiff.filesAdded.length > 0) ||
+      (datasetVersionDiff.oldVersion.versionState === DatasetVersionState.DEACCESSIONED ||
+        (datasetVersionDiff.filesAdded && datasetVersionDiff.filesAdded.length > 0) ||
         (datasetVersionDiff.filesRemoved && datasetVersionDiff.filesRemoved.length > 0) ||
         (datasetVersionDiff.filesReplaced && datasetVersionDiff.filesReplaced.length > 0)) ??
       false

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -79,10 +79,11 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
   getVersionDiff(
     persistentId: string,
     oldVersion: string,
-    newVersion: string
+    newVersion: string,
+    includeDeaccessioned: boolean
   ): Promise<DatasetVersionDiff> {
     return getDatasetVersionDiff
-      .execute(persistentId, oldVersion, newVersion)
+      .execute(persistentId, oldVersion, newVersion, includeDeaccessioned)
       .then((jsDatasetVersionDiff) => {
         return JSDatasetMapper.toDatasetVersionDiff(jsDatasetVersionDiff)
       })
@@ -92,7 +93,11 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
     datasetDetails: IDatasetDetails
   ): Promise<IDatasetDetails> {
     await getDataset
-      .execute(datasetDetails.jsDataset.persistentId, DatasetNonNumericVersion.LATEST_PUBLISHED)
+      .execute(
+        datasetDetails.jsDataset.persistentId,
+        DatasetNonNumericVersion.LATEST_PUBLISHED,
+        includeDeaccessioned
+      )
       .then((latestPublishedDataset) => {
         datasetDetails.latestPublishedVersionMajorNumber =
           latestPublishedDataset.versionInfo.majorNumber
@@ -108,7 +113,8 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
     await this.getVersionDiff(
       datasetDetails.jsDataset.persistentId,
       DatasetNonNumericVersion.LATEST_PUBLISHED,
-      DatasetNonNumericVersion.DRAFT
+      DatasetNonNumericVersion.DRAFT,
+      includeDeaccessioned
     ).then((datasetVersionDiff) => {
       datasetDetails.datasetVersionDiff = datasetVersionDiff
       return datasetDetails

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -1006,11 +1006,13 @@ describe('JS Dataset Mapper', () => {
     const expectedDatasetVersionDiff = {
       oldVersion: {
         versionNumber: '1.0',
-        lastUpdatedDate: '2023-05-15T08:21:03Z'
+        lastUpdatedDate: '2023-05-15T08:21:03Z',
+        versionState: DatasetVersionState.RELEASED
       },
       newVersion: {
         versionNumber: '2.0',
-        lastUpdatedDate: '2023-06-15T08:21:03Z'
+        lastUpdatedDate: '2023-06-15T08:21:03Z',
+        versionState: DatasetVersionState.RELEASED
       },
       metadataChanges: [
         {
@@ -1090,13 +1092,15 @@ describe('JS Dataset Mapper', () => {
           }
         }
       ],
-      termsOfAccess: [
-        {
-          fieldName: 'termsOfAccess',
-          oldValue: 'Old terms',
-          newValue: 'New terms'
-        }
-      ]
+      termsOfAccess: {
+        changed: [
+          {
+            fieldName: 'termsOfAccess',
+            oldValue: 'Old terms',
+            newValue: 'New terms'
+          }
+        ]
+      }
     }
     const actual = JSDatasetMapper.toDatasetVersionDiff(jsDatasetVersionDiff)
     expect(expectedDatasetVersionDiff).to.deep.equal(actual)

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -102,11 +102,13 @@ const jsDatasetLocks: JSDatasetLock[] = [
 const jsDatasetVersionDiff = {
   oldVersion: {
     versionNumber: '1.0',
-    lastUpdatedDate: '2023-05-15T08:21:03Z'
+    lastUpdatedDate: '2023-05-15T08:21:03Z',
+    versionState: DatasetVersionState.RELEASED
   },
   newVersion: {
     versionNumber: '2.0',
-    lastUpdatedDate: '2023-06-15T08:21:03Z'
+    lastUpdatedDate: '2023-06-15T08:21:03Z',
+    versionState: DatasetVersionState.RELEASED
   },
   metadataChanges: [
     {
@@ -186,13 +188,15 @@ const jsDatasetVersionDiff = {
       }
     }
   ],
-  termsOfAccess: [
-    {
-      fieldName: 'termsOfAccess',
-      oldValue: 'Old terms',
-      newValue: 'New terms'
-    }
-  ]
+  termsOfAccess: {
+    changed: [
+      {
+        fieldName: 'termsOfAccess',
+        oldValue: 'Old terms',
+        newValue: 'New terms'
+      }
+    ]
+  }
 }
 const jsDatasetFilesTotalOriginalDownloadSize = 5
 const jsDatasetFilesTotalArchivalDownloadSize = 7


### PR DESCRIPTION
## What this PR does / why we need it:
This PR integrates an update to getDatasetVersionDiff use case, which adds an `includeDeaccessioned `param.  The logic is needed to determine whether publishing the draft will require a major version number update.  After a Dataset is deaccessioned, the next version is required to be a major version update.

## Which issue(s) this PR closes:

- Closes #650 #651 #620

## Special notes for your reviewer:

## Suggestions on how to test this:

1. Create a dataset, publish it, then deaccession it
2. Edit the dataset to create a draft version
3. The Dataset page showing the draft version should display correctly
4. Choose Publish Dataset to view the Publish Dataset Modal.  The Publish modal should show that a major version number update is required.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No


