### PR TITLE
Dataset Page:  update Tab skeleton

### DIFF
--- a/src/sections/dataset/DatasetSkeleton.tsx
+++ b/src/sections/dataset/DatasetSkeleton.tsx
@@ -40,5 +40,11 @@ export const TabsSkeleton = () => (
     <Tabs.Tab eventKey="metadata" title="Metadata">
       <Skeleton height="1000px" style={{ marginTop: 20 }} />
     </Tabs.Tab>
+    <Tabs.Tab eventKey="terms" title="Terms">
+      <Skeleton height="1000px" style={{ marginTop: 20 }} />
+    </Tabs.Tab>
+    <Tabs.Tab eventKey="versions" title="Versions">
+      <Skeleton height="1000px" style={{ marginTop: 20 }} />
+    </Tabs.Tab>
   </Tabs>
 )

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -12,6 +12,7 @@ import { DeaccessionDatasetButton } from './DeaccessionDatasetButton'
 import { useSession } from '../../../session/SessionContext'
 import { QueryParamKey, Route } from '../../../Route.enum'
 import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
+import { useNotImplementedModal } from '../../.././not-implemented/NotImplementedModalContext'
 
 interface EditDatasetMenuProps {
   dataset: Dataset
@@ -33,6 +34,7 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
   const { user } = useSession()
   const { t } = useTranslation('dataset')
   const navigate = useNavigate()
+  const { showModal } = useNotImplementedModal()
 
   const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
     const searchParams = new URLSearchParams()
@@ -48,6 +50,22 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
     }
     if (eventKey === EditDatasetMenuItems.METADATA) {
       navigate(`${Route.EDIT_DATASET_METADATA}?${searchParams.toString()}`)
+      return
+    }
+    if (eventKey === EditDatasetMenuItems.TERMS) {
+      showModal()
+      return
+    }
+    if (eventKey === EditDatasetMenuItems.PERMISSIONS) {
+      showModal()
+      return
+    }
+    if (eventKey === EditDatasetMenuItems.PRIVATE_URL) {
+      showModal()
+      return
+    }
+    if (eventKey === EditDatasetMenuItems.THUMBNAILS_PLUS_WIDGETS) {
+      showModal()
       return
     }
   }

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetPermissionsMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetPermissionsMenu.tsx
@@ -46,7 +46,7 @@ export function EditDatasetPermissionsMenu({ dataset }: EditDatasetPermissionsMe
       id={`edit-permissions-menu`}
       title={t('datasetActionButtons.editDataset.permissions.title')}
       variant="secondary"
-      onSelect={() => showModal()}>
+      onSelect={showModal}>
       {dataset.permissions.canManageDatasetPermissions && (
         <DropdownButtonItem>
           {t('datasetActionButtons.editDataset.permissions.dataset')}

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetPermissionsMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetPermissionsMenu.tsx
@@ -5,6 +5,7 @@ import { useEffect, useState } from 'react'
 import { SettingName } from '../../../../settings/domain/models/Setting'
 import { HasPublicStore } from '../../../../settings/domain/models/HasPublicStore'
 import { useTranslation } from 'react-i18next'
+import { useNotImplementedModal } from '../../.././not-implemented/NotImplementedModalContext'
 
 interface EditDatasetPermissionsMenuProps {
   dataset: Dataset
@@ -13,6 +14,7 @@ export function EditDatasetPermissionsMenu({ dataset }: EditDatasetPermissionsMe
   const { t } = useTranslation('dataset')
   const { getSettingByName } = useSettings()
   const [hasPublicStore, setHasPublicStore] = useState<HasPublicStore>(false)
+  const { showModal } = useNotImplementedModal()
 
   useEffect(() => {
     getSettingByName<HasPublicStore>(SettingName.HAS_PUBLIC_STORE)
@@ -43,7 +45,8 @@ export function EditDatasetPermissionsMenu({ dataset }: EditDatasetPermissionsMe
     <DropdownButton
       id={`edit-permissions-menu`}
       title={t('datasetActionButtons.editDataset.permissions.title')}
-      variant="secondary">
+      variant="secondary"
+      onSelect={() => showModal()}>
       {dataset.permissions.canManageDatasetPermissions && (
         <DropdownButtonItem>
           {t('datasetActionButtons.editDataset.permissions.dataset')}

--- a/src/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.tsx
+++ b/src/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.tsx
@@ -32,9 +32,7 @@ export function SubmitForReviewButton({ dataset }: SubmitForReviewButtonProps) {
         !dataset.hasValidTermsOfAccess ||
         !dataset.isValid
       }
-      onClick={() => {
-        showModal()
-      }}>
+      onClick={showModal}>
       {dataset.version.isInReview
         ? t('datasetActionButtons.submitForReview.disabled')
         : t('datasetActionButtons.submitForReview.enabled')}

--- a/src/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.tsx
+++ b/src/sections/dataset/dataset-action-buttons/submit-for-review-button/SubmitForReviewButton.tsx
@@ -2,6 +2,7 @@ import { Dataset, DatasetPublishingStatus } from '../../../../dataset/domain/mod
 import { Button } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
 import { useSession } from '../../../session/SessionContext'
+import { useNotImplementedModal } from '../../../not-implemented/NotImplementedModalContext'
 
 interface SubmitForReviewButtonProps {
   dataset: Dataset
@@ -10,6 +11,7 @@ interface SubmitForReviewButtonProps {
 export function SubmitForReviewButton({ dataset }: SubmitForReviewButtonProps) {
   const { user } = useSession()
   const { t } = useTranslation('dataset')
+  const { showModal } = useNotImplementedModal()
 
   if (
     !dataset.version.isLatest ||
@@ -29,7 +31,10 @@ export function SubmitForReviewButton({ dataset }: SubmitForReviewButtonProps) {
         dataset.checkIsLockedFromPublishing(user.persistentId) ||
         !dataset.hasValidTermsOfAccess ||
         !dataset.isValid
-      }>
+      }
+      onClick={() => {
+        showModal()
+      }}>
       {dataset.version.isInReview
         ? t('datasetActionButtons.submitForReview.disabled')
         : t('datasetActionButtons.submitForReview.enabled')}


### PR DESCRIPTION
## What this PR does / why we need it:

- Dataset page skeleton should show four tabs while loading
- Add `Not implemented modal` to edit dataset actions

## Which issue(s) this PR closes:

- Closes #665 

## Special notes for your reviewer:

## Suggestions on how to test this:

- After publishing dataset, check if there are four tabs shown (Files, Metadata, Terms, Versions)
- Check the Edit Dataset => if something is not implemented, should show Not implemented modal

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:
![image](https://github.com/user-attachments/assets/5ff43a10-6cf8-4da9-892b-1d57be73e02e)

## Additional documentation:
