### PR TITLE
Featured Items aspect ratio recommendations

### DIFF
--- a/public/locales/en/editCollectionFeaturedItems.json
+++ b/public/locales/en/editCollectionFeaturedItems.json
@@ -10,13 +10,15 @@
   "form": {
     "image": {
       "label": "Image",
-      "description": "Upload an image to display with the item, accepted extensions are png, jpg, jpeg and webp, and the maximum file size is {{maxImageSize}}.",
+      "description": "Upload an image that will be used as the blog banner and thumbnail. Supported formats: PNG, JPG, JPEG, WEBP. Max file size: {{maxImageSize}}.",
       "invalid": {
         "size": "The file is too large. The maximum file size is {{maxImageSize}}"
       },
       "restoreInitial": "Restore initial image",
       "changeImage": "Change image",
-      "removeImage": "Remove image"
+      "removeImage": "Remove image",
+      "helperText": "For best results, use a landscape image (16:9, 4:3, or 5:3). Check the preview at the top of the page to see how it will look.",
+      "aspectRatioWarning": "Your image has approximately a {{aspectRatio}} aspect ratio and may not display well in the landscape banner.\nFor best results, use a landscape image (16:9, 4:3, or 5:3). You can still use it, but check the preview at the top of the page to see how it will look."
     },
     "content": {
       "label": "Content",

--- a/src/sections/edit-collection-featured-items/featured-items-form/FeaturedItemsFormHelper.ts
+++ b/src/sections/edit-collection-featured-items/featured-items-form/FeaturedItemsFormHelper.ts
@@ -9,7 +9,9 @@ import {
 } from '@/collection/domain/useCases/DTOs/CollectionFeaturedItemsDTO'
 
 export class FeaturedItemsFormHelper {
-  // To define the default form featured items values
+  /**
+   * @description To define the default form featured items values
+   */
   static defineFormDefaultFeaturedItems(
     collectionFeaturedItems: CollectionFeaturedItem[]
   ): FeaturedItemsFormData['featuredItems'] {
@@ -33,7 +35,9 @@ export class FeaturedItemsFormHelper {
     })
   }
 
-  // This method is to transform current form data into "actual featured items" to show the current preview while the user is editing
+  /**
+   * @description This method is to transform current form data into "actual featured items" to show the current preview while the user is editing
+   */
   static transformFormFieldsToFeaturedItems(
     featuredItemsFieldValues: FeaturedItemField[]
   ): CollectionFeaturedItem[] {
@@ -60,7 +64,9 @@ export class FeaturedItemsFormHelper {
     })
   }
 
-  // This method is to transform the form data into DTOs to send to the backend
+  /**
+   * @description This method is to transform the form data into DTOs to send to the backend
+   */
   static defineFeaturedItemsDTO(
     formFeaturedItems: FeaturedItemsFormData['featuredItems']
   ): CollectionFeaturedItemsDTO {
@@ -114,5 +120,71 @@ export class FeaturedItemsFormHelper {
 
   static generateFakeNumberId(): number {
     return Date.now() + Math.floor(Math.random() * 1000)
+  }
+
+  static hasRecommendedAspectRatio(file: File): Promise<{
+    hasRecommendedAspectRatio: boolean
+    aspectRatioStringValue: string
+  }> {
+    return new Promise((resolve) => {
+      const img = new Image()
+      img.src = URL.createObjectURL(file)
+
+      img.onload = () => {
+        const { width, height } = img
+        const aspectRatio = width / height
+
+        const minRatio = 1.3 // means the width is 30% greater than the height
+
+        URL.revokeObjectURL(img.src)
+
+        const aspectRatioStringValue = FeaturedItemsFormHelper.getAspectRatioString(width, height)
+
+        resolve({
+          hasRecommendedAspectRatio: aspectRatio >= minRatio,
+          aspectRatioStringValue: aspectRatioStringValue
+        })
+      }
+
+      img.onerror = () =>
+        resolve({
+          hasRecommendedAspectRatio: false,
+          aspectRatioStringValue: '0:0'
+        })
+    })
+  }
+
+  /**
+   * @description This method calculates the aspect ratio of an image and returns it as a string in the format "width:height".
+   * @example
+   * getAspectRatioString(1920, 1080) // returns "16:9"
+   * getAspectRatioString(800, 600) // returns "4:3"
+   */
+  static getAspectRatioString = (width: number, height: number): string => {
+    const maxVal = 16
+
+    const gcd = (a: number, b: number): number => {
+      while (b !== 0) [a, b] = [b, a % b]
+      return a
+    }
+
+    let w = width
+    let h = height
+
+    const divisor = gcd(w, h)
+    w = w / divisor
+    h = h / divisor
+
+    // If the width or height is greater than the maxVal, scale it down
+    if (w > maxVal || h > maxVal) {
+      const scale = maxVal / Math.max(w, h)
+      w = Math.round(w * scale)
+      h = Math.round(h * scale)
+      const reduced = gcd(w, h)
+      w = w / reduced
+      h = h / reduced
+    }
+
+    return `${w}:${h}`
   }
 }

--- a/src/sections/edit-collection-featured-items/featured-items-form/FeaturedItemsFormHelper.ts
+++ b/src/sections/edit-collection-featured-items/featured-items-form/FeaturedItemsFormHelper.ts
@@ -122,6 +122,10 @@ export class FeaturedItemsFormHelper {
     return Date.now() + Math.floor(Math.random() * 1000)
   }
 
+  /**
+   * @description This method checks if the image has a recommended aspect ratio (width is 30% greater than height).
+   */
+
   static hasRecommendedAspectRatio(file: File): Promise<{
     hasRecommendedAspectRatio: boolean
     aspectRatioStringValue: string

--- a/src/sections/edit-collection-featured-items/featured-items-form/featured-item-field/FeaturedItemField.module.scss
+++ b/src/sections/edit-collection-featured-items/featured-items-form/featured-item-field/FeaturedItemField.module.scss
@@ -54,6 +54,23 @@
     font-size: 0.875em;
   }
 
+  .aspect-ratio-warning {
+    display: flex;
+    gap: 0.5rem;
+    width: 100%;
+    margin-top: 0.25rem;
+    color: $dv-warning-color;
+    font-size: 0.875em;
+
+    svg {
+      margin-top: 3px;
+    }
+
+    @media (min-width: 992px) {
+      white-space: pre-line;
+    }
+  }
+
   .image-wrapper {
     position: relative;
     display: flex;

--- a/src/sections/edit-collection-featured-items/featured-items-form/featured-item-field/ImageField.tsx
+++ b/src/sections/edit-collection-featured-items/featured-items-form/featured-item-field/ImageField.tsx
@@ -194,12 +194,22 @@ export const ImageField = ({ itemIndex, initialImageUrl }: ImageFieldProps) => {
                   </Tooltip>
                 </div>
               </div>
-              {invalid && <div className={styles['error-msg']}>{error?.message}</div>}
+              {invalid && (
+                <div
+                  className={styles['error-msg']}
+                  data-testid={`image-invalid-message-${itemIndex.toString()}`}>
+                  {error?.message}
+                </div>
+              )}
               {!showAspectRatioWarning && !invalid && (
-                <Form.Group.Text>{t('form.image.helperText')}</Form.Group.Text>
+                <div data-testid={`image-helper-text-${itemIndex.toString()}`}>
+                  <Form.Group.Text>{t('form.image.helperText')}</Form.Group.Text>
+                </div>
               )}
               {showAspectRatioWarning && !invalid && (
-                <div className={styles['aspect-ratio-warning']}>
+                <div
+                  className={styles['aspect-ratio-warning']}
+                  data-testid={`aspect-ratio-warning-${itemIndex.toString()}`}>
                   <div>
                     <ExclamationCircleFill size={18} />
                   </div>

--- a/src/sections/edit-collection-featured-items/featured-items-form/featured-item-field/ImageField.tsx
+++ b/src/sections/edit-collection-featured-items/featured-items-form/featured-item-field/ImageField.tsx
@@ -2,7 +2,12 @@ import { useState, ChangeEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Controller, UseControllerProps, useFormContext } from 'react-hook-form'
 import { Button, Col, Form, Stack, Tooltip } from '@iqss/dataverse-design-system'
-import { ArrowDownUp, ArrowCounterclockwise, XLg } from 'react-bootstrap-icons'
+import {
+  ArrowDownUp,
+  ArrowCounterclockwise,
+  XLg,
+  ExclamationCircleFill
+} from 'react-bootstrap-icons'
 import cn from 'classnames'
 import { FeaturedItemsFormHelper } from '../FeaturedItemsFormHelper'
 import { appendTimestampToImageUrl } from '@/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard'
@@ -19,16 +24,28 @@ export const ImageField = ({ itemIndex, initialImageUrl }: ImageFieldProps) => {
   const { control, setValue } = useFormContext()
   const { t } = useTranslation('editCollectionFeaturedItems')
   const [selectedFileObjectURL, setSelectedFileObjectURL] = useState<string | null>(null)
+  const [imageAspectRatio, setImageAspectRatio] = useState<{
+    hasRecommendedAspectRatio: boolean
+    aspectRatioStringValue: string
+  } | null>(null)
 
   let fileInputRef: HTMLInputElement | null = null
 
-  const handleFileChange = (
+  const handleFileChange = async (
     e: ChangeEvent<HTMLInputElement>,
     formOnChange: (...event: unknown[]) => void
   ) => {
     const file = e.target.files?.[0]
 
     if (file) {
+      const { hasRecommendedAspectRatio, aspectRatioStringValue } =
+        await FeaturedItemsFormHelper.hasRecommendedAspectRatio(file)
+
+      setImageAspectRatio({
+        hasRecommendedAspectRatio,
+        aspectRatioStringValue
+      })
+
       setSelectedFileObjectURL(URL.createObjectURL(file))
     }
 
@@ -51,6 +68,7 @@ export const ImageField = ({ itemIndex, initialImageUrl }: ImageFieldProps) => {
   const handleRemoveImage = () => {
     selectedFileObjectURL && URL.revokeObjectURL(selectedFileObjectURL)
     setSelectedFileObjectURL(null)
+    setImageAspectRatio(null)
 
     fileInputRef?.value && (fileInputRef.value = '')
 
@@ -63,6 +81,7 @@ export const ImageField = ({ itemIndex, initialImageUrl }: ImageFieldProps) => {
   const handleRestoreInitialImage = () => {
     selectedFileObjectURL && URL.revokeObjectURL(selectedFileObjectURL)
     setSelectedFileObjectURL(null)
+    setImageAspectRatio(null)
 
     fileInputRef?.value && (fileInputRef.value = '')
 
@@ -71,6 +90,8 @@ export const ImageField = ({ itemIndex, initialImageUrl }: ImageFieldProps) => {
       shouldValidate: true
     })
   }
+
+  const showAspectRatioWarning = imageAspectRatio && !imageAspectRatio.hasRecommendedAspectRatio
 
   return (
     <Form.Group
@@ -173,8 +194,22 @@ export const ImageField = ({ itemIndex, initialImageUrl }: ImageFieldProps) => {
                   </Tooltip>
                 </div>
               </div>
-
               {invalid && <div className={styles['error-msg']}>{error?.message}</div>}
+              {!showAspectRatioWarning && !invalid && (
+                <Form.Group.Text>{t('form.image.helperText')}</Form.Group.Text>
+              )}
+              {showAspectRatioWarning && !invalid && (
+                <div className={styles['aspect-ratio-warning']}>
+                  <div>
+                    <ExclamationCircleFill size={18} />
+                  </div>
+                  <span>
+                    {t('form.image.aspectRatioWarning', {
+                      aspectRatio: imageAspectRatio.aspectRatioStringValue
+                    })}
+                  </span>
+                </div>
+              )}
             </Col>
           )
         }}

--- a/src/sections/featured-item/featured-item-view/FeaturedItemView.module.scss
+++ b/src/sections/featured-item/featured-item-view/FeaturedItemView.module.scss
@@ -9,7 +9,6 @@
   width: 100%;
   height: 300px;
   overflow: hidden;
-  background-color: $dv-secondary-color; // Optional fallback background
 
   img {
     flex-shrink: 0;

--- a/tests/component/collection/domain/models/CollectionFeaturedItemMother.ts
+++ b/tests/component/collection/domain/models/CollectionFeaturedItemMother.ts
@@ -9,7 +9,7 @@ export class CollectionFeaturedItemMother {
     return [
       {
         id: 1,
-        imageFileUrl: '/storybook/css-bg.webp',
+        imageFileUrl: '/storybook/css.webp',
         displayOrder: 1,
         content:
           '<h1 class="rte-heading">Some Title</h1><p class="rte-paragraph">Hello <strong class="rte-bold">Dataverse</strong> <em class="rte-italic">new </em><s class="rte-strike">rick</s> <strong class="rte-bold">rich</strong> <em class="rte-italic">text</em> <code class="rte-code">editor</code>! This is a <a target="_blank" rel="noopener noreferrer nofollow" class="rte-link" href="https://beta.dataverse.org/spa/">link</a>.</p><ul class="rte-bullet-list"><li><p class="rte-paragraph">Item</p></li><li><p class="rte-paragraph">Item</p></li></ul><ol class="rte-ordered-list"><li><p class="rte-paragraph">Item 1</p></li><li><p class="rte-paragraph">Item 2</p></li></ol><pre class="rte-code-block"><code class="language-typescriptreact">onUpdate: ({ editor }) =&gt; onChange &amp;&amp; onChange(editor.getHTML())</code></pre><blockquote class="rte-blockquote"><p class="rte-paragraph">This is a blockquoute</p></blockquote><p class="rte-paragraph"></p><p class="rte-paragraph"></p>'
@@ -24,13 +24,6 @@ export class CollectionFeaturedItemMother {
         id: 3,
         imageFileUrl: '/storybook/books.webp',
         displayOrder: 3,
-        content:
-          '<h1 class="rte-heading">Some Title</h1><p>Join a growing community of Harvard and worldwide researchers who share data in the Harvard Dataverse Repository</p>'
-      },
-      {
-        id: 4,
-        imageFileUrl: '/storybook/campus.jpg',
-        displayOrder: 4,
         content:
           '<h1 class="rte-heading">Some Title</h1><p>Join a growing community of Harvard and worldwide researchers who share data in the Harvard Dataverse Repository</p>'
       }

--- a/tests/component/sections/edit-collection-featured-items/FeaturedItemsFormHelper.spec.ts
+++ b/tests/component/sections/edit-collection-featured-items/FeaturedItemsFormHelper.spec.ts
@@ -165,4 +165,31 @@ describe('FeaturedItemsFormHelper', () => {
       expect(withTwoDecimals).to.deep.equal('9.77 KB')
     })
   })
+
+  describe('getAspectRatioString', () => {
+    it('should return 1:1 when width and height are equal', () => {
+      const result = FeaturedItemsFormHelper.getAspectRatioString(400, 400)
+
+      expect(result).to.deep.equal('1:1')
+    })
+
+    it('should return 4:3 when width is 12 and height is 9', () => {
+      const result = FeaturedItemsFormHelper.getAspectRatioString(12, 9)
+
+      expect(result).to.deep.equal('4:3')
+    })
+
+    it('should return 1:4 when width is 2 and height is 8', () => {
+      const result = FeaturedItemsFormHelper.getAspectRatioString(2, 8)
+
+      expect(result).to.deep.equal('1:4')
+    })
+
+    it('should scale down the aspect ratio to a more user friendly value', () => {
+      // For example, an image with dimensions 800x537 will be scale down to 16:11
+      const result = FeaturedItemsFormHelper.getAspectRatioString(800, 537)
+
+      expect(result).to.deep.equal('16:11')
+    })
+  })
 })


### PR DESCRIPTION
## What this PR does / why we need it:
This PR adds, in the Edit Collection Featured Items page:
- A helper text below the Image field about the recommended aspect ratio.
- Displays a warning message if the aspect ratio of the selected image is not the recommended one.

## Which issue(s) this PR closes:

- Closes #690 

## Special notes for your reviewer:

## Suggestions on how to test this:
Step 1: Run the Development Environment

1. Execute npm i.
2. Navigate with cd packages/design-system && npm i && npm run build.
3. Return with cd ../../.
4. Ensure you have a .env file similar to .env.example
5. Navigate with cd dev-env.
6. Before running next step, be sure have a fresh unstable dataverse image.
7. Start the environment using ./run-env.sh unstable.
8. To verify the environment, visit http://localhost:8000/ and check your local Dataverse installation.

Step 2: Test the feature
1. Log in and navigate to create a featured item within a collection of your own.
2. On the Image field, select a squared image (400x400: aspect ratio of 1) or something like (300x500: higher than wider)
3. Validate that the warning message is displayed below the field.
4. Select a landscape image (600x400), the warning message should not be displayed.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
