### PR TITLE
Rearrange Homepage elements on mobile to show search on top

### DIFF
--- a/src/sections/homepage/Homepage.module.scss
+++ b/src/sections/homepage/Homepage.module.scss
@@ -2,6 +2,12 @@
 @import 'node_modules/@iqss/dataverse-design-system/src/lib/assets/styles/design-tokens/colors.module';
 @import 'src/assets/variables';
 
+@mixin border-bottom-separator($pb: 1.5rem) {
+  margin-bottom: 1.5rem;
+  padding-bottom: $pb;
+  border-bottom: solid 1px $dv-border-color;
+}
+
 .section-wrapper {
   display: flex;
   flex-direction: column;
@@ -10,34 +16,42 @@
   padding-top: 2rem;
 }
 
-.separation-line {
-  width: 100%;
-  height: 1px;
-  margin: 0 auto;
-  background-color: $dv-border-color;
-  margin-block: 1.5rem;
-}
+.usage-wrapper {
+  @include border-bottom-separator;
 
-.featured-items-wrapper {
-  min-width: 100%;
+  order: 2;
 
-  .separation-line {
-    display: none;
-  }
-
-  &:has(h4) {
-    .separation-line {
-      display: block;
-    }
+  @media (min-width: 1024px) {
+    order: 1;
   }
 }
 
 .middle-search-cta-wrapper {
+  @include border-bottom-separator(3.5rem);
+
   display: flex;
   flex-direction: column;
   gap: 2rem;
   align-items: center;
   justify-content: center;
+  order: 1;
   width: 100%;
-  padding-block: 2rem;
+  padding-top: 2rem;
+
+  @media (min-width: 1024px) {
+    order: 2;
+  }
+}
+
+.featured-items-wrapper {
+  order: 3;
+  min-width: 100%;
+
+  &:has(h4) {
+    @include border-bottom-separator;
+  }
+}
+
+.metrics-wrapper {
+  order: 4;
 }

--- a/src/sections/homepage/Homepage.tsx
+++ b/src/sections/homepage/Homepage.tsx
@@ -34,9 +34,9 @@ export const Homepage = ({ collectionRepository, dataverseHubRepository }: Homep
 
   return (
     <section className={styles['section-wrapper']}>
-      <Usage collectionId={collection?.id as string} />
-
-      <div className={styles['separation-line']} />
+      <div className={styles['usage-wrapper']}>
+        <Usage collectionId={collection?.id as string} />
+      </div>
 
       <div className={styles['middle-search-cta-wrapper']}>
         <SearchInput />
@@ -44,8 +44,6 @@ export const Homepage = ({ collectionRepository, dataverseHubRepository }: Homep
           {t('browseCollections')}
         </Link>
       </div>
-
-      <div className={styles['separation-line']} />
 
       {collection && (
         <>
@@ -55,12 +53,13 @@ export const Homepage = ({ collectionRepository, dataverseHubRepository }: Homep
               collectionId={collection.id}
               withLoadingSkeleton={true}
             />
-            <div className={styles['separation-line']} />
           </div>
         </>
       )}
 
-      <Metrics dataverseHubRepository={dataverseHubRepository} />
+      <div className={styles['metrics-wrapper']}>
+        <Metrics dataverseHubRepository={dataverseHubRepository} />
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Rearrange the elements of the home page so that on mobile screens the search bar appears at the top.

## Which issue(s) this PR closes:

- Closes #684 

## Suggestions on how to test this:
Validate that on mobile screens (375px) the search bar is shown at the top and on desktop screens it is shown in the middle as it is currently shown in beta.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
Yes.
<img src="https://github.com/user-attachments/assets/ff7fac38-8c13-4a81-a60e-75c2884573d1" width="200" />


## Is there a release notes update needed for this change?:
No

## Additional documentation:
No