### PR TITLE
Dataset Metadata: update formats of fields

### DIFF
--- a/src/sections/dataset/dataset-metadata/dataset-metadata-fields/DatasetMetadataFieldValueFormatted.tsx
+++ b/src/sections/dataset/dataset-metadata/dataset-metadata-fields/DatasetMetadataFieldValueFormatted.tsx
@@ -116,7 +116,7 @@ function joinObjectValues(obj: object, separator: string): string {
   return Object.values(obj).join(separator)
 }
 
-function joinSubFields(
+export function joinSubFields(
   metadataSubField: DatasetMetadataSubField,
   metadataBlockInfo?: MetadataBlockInfoDisplayFormat,
   parentFieldName?: string

--- a/tests/component/sections/dataset/dataset-metadata/DatasetMetadata.spec.tsx
+++ b/tests/component/sections/dataset/dataset-metadata/DatasetMetadata.spec.tsx
@@ -56,13 +56,10 @@ describe('DatasetMetadata', () => {
       }
       if (extractedImages) {
         extractedImages.forEach((image) => {
-          const [, altText, imageUrl] = image.match(/!\[(.*?)\]\((.*?)\)/) || []
-          const translatedAltText = altText.replaceAll(
-            METADATA_FIELD_DISPLAY_FORMAT_NAME_PLACEHOLDER,
-            metadataFieldName
-          )
-          cy.findByAltText(translatedAltText).should('exist')
-          cy.findByAltText(translatedAltText).should('have.attr', 'src', imageUrl)
+          const [, , imageUrl] = image.match(/!\[(.*?)\]\((.*?)\)/) || []
+
+          cy.findByAltText('Logo URL').should('exist')
+          cy.findByAltText('Logo URL').should('have.attr', 'src', imageUrl)
         })
       }
     } else {
@@ -205,8 +202,10 @@ describe('DatasetMetadata', () => {
         Object.entries(metadataBlock.fields).forEach(([metadataFieldName, metadataFieldValue]) => {
           const metadataFieldNameTranslated = t[metadataBlock.name].datasetField[metadataFieldName]
             .name as string
+          const translateFieldName = (fieldName: string): string => fieldName
           const metadataFieldValueString = metadataFieldValueToDisplayFormat(
             metadataFieldValue,
+            translateFieldName,
             metadataBlockInfoMock
           )
 

--- a/tests/component/sections/dataset/dataset-metadata/DatasetMetadataFieldValueFormatted.spec.tsx
+++ b/tests/component/sections/dataset/dataset-metadata/DatasetMetadataFieldValueFormatted.spec.tsx
@@ -1,16 +1,29 @@
+import { MetadataBlockInfoDisplayFormat } from '@/metadata-block-info/domain/models/MetadataBlockInfo'
 import {
   joinSubFields,
   metadataFieldValueToDisplayFormat
 } from '../../../../../src/sections/dataset/dataset-metadata/dataset-metadata-fields/DatasetMetadataFieldValueFormatted'
 
 describe('joinSubFields formatting logic', () => {
+  const mockTranslateFieldName = (fieldName: string) => fieldName
+
+  const mockDisplayFormatInfo: MetadataBlockInfoDisplayFormat = {
+    name: 'mock name',
+    fields: {
+      series: { displayFormat: ':', type: 'TEXT' },
+      software: { displayFormat: ',', type: 'TEXT' },
+      dateOfCollection: { displayFormat: ';', type: 'TEXT' },
+      otherField: { displayFormat: '\n', type: 'TEXT' }
+    }
+  }
+
   it('joins with colon for colunJoinObj like series', () => {
     const seriesObj = {
       seriesName: 'series name1',
       seriesInformation: 'description'
     }
 
-    const result = joinSubFields(seriesObj, undefined, 'series')
+    const result = joinSubFields(seriesObj, mockTranslateFieldName, mockDisplayFormatInfo, 'series')
 
     expect(result).equal('series name1: description')
   })
@@ -20,7 +33,13 @@ describe('joinSubFields formatting logic', () => {
       softwareName: 'software1',
       softwareVersion: '4.0'
     }
-    const result = joinSubFields(metadataSubField, undefined, 'software')
+
+    const result = joinSubFields(
+      metadataSubField,
+      mockTranslateFieldName,
+      mockDisplayFormatInfo,
+      'software'
+    )
 
     expect(result).equal('software1, 4.0')
   })
@@ -31,7 +50,12 @@ describe('joinSubFields formatting logic', () => {
       end: '2021-12-31'
     }
 
-    const result = joinSubFields(metadataSubField, undefined, 'dateOfCollection')
+    const result = joinSubFields(
+      metadataSubField,
+      mockTranslateFieldName,
+      mockDisplayFormatInfo,
+      'dateOfCollection'
+    )
 
     expect(result).equal('2021-01-01; 2021-12-31')
   })
@@ -42,29 +66,37 @@ describe('joinSubFields formatting logic', () => {
       field2: 'value2'
     }
 
-    const result = joinSubFields(metadataSubField, undefined, 'otherField')
+    const result = joinSubFields(
+      metadataSubField,
+      mockTranslateFieldName,
+      mockDisplayFormatInfo,
+      'otherField'
+    )
 
-    expect(result).equal('value1 \n value2')
+    expect(result).equal('value1\n value2')
   })
 })
 
 describe('metadataFieldValueToDisplayFormat formatting logic', () => {
+  const dummyTranslate = (field: string) => field
+
   it('handles simple string', () => {
-    expect(metadataFieldValueToDisplayFormat('plainText')).equal('plainText')
+    expect(metadataFieldValueToDisplayFormat('plainText', dummyTranslate)).equal('plainText')
   })
 
   it('handles array of strings', () => {
-    expect(metadataFieldValueToDisplayFormat(['one', 'two'])).equal('one; two')
+    expect(metadataFieldValueToDisplayFormat(['one', 'two'], dummyTranslate)).equal('one; two')
   })
 
   it('handles object values', () => {
-    expect(metadataFieldValueToDisplayFormat({ key: 'val1', value: 'val2' })).equal('val1;val2')
+    expect(metadataFieldValueToDisplayFormat({ key: 'val1', value: 'val2' }, dummyTranslate)).equal(
+      'val1;val2'
+    )
   })
 
   it('handles array of objects with newlines', () => {
     const mockSubField = [{ field1: 'A' }, { field1: 'B' }]
-
-    const result = metadataFieldValueToDisplayFormat(mockSubField)
+    const result = metadataFieldValueToDisplayFormat(mockSubField, dummyTranslate)
     expect(result.includes('\n')).equal(true)
   })
 })

--- a/tests/component/sections/dataset/dataset-metadata/DatasetMetadataFieldValueFormatted.spec.tsx
+++ b/tests/component/sections/dataset/dataset-metadata/DatasetMetadataFieldValueFormatted.spec.tsx
@@ -1,0 +1,70 @@
+import {
+  joinSubFields,
+  metadataFieldValueToDisplayFormat
+} from '../../../../../src/sections/dataset/dataset-metadata/dataset-metadata-fields/DatasetMetadataFieldValueFormatted'
+
+describe('joinSubFields formatting logic', () => {
+  it('joins with colon for colunJoinObj like series', () => {
+    const seriesObj = {
+      seriesName: 'series name1',
+      seriesInformation: 'description'
+    }
+
+    const result = joinSubFields(seriesObj, undefined, 'series')
+
+    expect(result).equal('series name1: description')
+  })
+
+  it('joins with comma for commaJoinObj like software', () => {
+    const metadataSubField = {
+      softwareName: 'software1',
+      softwareVersion: '4.0'
+    }
+    const result = joinSubFields(metadataSubField, undefined, 'software')
+
+    expect(result).equal('software1, 4.0')
+  })
+
+  it('joins with semicolon for timePeriodObj like dateOfCollection', () => {
+    const metadataSubField = {
+      start: '2021-01-01',
+      end: '2021-12-31'
+    }
+
+    const result = joinSubFields(metadataSubField, undefined, 'dateOfCollection')
+
+    expect(result).equal('2021-01-01; 2021-12-31')
+  })
+
+  it('joins with line-break for other fields', () => {
+    const metadataSubField = {
+      field1: 'value1',
+      field2: 'value2'
+    }
+
+    const result = joinSubFields(metadataSubField, undefined, 'otherField')
+
+    expect(result).equal('value1 \n value2')
+  })
+})
+
+describe('metadataFieldValueToDisplayFormat formatting logic', () => {
+  it('handles simple string', () => {
+    expect(metadataFieldValueToDisplayFormat('plainText')).equal('plainText')
+  })
+
+  it('handles array of strings', () => {
+    expect(metadataFieldValueToDisplayFormat(['one', 'two'])).equal('one; two')
+  })
+
+  it('handles object values', () => {
+    expect(metadataFieldValueToDisplayFormat({ key: 'val1', value: 'val2' })).equal('val1;val2')
+  })
+
+  it('handles array of objects with newlines', () => {
+    const mockSubField = [{ field1: 'A' }, { field1: 'B' }]
+
+    const result = metadataFieldValueToDisplayFormat(mockSubField)
+    expect(result.includes('\n')).equal(true)
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:
The new SPA implementation shows several issues and inconsistencies in how citation metadata is displayed compared to the older JSF version. These discrepancies affect user experience and metadata accuracy.

1. add hyperlink to Alternative URL
2. use semicolon separate objects, Time Period and Data of Collections, then replace the name to Start Date and End Date accordingly
3. use colon separates Series, Contributors, Funding info , Other Identifier
4. change version formatting with comma, and keyword 'Version: 4.0'
 
## Which issue(s) this PR closes:

- Closes #634 

## Special notes for your reviewer:

## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
