### PR TITLE
skip deploy of backend, use IDE to deploy using debug port

### DIFF
--- a/dev-env/caddy/Caddyfile
+++ b/dev-env/caddy/Caddyfile
@@ -1,0 +1,12 @@
+# This configuration is intended to be used with Caddy, a very small high perf proxy.
+# It will serve the application containers Payara Admin GUI via HTTP instead of HTTPS,
+# avoiding the trouble of self signed certificates for local development.
+
+:4848 {
+	reverse_proxy https://dataverse:4848 {
+		transport http {
+			tls_insecure_skip_verify
+		}
+		header_down Location "^https://" "http://"
+	}
+}

--- a/dev-env/docker-compose-dev.yml
+++ b/dev-env/docker-compose-dev.yml
@@ -43,6 +43,7 @@ services:
     restart: on-failure
     user: payara
     environment:
+      SKIP_DEPLOY: 1
       dataverse_files_storage__driver__id: s3
       DATAVERSE_DB_HOST: postgres
       DATAVERSE_DB_PASSWORD: secret
@@ -77,7 +78,10 @@ services:
     # This is necessary because the dev_nginx proxy is placed on top of the Dataverse service, making those URLs unreachable unless this port is exposed. 
     # This workaround is only necessary and intended for the local dev environment and will not be used in the remote environment, where we use a production DNS.
     ports:
-      - '8080:8080'
+      - "8080:8080" # HTTP (Dataverse Application)
+      - "4949:4848" # HTTPS (Payara Admin Console)
+      - "9009:9009" # JDWP
+      - "8686:8686" # JMX
     networks:
       - dataverse
     depends_on:
@@ -92,6 +96,24 @@ services:
     mem_limit: 2147483648 # 2 GiB
     mem_reservation: 1024m
     privileged: false
+
+  # This proxy configuration is only intended to be used for development purposes!
+  # DO NOT USE IN PRODUCTION! HIGH SECURITY RISK!
+  dev_proxy:
+    image: caddy:2-alpine
+    # The command below is enough to enable using the admin gui, but it will not rewrite location headers to HTTP.
+    # To achieve rewriting from https:// to http://, we need a simple configuration file
+    #command: ["caddy", "reverse-proxy", "-f", ":4848", "-t", "https://dataverse:4848", "--insecure"]
+    command: ["caddy", "run", "-c", "/Caddyfile"]
+    ports:
+      - "4848:4848" # Will expose Payara Admin Console (HTTPS) as HTTP
+    restart: always
+    volumes:
+      - ./caddy/Caddyfile:/Caddyfile:ro
+    depends_on:
+      - dev_dataverse
+    networks:
+      - dataverse
 
   dv_initializer:
     container_name: 'dv_initializer'

--- a/dev-env/run-env.sh
+++ b/dev-env/run-env.sh
@@ -14,4 +14,4 @@ echo "INFO - Removing current environment if exists..."
 ./rm-env.sh
 
 echo "INFO - Running docker containers..."
-docker compose -f "./docker-compose-dev.yml" up -d --build
+SKIP_DEPLOY=1 docker compose -f "./docker-compose-dev.yml" up -d --build


### PR DESCRIPTION
## What this PR does / why we need it:

backend [fast redeploy](https://guides.dataverse.org/en/6.6/container/dev-usage.html#redeploying) is awesome 🎉
frontend [dev-env](https://github.com/IQSS/dataverse-frontend/blob/13446785b1cd87c52d46fa9295e71ee73bada1e8/DEVELOPER_GUIDE.md#running-the-project-locally) can't use it 😞

## Which issue(s) this PR closes:

- Closes #689

## Special notes for your reviewer:

I noticed that single quotes are used in this repo (double in the main repo). I'm happy to change them to single if that's what we want.

## Suggestions on how to test this:

Like usual, run this:

```
./run-env.sh unstable
```

Then deploy using your IDE (you have to [configure](https://guides.dataverse.org/en/6.6/container/dev-usage.html#redeploying) it first) using Java Debug Wire Protocol (JDWP). In the recording mentioned in the issue, Netbeans is used.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

No.

## Is there a release notes update needed for this change?:

Maybe?

## Additional documentation:

See discussion at [#dev > full stack DX, fast feedback loop @ 💬](https://dataverse.zulipchat.com/#narrow/channel/379673-dev/topic/full.20stack.20DX.2C.20fast.20feedback.20loop/near/515718852)

Container meeting from 2025-05-08 ([notes](https://docs.google.com/document/d/1-sq4fMJZ_f9sOQrhDdNF5FTJ5c212BBaUoF8foh4B20/edit?usp=sharing), [recording](https://drive.google.com/drive/folders/1fuu-UExLELZvqWBA0MaL-1_KmwUCK3Di?usp=drive_link))