### PR TITLE
Designs for Homepage Search Engine Selector

### DIFF
--- a/packages/design-system/src/lib/components/dropdown-button/DropdownButton.tsx
+++ b/packages/design-system/src/lib/components/dropdown-button/DropdownButton.tsx
@@ -18,6 +18,7 @@ interface DropdownButtonProps {
   disabled?: boolean
   children: ReactNode
   ariaLabel?: string
+  size?: 'sm' | 'lg'
 }
 
 export function DropdownButton({
@@ -30,6 +31,7 @@ export function DropdownButton({
   onSelect,
   disabled,
   ariaLabel,
+  size,
   children
 }: DropdownButtonProps) {
   return (
@@ -46,6 +48,7 @@ export function DropdownButton({
       variant={variant}
       as={asButtonGroup ? ButtonGroup : undefined}
       disabled={disabled}
+      size={size}
       onSelect={onSelect}>
       {children}
     </DropdownButtonBS>

--- a/packages/design-system/src/lib/components/dropdown-button/dropdown-button-item/DropdownButtonItem.tsx
+++ b/packages/design-system/src/lib/components/dropdown-button/dropdown-button-item/DropdownButtonItem.tsx
@@ -9,6 +9,7 @@ interface DropdownItemProps extends React.HTMLAttributes<HTMLElement> {
   children: ReactNode
   as?: ElementType
   to?: string // When passing <Link> as the `as` prop, this prop is used to pass the URL <DropdownButtonItem as={Link} to="/some-path">...</DropdownButtonItem>
+  active?: boolean
 }
 
 export function DropdownButtonItem({
@@ -18,6 +19,7 @@ export function DropdownButtonItem({
   download,
   children,
   as,
+  active,
   ...props
 }: DropdownItemProps) {
   return (
@@ -26,6 +28,7 @@ export function DropdownButtonItem({
       eventKey={eventKey}
       disabled={disabled}
       download={download}
+      active={active}
       as={as}
       {...props}>
       {children}

--- a/src/sections/homepage/search-input/SearchDropdown.tsx
+++ b/src/sections/homepage/search-input/SearchDropdown.tsx
@@ -1,0 +1,74 @@
+import { ForwardedRef, forwardRef } from 'react'
+import cn from 'classnames'
+import { Dropdown } from 'react-bootstrap'
+import { CaretDownFill, Search as SearchIcon, Stars as StarsIcon } from 'react-bootstrap-icons'
+import styles from './SearchInput.module.scss'
+
+interface SearchDropdownProps {
+  searchEngineSelected: string
+  handleSearchEngineSelect: (eventKey: string | null) => void
+  position?: 'left' | 'right'
+}
+
+export const SearchDropdown = ({
+  searchEngineSelected,
+  handleSearchEngineSelect,
+  position
+}: SearchDropdownProps) => {
+  return (
+    <Dropdown
+      className={styles['search-dropdown']}
+      align={position === 'left' ? 'start' : 'end'}
+      onSelect={handleSearchEngineSelect}>
+      <Dropdown.Toggle as={CustomToggle} position={position} />
+
+      <Dropdown.Menu className={styles['search-dropdown-menu']}>
+        <Dropdown.Header>Search Engines</Dropdown.Header>
+        <Dropdown.Item
+          eventKey="one"
+          active={searchEngineSelected === 'one'}
+          className={styles['search-dropdown-item']}>
+          <SearchIcon size={12} />
+          Dataverse Engine
+        </Dropdown.Item>
+        <Dropdown.Item
+          eventKey="two"
+          active={searchEngineSelected === 'two'}
+          className={styles['search-dropdown-item']}>
+          <StarsIcon size={12} />
+          External Engine 1
+        </Dropdown.Item>
+        <Dropdown.Item
+          eventKey="three"
+          active={searchEngineSelected === 'three'}
+          className={styles['search-dropdown-item']}>
+          <StarsIcon size={12} />
+          External Engine 2
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  )
+}
+
+interface CustomToggleProps {
+  onClick: (event: React.MouseEvent<HTMLElement>) => void
+  position?: 'left' | 'right'
+}
+
+const CustomToggle = forwardRef(({ onClick, position }: CustomToggleProps, ref) => (
+  <button
+    type="button"
+    ref={ref as ForwardedRef<HTMLButtonElement>}
+    onClick={(e) => {
+      e.preventDefault()
+      onClick(e)
+    }}
+    className={cn(styles['search-dropdown-btn'], {
+      [styles['on-the-left']]: position === 'left',
+      [styles['on-the-right']]: position === 'right'
+    })}>
+    <CaretDownFill size={14} />
+  </button>
+))
+
+CustomToggle.displayName = 'CustomToggle'

--- a/src/sections/homepage/search-input/SearchInput.module.scss
+++ b/src/sections/homepage/search-input/SearchInput.module.scss
@@ -7,6 +7,7 @@
   --search-input-gap: 4px;
   --search-input-transition: 0.15s ease-in-out;
   --search-icon-btn-width: 60px;
+  --search-engine-icon-btn-width: 35px;
 }
 
 .search-input-wrapper {
@@ -36,11 +37,14 @@
 }
 
 .text-input {
+  position: relative;
+  z-index: 2;
   height: 100%;
   border: 0;
   border-radius: 999px;
   caret-color: $dv-brand-color;
   padding-inline: 1.25rem;
+  outline: solid 4px $dv-brand-color;
 
   &:focus {
     box-shadow: none;
@@ -53,7 +57,9 @@
   margin-right: 1rem;
 }
 
-.search-btn {
+%search-btn {
+  position: relative;
+  z-index: 3;
   display: grid;
   place-items: center;
   min-width: var(--search-icon-btn-width);
@@ -81,5 +87,82 @@
 
   svg {
     color: $dv-primary-text-color;
+  }
+}
+
+.search-btn {
+  @extend %search-btn;
+}
+
+.search-dropdown {
+  height: 100%;
+
+  .search-dropdown-btn {
+    @extend %search-btn;
+
+    z-index: 2;
+    min-width: var(--search-engine-icon-btn-width);
+
+    &.on-the-left {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+
+      &::after {
+        position: absolute;
+        top: 0;
+        left: 100%;
+        width: calc(
+          1.25rem + var(--search-input-gap)
+        ); // The padding inline the input has + flex gap of the search input
+
+        height: 100%;
+        background-color: transparent;
+        transition: var(--search-input-transition);
+        transition-property: background-color;
+        content: '';
+      }
+
+      &:hover::after {
+        background-color: color.adjust($dv-brand-color, $lightness: -10%);
+      }
+
+      &:active::after {
+        background-color: color.adjust($dv-brand-color, $lightness: -15%);
+      }
+
+      svg {
+        margin-left: 4px;
+      }
+    }
+
+    &.on-the-right {
+      aspect-ratio: 1;
+      height: 100%;
+    }
+  }
+
+  .search-dropdown-menu {
+    min-width: calc(var(--search-input-max-width) / 2);
+    margin-top: 10px;
+    padding-top: 0;
+
+    .search-dropdown-item {
+      display: flex;
+      gap: 0.35rem;
+      align-items: center;
+
+      svg {
+        color: $dv-text-color;
+      }
+
+      &[aria-selected='true'],
+      &:active {
+        background-color: $dv-brand-color;
+
+        svg {
+          color: #fff;
+        }
+      }
+    }
   }
 }

--- a/src/sections/homepage/search-input/SearchInput.tsx
+++ b/src/sections/homepage/search-input/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import React, { useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Form, CloseButton } from '@iqss/dataverse-design-system'
@@ -6,13 +6,23 @@ import { Search as SearchIcon } from 'react-bootstrap-icons'
 import { Route } from '../../Route.enum'
 import { CollectionItemType } from '../../../collection/domain/models/CollectionItemType'
 import { CollectionItemsQueryParams } from '@/collection/domain/models/CollectionItemsQueryParams'
+import { SearchDropdown } from './SearchDropdown'
 import styles from './SearchInput.module.scss'
 
-export const SearchInput = () => {
+interface SearchInputProps {
+  hasMoreThanOneSearchEngine?: boolean
+  searchDropdownPosition?: 'left' | 'right'
+}
+
+export const SearchInput = ({
+  hasMoreThanOneSearchEngine = false,
+  searchDropdownPosition = 'left'
+}: SearchInputProps) => {
   const navigate = useNavigate()
   const { t } = useTranslation('shared')
   const inputSearchRef = useRef<HTMLInputElement>(null)
   const [searchValue, setSearchValue] = useState('')
+  const [searchEngineSelected, setSearchEngineSelected] = useState<string>('one')
 
   const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setSearchValue(event.target.value)
@@ -44,8 +54,19 @@ export const SearchInput = () => {
     inputSearchRef.current?.focus()
   }
 
+  const handleSearchEngineSelect = (eventKey: string | null) => {
+    setSearchEngineSelected(eventKey as string)
+  }
+
   return (
     <form onSubmit={handleSubmit} className={styles['search-input-wrapper']} role="search">
+      {hasMoreThanOneSearchEngine && searchDropdownPosition === 'left' && (
+        <SearchDropdown
+          searchEngineSelected={searchEngineSelected}
+          handleSearchEngineSelect={handleSearchEngineSelect}
+          position="left"
+        />
+      )}
       <div className={styles['input-and-clear-wrapper']}>
         <Form.Group.Input
           type="text"
@@ -65,7 +86,13 @@ export const SearchInput = () => {
           />
         )}
       </div>
-
+      {hasMoreThanOneSearchEngine && searchDropdownPosition === 'right' && (
+        <SearchDropdown
+          searchEngineSelected={searchEngineSelected}
+          handleSearchEngineSelect={handleSearchEngineSelect}
+          position="right"
+        />
+      )}
       <button type="submit" aria-label={t('submitSearch')} className={styles['search-btn']}>
         <SearchIcon size={22} />
       </button>

--- a/src/sections/homepage/search-input/SearchInput2.module.scss
+++ b/src/sections/homepage/search-input/SearchInput2.module.scss
@@ -1,0 +1,112 @@
+@use 'sass:color';
+@import 'node_modules/@iqss/dataverse-design-system/src/lib/assets/styles/design-tokens/colors.module';
+
+:root {
+  --search-input-height: 50px;
+  --search-input-max-width: 580px;
+  --search-input-gap: 4px;
+  --search-input-transition: 0.15s ease-in-out;
+  --search-icon-btn-width: 60px;
+  --search-engine-icon-btn-width: 35px;
+}
+
+.main-search-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  width: min(100%, var(--search-input-max-width));
+}
+
+.search-input-wrapper {
+  display: flex;
+  gap: var(--search-input-gap);
+  align-items: center;
+  width: min(100%, var(--search-input-max-width));
+  height: var(--search-input-height);
+  background-color: $dv-brand-color;
+  border: solid 4px $dv-brand-color;
+  border-radius: 999px;
+  transition: var(--search-input-transition);
+  transition-property: box-shadow;
+
+  &:focus-within,
+  &:hover {
+    box-shadow: 0 0 0 0.15rem color.adjust($dv-brand-color, $alpha: -0.7);
+  }
+}
+
+.input-and-clear-wrapper {
+  position: relative;
+  display: flex;
+  flex: 1;
+  align-items: center;
+  align-self: stretch;
+}
+
+.text-input {
+  position: relative;
+  z-index: 2;
+  height: 100%;
+  border: 0;
+  border-radius: 999px;
+  caret-color: $dv-brand-color;
+  padding-inline: 1.25rem;
+  outline: solid 4px $dv-brand-color;
+
+  &:focus {
+    box-shadow: none;
+  }
+}
+
+.clear-btn {
+  position: absolute;
+  right: 0;
+  margin-right: 1rem;
+}
+
+%search-btn {
+  position: relative;
+  z-index: 3;
+  display: grid;
+  place-items: center;
+  min-width: var(--search-icon-btn-width);
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+  border: 0;
+  border-radius: 999px;
+  transition: var(--search-input-transition);
+  transition-property: background-color;
+
+  &:hover {
+    background-color: color.adjust($dv-brand-color, $lightness: -10%);
+  }
+
+  &:focus-visible {
+    outline: 0;
+    box-shadow: 0 0 0 0.25rem color.adjust($dv-brand-color, $lightness: -5%);
+  }
+
+  &:active {
+    background-color: color.adjust($dv-brand-color, $lightness: -15%);
+  }
+
+  svg {
+    color: $dv-primary-text-color;
+  }
+}
+
+.search-btn {
+  @extend %search-btn;
+}
+
+.search-options {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+
+  &:not(:empty) {
+    padding-inline: 1.5rem;
+  }
+}

--- a/src/sections/homepage/search-input/SearchInput2.tsx
+++ b/src/sections/homepage/search-input/SearchInput2.tsx
@@ -1,0 +1,120 @@
+import React, { useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import {
+  Form,
+  CloseButton,
+  DropdownButton,
+  DropdownButtonItem
+} from '@iqss/dataverse-design-system'
+import { Search as SearchIcon } from 'react-bootstrap-icons'
+import { Route } from '../../Route.enum'
+import { CollectionItemType } from '../../../collection/domain/models/CollectionItemType'
+import { CollectionItemsQueryParams } from '@/collection/domain/models/CollectionItemsQueryParams'
+import styles from './SearchInput2.module.scss'
+
+interface SearchInput2Props {
+  hasMoreThanOneSearchEngine?: boolean
+}
+
+const searchEngineOptions = [
+  { id: 'one', label: 'Dataverse Engine' },
+  { id: 'two', label: 'External Engine 1' },
+  { id: 'three', label: 'External Engine 2' }
+]
+
+export const SearchInput2 = ({ hasMoreThanOneSearchEngine = false }: SearchInput2Props) => {
+  const navigate = useNavigate()
+  const { t } = useTranslation('shared')
+  const inputSearchRef = useRef<HTMLInputElement>(null)
+  const [searchValue, setSearchValue] = useState('')
+  const [searchEngineSelected, setSearchEngineSelected] = useState<string>('one')
+
+  const handleSearchChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchValue(event.target.value)
+  }
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+
+    const trimmedSearchValue = searchValue.trim()
+
+    if (!trimmedSearchValue) return
+
+    const encodedSearchValue = encodeURIComponent(trimmedSearchValue)
+
+    const searchParams = new URLSearchParams()
+    searchParams.set(CollectionItemsQueryParams.QUERY, encodedSearchValue)
+    searchParams.set(
+      CollectionItemsQueryParams.TYPES,
+      [CollectionItemType.COLLECTION, CollectionItemType.DATASET, CollectionItemType.FILE].join(',')
+    )
+
+    const collectionUrlWithQuery = `${Route.COLLECTIONS_BASE}?${searchParams.toString()}`
+
+    navigate(collectionUrlWithQuery)
+  }
+
+  const handleClearSearch = () => {
+    setSearchValue('')
+    inputSearchRef.current?.focus()
+  }
+
+  const handleSearchEngineSelect = (eventKey: string | null) => {
+    console.log('Selected search engine:', eventKey)
+    setSearchEngineSelected(eventKey as string)
+  }
+
+  const searchEngineLabel = searchEngineOptions.find(
+    (option) => option.id === searchEngineSelected
+  )?.label
+
+  return (
+    <div className={styles['main-search-wrapper']}>
+      <form onSubmit={handleSubmit} className={styles['search-input-wrapper']} role="search">
+        <div className={styles['input-and-clear-wrapper']}>
+          <Form.Group.Input
+            type="text"
+            aria-label={t('search')}
+            autoFocus
+            autoComplete="off"
+            className={styles['text-input']}
+            value={searchValue}
+            onChange={handleSearchChange}
+            ref={inputSearchRef}
+          />
+          {searchValue && (
+            <CloseButton
+              aria-label={t('clearSearch')}
+              className={styles['clear-btn']}
+              onClick={handleClearSearch}
+            />
+          )}
+        </div>
+
+        <button type="submit" aria-label={t('submitSearch')} className={styles['search-btn']}>
+          <SearchIcon size={22} />
+        </button>
+      </form>
+      <div className={styles['search-options']}>
+        {hasMoreThanOneSearchEngine && (
+          <DropdownButton
+            title={searchEngineLabel || 'Search Engine'}
+            id="dropdown-select"
+            size="sm"
+            variant="secondary"
+            onSelect={handleSearchEngineSelect}>
+            {searchEngineOptions.map((option) => (
+              <DropdownButtonItem
+                eventKey={option.id}
+                active={searchEngineSelected === option.id}
+                key={option.id}>
+                {option.label}
+              </DropdownButtonItem>
+            ))}
+          </DropdownButton>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/stories/homepage/SearchInput.stories.tsx
+++ b/src/stories/homepage/SearchInput.stories.tsx
@@ -1,0 +1,73 @@
+import { SearchInput } from '@/sections/homepage/search-input/SearchInput'
+import { Meta, StoryObj } from '@storybook/react'
+import { WithI18next } from '../WithI18next'
+import { SearchInput2 } from '@/sections/homepage/search-input/SearchInput2'
+
+const meta: Meta<typeof SearchInput> = {
+  title: 'Sections/Homepage/SearchInput',
+  component: SearchInput,
+  decorators: [WithI18next],
+  parameters: {
+    // Sets the delay for all stories.
+    chromatic: { delay: 15000, pauseAnimationAtEnd: true }
+  }
+}
+
+export default meta
+type Story = StoryObj<typeof SearchInput>
+
+export const Default: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingBlock: '2rem'
+      }}>
+      <SearchInput />
+    </div>
+  )
+}
+
+export const WithSearchEnginesDropdown: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingBlock: '2rem'
+      }}>
+      <SearchInput hasMoreThanOneSearchEngine={true} />
+    </div>
+  )
+}
+
+export const WithSearchEngineDropdownOnTheRight: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingBlock: '2rem'
+      }}>
+      <SearchInput hasMoreThanOneSearchEngine={true} searchDropdownPosition="right" />
+    </div>
+  )
+}
+
+export const WithSearchEngineSelectorBelow: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        paddingBlock: '2rem'
+      }}>
+      <SearchInput2 hasMoreThanOneSearchEngine={true} />
+    </div>
+  )
+}


### PR DESCRIPTION
## What this PR does / why we need it:
Implements some designs for the Homepage search bar for allowing users to select a different search engine.
See [Storybook stories](https://646f68aa9beb01b35c599acd-tklpzptzhq.chromatic.com/?path=/story/sections-homepage-searchinput--default), the first story is the default, when the application has only one search engine.

I've implemented 3 options for when the application has more than one search engine:
- Search engine drop-down button on the left side of the search bar. [Story](https://646f68aa9beb01b35c599acd-tklpzptzhq.chromatic.com/?path=/story/sections-homepage-searchinput--with-search-engines-dropdown)
- Search engine drop-down button on the right side of the search bar. [Story](https://646f68aa9beb01b35c599acd-tklpzptzhq.chromatic.com/?path=/story/sections-homepage-searchinput--with-search-engine-dropdown-on-the-right)
- Search engine drop-down below the search bar. [Story](https://646f68aa9beb01b35c599acd-tklpzptzhq.chromatic.com/?path=/story/sections-homepage-searchinput--with-search-engine-selector-below)

## Which issue(s) this PR closes:

- Closes #691 
