### PR TITLE
Fix: avoid showing app loader when refreshing token

### DIFF
--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -16,7 +16,8 @@ export const ProtectedRoute = () => {
   const { token, loginInProgress: oidcLoginInProgress, logIn: oidcLogin } = useContext(AuthContext)
   const { user, isLoadingUser } = useSession()
 
-  const isSafeToRenderProtectedRoute = !oidcLoginInProgress && !isLoadingUser && token && user
+  // We only show the loader if we dont have a token neither a user and we are in the process of logging in or loading the user data.
+  const showLoader = !token && !user && (oidcLoginInProgress || isLoadingUser)
 
   useEffect(() => {
     if (oidcLoginInProgress || isLoadingUser) return
@@ -28,7 +29,7 @@ export const ProtectedRoute = () => {
     }
   }, [token, oidcLogin, oidcLoginInProgress, isLoadingUser, pathname, search])
 
-  if (!isSafeToRenderProtectedRoute) {
+  if (showLoader) {
     return <AppLoader />
   }
 


### PR DESCRIPTION
## What this PR does / why we need it:
I've addressed an issue where the app loading spinner was unexpectedly appearing during background authentication token refreshes. This was causing the current page state to reset, which could interrupt users who were in the middle of tasks like filling out forms.

This fix should prevent that interruption.

## Special notes for your reviewer:

## Suggestions on how to test this:
To easily test this, open the Keycloak admin panel, select the Test instance,  and modify the Access Token Lifespan duration to 10 or 20 seconds (it's set to 5 minutes).

Next, open your browser's developer tools and navigate to the network tab. You should observe that a new token is fetched every 10/20 secs. To verify the persistence of form data, navigate to a page with form fields, such as the "Create collection" page. Enter some values into the fields and confirm that these values are retained even after the new token has been obtained.
Please ping me if you need help with the Keycloak admin panel.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes update needed for this change?:
No

## Additional documentation:
No
