### PR TITLE
Integrate get application terms of use in account linking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.42",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr296.fa41668",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3560,9 +3560,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.42",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.42/9bb5781e9a747fbe2e07dc74e8550b42c0efb9e9",
-      "integrity": "sha512-qx2hLDTKx/7vnj7jkNpzguXaNzcmmtDvoQVJaCewrw1+ogH2G+pv9S40dDTJK7Wf8Zuxz6uxsUvA9O9WcurdNQ==",
+      "version": "2.0.0-pr296.fa41668",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr296.fa41668/119112c8bbcffa235d3b65026d3fdfdd126c5d4c",
+      "integrity": "sha512-8luMS1K8wki7/bPzd+nnq5NIbmticYQx5SM670qhkq+yjlifGl8/xGWRaWBzjvCaIL7yCeUr6pgbfqeS/IU1gQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-pr296.fa41668",
+        "@iqss/dataverse-client-javascript": "2.0.0-alpha.44",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3560,9 +3560,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-pr296.fa41668",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr296.fa41668/119112c8bbcffa235d3b65026d3fdfdd126c5d4c",
-      "integrity": "sha512-8luMS1K8wki7/bPzd+nnq5NIbmticYQx5SM670qhkq+yjlifGl8/xGWRaWBzjvCaIL7yCeUr6pgbfqeS/IU1gQ==",
+      "version": "2.0.0-alpha.44",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.44/17eec76da851b0b204674c74c66937b588425b8f",
+      "integrity": "sha512-zEcqwFbqB1rJQAoRzthURdnlnfGMfoctVGt1RPfEBDVWHC6esM9OeS210v2C+ASMJ0IrK4e+9d7775ZpaMrZRA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-pr296.fa41668",
+    "@iqss/dataverse-client-javascript": "2.0.0-alpha.44",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.42",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr296.fa41668",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/public/locales/en/signUp.json
+++ b/public/locales/en/signUp.json
@@ -64,8 +64,7 @@
       "primaryLabel": "General Terms of Use",
       "label": "I have read and accept the Dataverse General Terms of Use as outlined above.",
       "description": "The terms and conditions for using the application and services.",
-      "required": "Please check the box to indicate your acceptance of the General Terms of Use.",
-      "noTerms": "There are no Terms of Use for this Dataverse installation."
+      "required": "Please check the box to indicate your acceptance of the General Terms of Use."
     }
   },
   "submit": "Create Account",

--- a/src/info/infrastructure/repositories/DataverseInfoJSDataverseRepository.ts
+++ b/src/info/infrastructure/repositories/DataverseInfoJSDataverseRepository.ts
@@ -1,5 +1,8 @@
-import { getDataverseVersion, ReadError } from '@iqss/dataverse-client-javascript'
-import { axiosInstance } from '@/axiosInstance'
+import {
+  getApplicationTermsOfUse,
+  getDataverseVersion,
+  ReadError
+} from '@iqss/dataverse-client-javascript'
 import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
 import { DataverseVersion } from '@/info/domain/models/DataverseVersion'
 import { TermsOfUse } from '@/info/domain/models/TermsOfUse'
@@ -30,12 +33,9 @@ export class DataverseInfoJSDataverseRepository implements DataverseInfoReposito
       })
   }
 
-  async getTermsOfUse() {
-    //TODO - This is not actually used and should be replaced with a js-dataverse use case when we have available the endpoint to get the installation terms of use not api terms of use.
-    const response = await axiosInstance.get<{ data: { message: TermsOfUse } }>(
-      '/api/v1/info/apiTermsOfUse',
-      { excludeToken: true }
-    )
-    return JSTermsOfUseMapper.toSanitizedTermsOfUse(response.data.data.message)
+  getTermsOfUse(): Promise<TermsOfUse> {
+    return getApplicationTermsOfUse
+      .execute()
+      .then((termsOfUse) => JSTermsOfUseMapper.toSanitizedTermsOfUse(termsOfUse))
   }
 }

--- a/src/sections/sign-up/SignUp.tsx
+++ b/src/sections/sign-up/SignUp.tsx
@@ -2,16 +2,22 @@ import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Alert, Tabs } from '@iqss/dataverse-design-system'
 import { UserRepository } from '@/users/domain/repositories/UserRepository'
+import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
 import { useLoading } from '../loading/LoadingContext'
 import { ValidTokenNotLinkedAccountForm } from './valid-token-not-linked-account-form/ValidTokenNotLinkedAccountForm'
 import styles from './SignUp.module.scss'
 
 interface SignUpProps {
   userRepository: UserRepository
+  dataverseInfoRepository: DataverseInfoRepository
   hasValidTokenButNotLinkedAccount: boolean
 }
 
-export const SignUp = ({ userRepository, hasValidTokenButNotLinkedAccount }: SignUpProps) => {
+export const SignUp = ({
+  userRepository,
+  dataverseInfoRepository,
+  hasValidTokenButNotLinkedAccount
+}: SignUpProps) => {
   const { t } = useTranslation('signUp')
   const { setIsLoading } = useLoading()
 
@@ -58,7 +64,10 @@ export const SignUp = ({ userRepository, hasValidTokenButNotLinkedAccount }: Sig
         <Tabs.Tab eventKey="accountInfo" title={t('accountInfo')}>
           <div className={styles['tab-container']}>
             {hasValidTokenButNotLinkedAccount && (
-              <ValidTokenNotLinkedAccountForm userRepository={userRepository} />
+              <ValidTokenNotLinkedAccountForm
+                userRepository={userRepository}
+                dataverseInfoRepository={dataverseInfoRepository}
+              />
             )}
           </div>
         </Tabs.Tab>

--- a/src/sections/sign-up/SignUpFactory.tsx
+++ b/src/sections/sign-up/SignUpFactory.tsx
@@ -2,10 +2,11 @@ import { ReactElement } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { SignUp } from './SignUp'
 import { QueryParamKey } from '../Route.enum'
-
 import { UserJSDataverseRepository } from '@/users/infrastructure/repositories/UserJSDataverseRepository'
+import { DataverseInfoJSDataverseRepository } from '@/info/infrastructure/repositories/DataverseInfoJSDataverseRepository'
 
 const userRepository = new UserJSDataverseRepository()
+const dataverseInfoRepository = new DataverseInfoJSDataverseRepository()
 
 export class SignUpFactory {
   static create(): ReactElement {
@@ -22,6 +23,7 @@ function SignUpWithSearchParams() {
   return (
     <SignUp
       userRepository={userRepository}
+      dataverseInfoRepository={dataverseInfoRepository}
       hasValidTokenButNotLinkedAccount={hasValidTokenButNotLinkedAccount}
     />
   )

--- a/src/sections/sign-up/valid-token-not-linked-account-form/FormFields.module.scss
+++ b/src/sections/sign-up/valid-token-not-linked-account-form/FormFields.module.scss
@@ -19,10 +19,12 @@
 }
 
 .terms-of-use-wrapper {
-  max-height: 200px;
+  height: 100px;
+  min-height: 100px;
   padding: 12px;
   overflow-y: auto;
-  background-color: #f5f5f5;
+  background-color: #e9ecef;
   border: solid 1px $dv-border-color;
   border-radius: 6px;
+  resize: vertical;
 }

--- a/src/sections/sign-up/valid-token-not-linked-account-form/FormFields.module.scss
+++ b/src/sections/sign-up/valid-token-not-linked-account-form/FormFields.module.scss
@@ -23,7 +23,7 @@
   min-height: 100px;
   padding: 12px;
   overflow-y: auto;
-  background-color: #e9ecef;
+  background-color: #f5f5f5;
   border: solid 1px $dv-border-color;
   border-radius: 6px;
   resize: vertical;

--- a/src/sections/sign-up/valid-token-not-linked-account-form/FormFields.tsx
+++ b/src/sections/sign-up/valid-token-not-linked-account-form/FormFields.tsx
@@ -318,7 +318,7 @@ export const FormFields = ({ userRepository, formDefaultValues, termsOfUse }: Fo
                     <div
                       className={styles['terms-of-use-wrapper']}
                       dangerouslySetInnerHTML={{
-                        __html: termsOfUse ? termsOfUse : t('fields.termsAccepted.noTerms')
+                        __html: termsOfUse
                       }}
                     />
 

--- a/src/sections/sign-up/valid-token-not-linked-account-form/ValidTokenNotLinkedAccountForm.tsx
+++ b/src/sections/sign-up/valid-token-not-linked-account-form/ValidTokenNotLinkedAccountForm.tsx
@@ -1,24 +1,30 @@
 import { useContext } from 'react'
 import { AuthContext } from 'react-oauth2-code-pkce'
+import { Alert } from '@iqss/dataverse-design-system'
 import { UserRepository } from '@/users/domain/repositories/UserRepository'
-// import { useGetTermsOfUse } from '@/shared/hooks/useGetTermsOfUse'
+import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
+import { useGetTermsOfUse } from '@/shared/hooks/useGetTermsOfUse'
 import { OIDC_STANDARD_CLAIMS, type ValidTokenNotLinkedAccountFormData } from './types'
 import { ValidTokenNotLinkedAccountFormHelper } from './ValidTokenNotLinkedAccountFormHelper'
 import { FormFields } from './FormFields'
-// import { FormFieldsSkeleton } from './FormFieldsSkeleton'
+import { FormFieldsSkeleton } from './FormFieldsSkeleton'
 
 interface ValidTokenNotLinkedAccountFormProps {
   userRepository: UserRepository
+  dataverseInfoRepository: DataverseInfoRepository
 }
 
 export const ValidTokenNotLinkedAccountForm = ({
-  userRepository
+  userRepository,
+  dataverseInfoRepository
 }: ValidTokenNotLinkedAccountFormProps) => {
   const { tokenData } = useContext(AuthContext)
 
-  // TODO - Use actual terms of use when available in API 👇
-  // const { termsOfUse, isLoading: isLoadingTermsOfUse } =
-  //   useGetTermsOfUse(dataverseInfoRepository)
+  const {
+    termsOfUse,
+    isLoading: isLoadingTermsOfUse,
+    error: errorTermsOfUse
+  } = useGetTermsOfUse(dataverseInfoRepository)
 
   const defaultUserName =
     ValidTokenNotLinkedAccountFormHelper.getTokenDataValue<string>(
@@ -58,15 +64,19 @@ export const ValidTokenNotLinkedAccountForm = ({
     termsAccepted: false
   }
 
-  // if (isLoadingTermsOfUse) {
-  //   return <FormFieldsSkeleton />
-  // }
+  if (isLoadingTermsOfUse) {
+    return <FormFieldsSkeleton />
+  }
+
+  if (errorTermsOfUse) {
+    return <Alert variant="danger">{errorTermsOfUse}</Alert>
+  }
 
   return (
     <FormFields
       userRepository={userRepository}
       formDefaultValues={formDefaultValues}
-      termsOfUse=""
+      termsOfUse={termsOfUse}
     />
   )
 }

--- a/src/sections/sign-up/valid-token-not-linked-account-form/useSubmitUser.ts
+++ b/src/sections/sign-up/valid-token-not-linked-account-form/useSubmitUser.ts
@@ -69,7 +69,8 @@ export const useSubmitUser = (
       })
       .catch((err: WriteError) => {
         const error = new JSDataverseWriteErrorHandler(err)
-        const formattedError = error.getReasonWithoutStatusCode() ?? error.getErrorMessage()
+        const formattedError =
+          error.getReasonWithoutStatusCode() ?? /* istanbul ignore next */ error.getErrorMessage()
 
         setSubmitError(formattedError)
         setSubmissionStatus(SubmissionStatus.Errored)

--- a/src/shared/core/domain/models/PublicationStatus.ts
+++ b/src/shared/core/domain/models/PublicationStatus.ts
@@ -1,5 +1,7 @@
 export enum PublicationStatus {
   Published = 'Published',
   Unpublished = 'Unpublished',
-  Draft = 'Draft'
+  Draft = 'Draft',
+  Deaccessioned = 'Deaccessioned',
+  InReview = 'In Review'
 }

--- a/src/shared/hooks/useGetTermsOfUse.ts
+++ b/src/shared/hooks/useGetTermsOfUse.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react'
 import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
+import { ReadError } from '@iqss/dataverse-client-javascript'
+import { JSDataverseReadErrorHandler } from '../helpers/JSDataverseReadErrorHandler'
 
 interface UseGetTermsOfUseReturnType {
   termsOfUse: string
@@ -22,11 +24,15 @@ export const useGetTermsOfUse = (
 
         setTermsOfUse(termsOfUse)
       } catch (err) {
-        const errorMessage =
-          err instanceof Error && err.message
-            ? err.message
-            : 'Something went wrong getting the use of terms. Try again later.'
-        setError(errorMessage)
+        if (err instanceof ReadError) {
+          const error = new JSDataverseReadErrorHandler(err)
+          const formattedError =
+            error.getReasonWithoutStatusCode() ?? /* istanbul ignore next */ error.getErrorMessage()
+
+          setError(formattedError)
+        } else {
+          setError('Something went wrong getting the use of terms. Try again later.')
+        }
       } finally {
         setIsLoading(false)
       }

--- a/src/stories/shared-mock-repositories/info/DataverseInfoMockErrorRepository.ts
+++ b/src/stories/shared-mock-repositories/info/DataverseInfoMockErrorRepository.ts
@@ -1,0 +1,22 @@
+import { DataverseVersion } from '@/info/domain/models/DataverseVersion'
+import { TermsOfUse } from '@/info/domain/models/TermsOfUse'
+import { FakerHelper } from '@tests/component/shared/FakerHelper'
+import { DataverseInfoMockRepository } from './DataverseInfoMockRepository'
+
+export class DataverseInfoMockErrorRepository implements DataverseInfoMockRepository {
+  getVersion(): Promise<DataverseVersion> {
+    return new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        reject()
+      }, FakerHelper.loadingTimout())
+    })
+  }
+
+  getTermsOfUse(): Promise<TermsOfUse> {
+    return new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        reject()
+      }, FakerHelper.loadingTimout())
+    })
+  }
+}

--- a/src/stories/sign-up/SignUp.stories.tsx
+++ b/src/stories/sign-up/SignUp.stories.tsx
@@ -5,6 +5,8 @@ import { SignUp } from '@/sections/sign-up/SignUp'
 import { WithOIDCAuthContext } from '../WithOIDCAuthContext'
 import { UserMockRepository } from '../shared-mock-repositories/user/UserMockRepository'
 import { DataverseInfoMockRepository } from '../shared-mock-repositories/info/DataverseInfoMockRepository'
+import { DataverseInfoMockLoadingRepository } from '../shared-mock-repositories/info/DataverseInfoMockLoadingkRepository'
+import { DataverseInfoMockErrorRepository } from '../shared-mock-repositories/info/DataverseInfoMockErrorRepository'
 
 const meta: Meta<typeof SignUp> = {
   title: 'Pages/Sign Up',
@@ -23,6 +25,26 @@ export const ValidTokenWithNotLinkedAccount: Story = {
     <SignUp
       userRepository={new UserMockRepository()}
       dataverseInfoRepository={new DataverseInfoMockRepository()}
+      hasValidTokenButNotLinkedAccount
+    />
+  )
+}
+
+export const LoadingTermsOfUse: Story = {
+  render: () => (
+    <SignUp
+      userRepository={new UserMockRepository()}
+      dataverseInfoRepository={new DataverseInfoMockLoadingRepository()}
+      hasValidTokenButNotLinkedAccount
+    />
+  )
+}
+
+export const FailedToFetchTermsOfUse: Story = {
+  render: () => (
+    <SignUp
+      userRepository={new UserMockRepository()}
+      dataverseInfoRepository={new DataverseInfoMockErrorRepository()}
       hasValidTokenButNotLinkedAccount
     />
   )

--- a/src/stories/sign-up/SignUp.stories.tsx
+++ b/src/stories/sign-up/SignUp.stories.tsx
@@ -4,6 +4,7 @@ import { WithI18next } from '../WithI18next'
 import { SignUp } from '@/sections/sign-up/SignUp'
 import { WithOIDCAuthContext } from '../WithOIDCAuthContext'
 import { UserMockRepository } from '../shared-mock-repositories/user/UserMockRepository'
+import { DataverseInfoMockRepository } from '../shared-mock-repositories/info/DataverseInfoMockRepository'
 
 const meta: Meta<typeof SignUp> = {
   title: 'Pages/Sign Up',
@@ -19,6 +20,10 @@ type Story = StoryObj<typeof SignUp>
 
 export const ValidTokenWithNotLinkedAccount: Story = {
   render: () => (
-    <SignUp userRepository={new UserMockRepository()} hasValidTokenButNotLinkedAccount />
+    <SignUp
+      userRepository={new UserMockRepository()}
+      dataverseInfoRepository={new DataverseInfoMockRepository()}
+      hasValidTokenButNotLinkedAccount
+    />
   )
 }

--- a/tests/component/info/models/TermsOfUseMother.ts
+++ b/tests/component/info/models/TermsOfUseMother.ts
@@ -2,6 +2,10 @@ import { TermsOfUse } from '@/info/domain/models/TermsOfUse'
 
 export class TermsOfUseMother {
   static create(): TermsOfUse {
+    return 'Be nice to each other!'
+  }
+
+  static createWithOnClickScript(): TermsOfUse {
     return '<h3>Terms of Use SPA dev</h3><p>Please see our full <a href="https://beta.dataverse.org/spa/">terms of use</a></p><p onclick="alert(\'this alert is to text sanitization\')">Thanks for reading!</p>'
   }
 

--- a/tests/component/sections/sign-up/SignUp.spec.tsx
+++ b/tests/component/sections/sign-up/SignUp.spec.tsx
@@ -26,7 +26,11 @@ describe('SignUp', () => {
           error: null,
           login: () => {} // 👈 deprecated
         }}>
-        <SignUp userRepository={userRepository} hasValidTokenButNotLinkedAccount={true} />
+        <SignUp
+          userRepository={userRepository}
+          dataverseInfoRepository={dataverseInfoRepository}
+          hasValidTokenButNotLinkedAccount={true}
+        />
       </AuthContext.Provider>
     )
 
@@ -52,7 +56,11 @@ describe('SignUp', () => {
           error: null,
           login: () => {} // 👈 deprecated
         }}>
-        <SignUp userRepository={userRepository} hasValidTokenButNotLinkedAccount={false} />
+        <SignUp
+          userRepository={userRepository}
+          dataverseInfoRepository={dataverseInfoRepository}
+          hasValidTokenButNotLinkedAccount={false}
+        />
       </AuthContext.Provider>
     )
 

--- a/tests/component/shared/hooks/useGetTermsOfUse.spec.ts
+++ b/tests/component/shared/hooks/useGetTermsOfUse.spec.ts
@@ -2,6 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { useGetTermsOfUse } from '@/shared/hooks/useGetTermsOfUse'
 import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
 import { TermsOfUseMother } from '@tests/component/info/models/TermsOfUseMother'
+import { ReadError } from '@iqss/dataverse-client-javascript'
 
 const dataverseInfoRepository: DataverseInfoRepository = {} as DataverseInfoRepository
 const termsOfUseMock = TermsOfUseMother.create()
@@ -25,8 +26,8 @@ describe('useGetTermsOfUse', () => {
   })
 
   describe('Error handling', () => {
-    it('should return correct error message when there is an error type catched', async () => {
-      dataverseInfoRepository.getTermsOfUse = cy.stub().rejects(new Error('Error message'))
+    it('should return correct error message when it is a ReadError instance from js-dataverse', async () => {
+      dataverseInfoRepository.getTermsOfUse = cy.stub().rejects(new ReadError('Error message'))
 
       const { result } = renderHook(() => useGetTermsOfUse(dataverseInfoRepository))
 
@@ -41,7 +42,7 @@ describe('useGetTermsOfUse', () => {
       })
     })
 
-    it('should return correct error message when there is not an error type catched', async () => {
+    it('should return correct default error message when it is not a ReadError instance from js-dataverse', async () => {
       dataverseInfoRepository.getTermsOfUse = cy.stub().rejects('Error message')
 
       const { result } = renderHook(() => useGetTermsOfUse(dataverseInfoRepository))


### PR DESCRIPTION
## What this PR does / why we need it:
Integrate the js-dataverse `GetApplicationTermsOfUse` use case.
After a successful OIDC login from the SPA, an account linking / complete information screen is displayed. At that point, we need to display the Installation Terms Of Use.

![Image](https://github.com/user-attachments/assets/1d96d6df-9d3d-4e8f-baf4-c52c3aa6c192)

## Which issue(s) this PR closes:

- Closes #674 

## Special notes for your reviewer:
⚠️ ~The js-dataverse package is using a PR version, after https://github.com/IQSS/dataverse-client-javascript/pull/296 is merged we need to update package version to use alpha~.

## Suggestions on how to test this:
Step 1: Run the Development Environment

1. Execute npm i.
2. Navigate with cd packages/design-system && npm i && npm run build.
3. Return with cd ../../.
4. Ensure you have a .env file similar to .env.example
5. Navigate with cd dev-env.
6. Before running next step, be sure have a fresh unstable dataverse image.
7. Start the environment using ./run-env.sh unstable.
8. To verify the environment, visit http://localhost:8000/ and check your local Dataverse installation.

Step 2: Test the feature

1. Got to the SPA and click the Log In button.
2. Sign in with a user from the keycloak instance
     email: dataverse-user@mailinator.com
     pass: user
3. You should be redirected to the Account - Sign Up page. Under General Terms of Use you should see the default message when installation terms of use are not set which is "There are no Terms of Use for this Dataverse Installation". Don't close this page.
4. Now lets update the applications terms:
- Create a `tou.html` file in your desktop with something like: `<p>Be nice to each other</p>`
- now run `curl -X PUT http://localhost:8000/api/admin/settings/:ApplicationTermsOfUse --upload-file ~/Desktop/tou.html`  and you should receive a response like: `{"status":"OK","data":{":ApplicationTermsOfUse":"<p>Be nice to each other</p>\n"}}`

5. Now reload the Account - Sign Up page and you should see the new General Terms of Use displayed.

