### PR TITLE
704 get version summary when tab clicked

### DIFF
--- a/src/dataset/domain/models/Dataset.ts
+++ b/src/dataset/domain/models/Dataset.ts
@@ -1,7 +1,6 @@
 import { Alert, AlertMessageKey } from '../../../alert/domain/models/Alert'
 import { UpwardHierarchyNode } from '../../../shared/hierarchy/domain/models/UpwardHierarchyNode'
 import { FileDownloadSize } from '../../../files/domain/models/FileMetadata'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 
 export enum DatasetLabelSemanticMeaning {
   DATASET = 'dataset',
@@ -424,7 +423,6 @@ export class Dataset {
     public readonly downloadUrls: DatasetDownloadUrls,
     public readonly fileDownloadSizes: FileDownloadSize[],
     public readonly hierarchy: UpwardHierarchyNode,
-    public readonly versionsSummaries: DatasetVersionSummaryInfo[],
     public readonly license?: DatasetLicense,
     public readonly thumbnail?: string,
     public readonly privateUrl?: PrivateUrl, // will be set if the user requested a version that did not exist
@@ -519,7 +517,6 @@ export class Dataset {
       public readonly downloadUrls: DatasetDownloadUrls,
       public readonly fileDownloadSizes: FileDownloadSize[],
       public readonly hierarchy: UpwardHierarchyNode,
-      public readonly versionsSummaries: DatasetVersionSummaryInfo[],
       public readonly license?: DatasetLicense,
       public readonly thumbnail?: string,
       public readonly privateUrl?: PrivateUrl, // will be set if the user requested a version that did not exist
@@ -589,7 +586,6 @@ export class Dataset {
         this.downloadUrls,
         this.fileDownloadSizes,
         this.hierarchy,
-        this.versionsSummaries,
         this.license,
         this.thumbnail,
         this.privateUrl,

--- a/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
+++ b/src/dataset/infrastructure/mappers/JSDatasetMapper.ts
@@ -7,7 +7,6 @@ import {
   DatasetUserPermissions as JSDatasetPermissions,
   DatasetVersionDiff as JSDatasetVersionDiff,
   DatasetVersionState,
-  DatasetVersionSummaryInfo as JSDatasetVersionSummaryInfo,
   DvObjectOwnerNode as JSUpwardHierarchyNode
 } from '@iqss/dataverse-client-javascript'
 import { DatasetVersionDiff } from '../../domain/models/DatasetVersionDiff'
@@ -45,7 +44,6 @@ export class JSDatasetMapper {
     jsDatasetLocks: JSDatasetLock[],
     jsDatasetFilesTotalOriginalDownloadSize: number,
     jsDatasetFilesTotalArchivalDownloadSize: number,
-    jsDatasetVersionSummaries: JSDatasetVersionSummaryInfo[],
     requestedVersion?: string,
     privateUrl?: PrivateUrl,
     latestPublishedVersionMajorNumber?: number,
@@ -89,7 +87,6 @@ export class JSDatasetMapper {
         version,
         jsDataset.isPartOf
       ),
-      jsDatasetVersionSummaries,
       jsDataset.license,
       undefined, // TODO: get dataset thumbnail from js-dataverse https://github.com/IQSS/dataverse-frontend/issues/203
       privateUrl,

--- a/src/sections/dataset/Dataset.tsx
+++ b/src/sections/dataset/Dataset.tsx
@@ -107,6 +107,7 @@ export function Dataset({
       setActiveTab(key)
     }
   }
+
   return (
     <>
       <NotImplementedModal show={isModalOpen} handleClose={hideModal} />
@@ -199,7 +200,8 @@ export function Dataset({
                   <DatasetVersions
                     datasetRepository={datasetRepository}
                     datasetId={dataset.persistentId}
-                    key={dataset.version.publishingStatus}
+                    isInView={activeTab === 'versions'}
+                    key={dataset.internalVersionNumber}
                   />
                 </div>
               </Tabs.Tab>

--- a/src/sections/dataset/dataset-versions/DatasetVersions.tsx
+++ b/src/sections/dataset/dataset-versions/DatasetVersions.tsx
@@ -25,10 +25,12 @@ export function DatasetVersions({ datasetRepository, datasetId }: DatasetVersion
   const navigate = useNavigate()
   const { t } = useTranslation('dataset')
   const [selectedVersions, setSelectedVersions] = useState<DatasetVersionSummaryInfo[]>([])
-  const { datasetVersionSummaries, error, isLoading } = useGetDatasetVersionsSummaries({
-    datasetRepository,
-    persistentId: datasetId
-  })
+  const { datasetVersionSummaries, error, isLoading, fetchSummaries } =
+    useGetDatasetVersionsSummaries({
+      datasetRepository,
+      persistentId: datasetId,
+      autoFetch: true
+    })
 
   const handleCheckboxChange = (datasetSummary: DatasetVersionSummaryInfo) => {
     setSelectedVersions((prevSelected) => {

--- a/src/sections/dataset/dataset-versions/DatasetVersions.tsx
+++ b/src/sections/dataset/dataset-versions/DatasetVersions.tsx
@@ -114,6 +114,7 @@ export function DatasetVersions({ datasetRepository, datasetId, isInView }: Data
                     <td style={{ verticalAlign: 'middle' }}>
                       <Form.Group.Checkbox
                         label=""
+                        aria-label="Select row"
                         id={`dataset-${dataset.id}`}
                         data-testid="select-checkbox"
                         checked={selectedVersions.some((item) => item.id === dataset.id)}

--- a/src/sections/dataset/deaccession-dataset/DeaccessionDatasetModal.tsx
+++ b/src/sections/dataset/deaccession-dataset/DeaccessionDatasetModal.tsx
@@ -42,8 +42,8 @@ export function DeaccessionDatasetModal({
 
   const publishedVersions =
     datasetVersionSummaries?.filter((version) => {
-      const summary = version.summary as { deaccessioned: Deaccessioned }
-      return version.publishedOn && !summary.deaccessioned
+      const summary = version?.summary as { deaccessioned: Deaccessioned }
+      return version.publishedOn && !summary?.deaccessioned
     }) || []
 
   const defaultVersions = publishedVersions.length === 1 ? [publishedVersions[0].versionNumber] : []
@@ -136,7 +136,7 @@ export function DeaccessionDatasetModal({
                 {publishedVersions.length > 1 && (
                   <Form.Group as={Col}>
                     <Form.Group.Label required>{t('deaccession.version.label')}</Form.Group.Label>
-                    <div>
+                    <div data-testid="published-versions">
                       <Controller
                         name="versions"
                         control={control}

--- a/src/sections/dataset/deaccession-dataset/DeaccessionDatasetModal.tsx
+++ b/src/sections/dataset/deaccession-dataset/DeaccessionDatasetModal.tsx
@@ -1,198 +1,318 @@
+import { useEffect, useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
 import { Trans, useTranslation } from 'react-i18next'
+import Skeleton, { SkeletonTheme } from 'react-loading-skeleton'
+import { toast } from 'react-toastify'
 import { Alert, Button, Col, Form, Modal, Stack } from '@iqss/dataverse-design-system'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { useDataset } from '../DatasetContext'
+import { Deaccessioned } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
 import { isValidURL } from '@/metadata-block-info/domain/models/fieldValidations'
+import { useGetDatasetVersionsSummaries } from '../dataset-versions/useGetDatasetVersionsSummaries'
 import { DeaccessionFormData } from './DeaccessionFormData'
-import { Controller, Control, FieldErrors } from 'react-hook-form'
+import { ConfirmationModal } from './ConfirmationModal'
+import { useDeaccessionDataset } from './useDeaccessionDataset'
 
 interface DeaccessionDatasetModalProps {
+  datasetRepository: DatasetRepository
+  datasetPersistentId: string
   show: boolean
-  publishedVersions: DatasetVersionSummaryInfo[]
-  handleClose: () => void
-  handleSubmitForm: () => void
-  control: Control<DeaccessionFormData>
-  errors: FieldErrors<DeaccessionFormData>
+  handleCloseDeaccessionModal: () => void
 }
 
 export function DeaccessionDatasetModal({
+  datasetRepository,
+  datasetPersistentId,
   show,
-  publishedVersions,
-  handleClose,
-  handleSubmitForm,
-  control,
-  errors
+  handleCloseDeaccessionModal
 }: DeaccessionDatasetModalProps) {
   const { t } = useTranslation(['dataset', 'shared'])
+  const [showConfirmationModal, setShowConfirmationModal] = useState(false)
+  const { refreshDataset } = useDataset()
 
-  function isValidNonEmptyURL(value: string): boolean {
+  const {
+    datasetVersionSummaries,
+    isLoading: isLoadingDatasetVersionSummaries,
+    fetchSummaries
+  } = useGetDatasetVersionsSummaries({
+    datasetRepository,
+    persistentId: datasetPersistentId,
+    autoFetch: false
+  })
+
+  const publishedVersions =
+    datasetVersionSummaries?.filter((version) => {
+      const summary = version.summary as { deaccessioned: Deaccessioned }
+      return version.publishedOn && !summary.deaccessioned
+    }) || []
+
+  const defaultVersions = publishedVersions.length === 1 ? [publishedVersions[0].versionNumber] : []
+
+  const { submissionStatus, submitDeaccession, deaccessionError } = useDeaccessionDataset(
+    datasetRepository,
+    datasetPersistentId,
+    onDeaccessionSucceed
+  )
+
+  const {
+    control,
+    handleSubmit,
+    formState: { errors },
+    watch,
+    reset
+  } = useForm<DeaccessionFormData>({
+    defaultValues: { versions: defaultVersions, deaccessionForwardUrl: '' }
+  })
+
+  function onDeaccessionSucceed() {
+    setShowConfirmationModal(false)
+    refreshDataset()
+    toast.success('Dataset deaccessioned successfully')
+  }
+
+  // Get version summaries only when modal is shown and if we dont have the data already
+  useEffect(() => {
+    if (show && !datasetVersionSummaries) {
+      void fetchSummaries()
+    }
+  }, [show, datasetVersionSummaries, fetchSummaries])
+
+  const handleCancelConfirmation = () => {
+    setShowConfirmationModal(false)
+  }
+
+  const handleSubmitForm = () => {
+    handleCloseDeaccessionModal()
+    setShowConfirmationModal(true)
+  }
+
+  const handleConfirmDeaccession = () => {
+    const formData = watch()
+    submitDeaccession(formData)
+  }
+
+  const isValidNonEmptyURL = (value: string): boolean => {
     if (value.trim() === '') {
       return true // Consider empty strings as valid
     }
     return isValidURL(value)
   }
 
+  const handleCloseWithReset = () => {
+    handleCloseDeaccessionModal()
+    reset()
+  }
+
   return (
-    <Modal show={show} onHide={handleClose} size="xl">
-      <Modal.Header>
-        <Modal.Title>Deaccession Dataset</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Stack direction="vertical">
-          <Alert
-            variant={'warning'}
-            customHeading={'Deaccession is permanent.'}
-            dismissible={false}>
-            <Trans
-              t={t}
-              i18nKey="deaccession.warning"
-              components={{
-                anchor: (
-                  <a
-                    href="https://guides.dataverse.org/en/latest/user/dataset-management.html#dataset-deaccession"
-                    target="_blank"
-                    rel="noreferrer"
-                  />
-                )
-              }}
-            />
-          </Alert>
-          <form noValidate={true} onSubmit={handleSubmitForm}>
-            {publishedVersions.length > 1 && (
-              <Form.Group as={Col}>
-                <Form.Group.Label>{t('deaccession.version.label')}</Form.Group.Label>
-                <div>
+    <>
+      <Modal show={show} onHide={handleCloseWithReset} size="lg">
+        <Modal.Header>
+          <Modal.Title>Deaccession Dataset</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {isLoadingDatasetVersionSummaries ? (
+            <DeaccessionDatasetModalSkeleton />
+          ) : (
+            <Stack direction="vertical">
+              <Alert
+                variant={'warning'}
+                customHeading={'Deaccession is permanent.'}
+                dismissible={false}>
+                <Trans
+                  t={t}
+                  i18nKey="deaccession.warning"
+                  components={{
+                    anchor: (
+                      <a
+                        href="https://guides.dataverse.org/en/latest/user/dataset-management.html#dataset-deaccession"
+                        target="_blank"
+                        rel="noreferrer"
+                      />
+                    )
+                  }}
+                />
+              </Alert>
+              <form noValidate={true} onSubmit={handleSubmit(handleSubmitForm)}>
+                {publishedVersions.length > 1 && (
+                  <Form.Group as={Col}>
+                    <Form.Group.Label required>{t('deaccession.version.label')}</Form.Group.Label>
+                    <div>
+                      <Controller
+                        name="versions"
+                        control={control}
+                        rules={{
+                          validate: (value) =>
+                            value.length > 0 ? true : t('deaccession.version.validation')
+                        }}
+                        render={({ field }) => (
+                          <>
+                            {publishedVersions.map(
+                              (version) =>
+                                version.publishedOn && (
+                                  <Form.Group.Checkbox
+                                    key={version.versionNumber}
+                                    id={version.versionNumber}
+                                    label={`${version.versionNumber} - ${version.publishedOn}`}
+                                    value={version.versionNumber}
+                                    checked={field.value.includes(version.versionNumber)}
+                                    isInvalid={!!errors.versions}
+                                    onChange={(e) => {
+                                      const newValue = e.target.checked
+                                        ? [...field.value, e.target.value]
+                                        : field.value.filter((val) => val !== e.target.value)
+                                      field.onChange(newValue)
+                                    }}
+                                  />
+                                )
+                            )}
+                            {errors.versions?.message && (
+                              <Form.Group.Feedback type="invalid" style={{ display: 'block' }}>
+                                {errors.versions?.message}
+                              </Form.Group.Feedback>
+                            )}
+                          </>
+                        )}
+                      />
+                    </div>
+                  </Form.Group>
+                )}
+                <Form.Group as={Col} controlId={'deccessionReason'}>
+                  <Form.Group.Label required>{t('deaccession.reason.label')}</Form.Group.Label>
                   <Controller
-                    name="versions"
+                    name="deaccessionReason"
                     control={control}
-                    rules={{
-                      validate: (value) =>
-                        value.length > 0 ? true : t('deaccession.version.validation')
-                    }}
-                    render={({ field }) => (
+                    rules={{ required: t('deaccession.reason.validation') }}
+                    render={({ field: { onChange, ref, value }, fieldState }) => (
                       <>
-                        {publishedVersions.map(
-                          (version) =>
-                            version.publishedOn && (
-                              <Form.Group.Checkbox
-                                key={version.versionNumber}
-                                id={version.versionNumber}
-                                label={`${version.versionNumber} - ${version.publishedOn}`}
-                                value={version.versionNumber}
-                                checked={field.value.includes(version.versionNumber)}
-                                isInvalid={!!errors.versions}
-                                invalidFeedback={errors.versions?.message}
-                                onChange={(e) => {
-                                  const newValue = e.target.checked
-                                    ? [...field.value, e.target.value]
-                                    : field.value.filter((val) => val !== e.target.value)
-                                  field.onChange(newValue)
-                                }}
-                              />
-                            )
+                        <Form.Group.Select
+                          value={value}
+                          onChange={onChange}
+                          isInvalid={fieldState.invalid}
+                          ref={ref}>
+                          <option>Select...</option>
+                          <option value={t('deaccession.reason.options.identifiable')}>
+                            {t('deaccession.reason.options.identifiable')}
+                          </option>
+                          <option value={t('deaccession.reason.options.retracted')}>
+                            {t('deaccession.reason.options.retracted')}
+                          </option>
+                          <option value={t('deaccession.reason.options.transferred')}>
+                            {t('deaccession.reason.options.transferred')}
+                          </option>
+                          <option value={t('deaccession.reason.options.irb')}>
+                            {t('deaccession.reason.options.irb')}
+                          </option>
+                          <option value={t('deaccession.reason.options.legalIssue')}>
+                            {t('deaccession.reason.options.legalIssue')}
+                          </option>
+                          <option value={t('deaccession.reason.options.invalid')}>
+                            {t('deaccession.reason.options.invalid')}
+                          </option>
+                        </Form.Group.Select>
+                        <Form.Group.Feedback type="invalid">
+                          {fieldState.error?.message}
+                        </Form.Group.Feedback>
+                      </>
+                    )}></Controller>
+                </Form.Group>
+                <Form.Group as={Col}>
+                  <Form.Group.Label>{t('deaccession.reasonOther.label')}</Form.Group.Label>
+                  <Controller
+                    name="deaccessionReasonOther"
+                    control={control}
+                    render={({
+                      field: { onChange, ref, value },
+                      fieldState: { invalid, error }
+                    }) => (
+                      <>
+                        <Form.Group.TextArea
+                          value={value}
+                          onChange={onChange}
+                          isInvalid={invalid}
+                          rows={2}
+                          ref={ref}
+                        />
+                        {invalid && (
+                          <Form.Group.Feedback type="invalid">{error?.message}</Form.Group.Feedback>
                         )}
                       </>
                     )}
                   />
-                </div>
-              </Form.Group>
-            )}
-            <Form.Group as={Col} controlId={'deccessionReason'}>
-              <Form.Group.Label required>{t('deaccession.reason.label')}</Form.Group.Label>
-              <Controller
-                name="deaccessionReason"
-                control={control}
-                rules={{ required: t('deaccession.reason.validation') }}
-                render={({ field: { onChange, ref, value }, fieldState }) => (
-                  <>
-                    <Form.Group.Select
-                      value={value}
-                      onChange={onChange}
-                      isInvalid={fieldState.invalid}
-                      ref={ref}>
-                      <option>Select...</option>
-                      <option value={t('deaccession.reason.options.identifiable')}>
-                        {t('deaccession.reason.options.identifiable')}
-                      </option>
-                      <option value={t('deaccession.reason.options.retracted')}>
-                        {t('deaccession.reason.options.retracted')}
-                      </option>
-                      <option value={t('deaccession.reason.options.transferred')}>
-                        {t('deaccession.reason.options.transferred')}
-                      </option>
-                      <option value={t('deaccession.reason.options.irb')}>
-                        {t('deaccession.reason.options.irb')}
-                      </option>
-                      <option value={t('deaccession.reason.options.legalIssue')}>
-                        {t('deaccession.reason.options.legalIssue')}
-                      </option>
-                      <option value={t('deaccession.reason.options.invalid')}>
-                        {t('deaccession.reason.options.invalid')}
-                      </option>
-                    </Form.Group.Select>
-                    <Form.Group.Feedback type="invalid">
-                      {fieldState.error?.message}
-                    </Form.Group.Feedback>
-                  </>
-                )}></Controller>
-            </Form.Group>
-            <Form.Group as={Col}>
-              <Form.Group.Label>{t('deaccession.reasonOther.label')}</Form.Group.Label>
-              <Controller
-                name="deaccessionReasonOther"
-                control={control}
-                render={({ field: { onChange, ref, value }, fieldState: { invalid, error } }) => (
-                  <>
-                    <Form.Group.TextArea
-                      value={value}
-                      onChange={onChange}
-                      isInvalid={invalid}
-                      ref={ref}
-                    />
-                    {invalid && (
-                      <Form.Group.Feedback type="invalid">{error?.message}</Form.Group.Feedback>
+                </Form.Group>
+                <Form.Group as={Col}>
+                  <Form.Group.Label>{t('deaccession.forwardUrl.label')}</Form.Group.Label>
+                  <Controller
+                    name="deaccessionForwardUrl"
+                    control={control}
+                    rules={{
+                      validate: (value) =>
+                        isValidNonEmptyURL(value) || t('deaccession.forwardUrl.validation')
+                    }}
+                    render={({
+                      field: { onChange, ref, value },
+                      fieldState: { invalid, error }
+                    }) => (
+                      <>
+                        <Form.Group.Input
+                          type="text"
+                          placeholder="https://"
+                          data-testid="deaccession-forward-url"
+                          value={value}
+                          onChange={onChange}
+                          isInvalid={invalid}
+                          ref={ref}
+                        />
+                        {invalid && (
+                          <Form.Group.Feedback type="invalid">{error?.message}</Form.Group.Feedback>
+                        )}
+                      </>
                     )}
-                  </>
-                )}
-              />
-            </Form.Group>
-            <Form.Group as={Col}>
-              <Form.Group.Label>{t('deaccession.forwardUrl.label')}</Form.Group.Label>
-              <Controller
-                name="deaccessionForwardUrl"
-                control={control}
-                rules={{
-                  validate: (value) =>
-                    isValidNonEmptyURL(value) || t('deaccession.forwardUrl.validation')
-                }}
-                render={({ field: { onChange, ref, value }, fieldState: { invalid, error } }) => (
-                  <>
-                    <Form.Group.Input
-                      type="text"
-                      placeholder="https://"
-                      data-testid="deaccession-forward-url"
-                      value={value}
-                      onChange={onChange}
-                      isInvalid={invalid}
-                      ref={ref}
-                    />
-                    {invalid && (
-                      <Form.Group.Feedback type="invalid">{error?.message}</Form.Group.Feedback>
-                    )}
-                  </>
-                )}
-              />
-            </Form.Group>
-
-            <Button variant="primary" type="submit">
-              {t('continue', { ns: 'shared' })}
-            </Button>
-            <Button withSpacing variant="secondary" type="button" onClick={handleClose}>
-              {t('cancel', { ns: 'shared' })}
-            </Button>
-          </form>
-        </Stack>
-      </Modal.Body>
-      <Modal.Footer></Modal.Footer>
-    </Modal>
+                  />
+                </Form.Group>
+              </form>
+            </Stack>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button withSpacing variant="secondary" type="button" onClick={handleCloseWithReset}>
+            {t('cancel', { ns: 'shared' })}
+          </Button>
+          <Button
+            variant="primary"
+            type="button"
+            onClick={handleSubmit(handleSubmitForm)}
+            disabled={isLoadingDatasetVersionSummaries}>
+            {t('continue', { ns: 'shared' })}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+      <ConfirmationModal
+        submissionStatus={submissionStatus}
+        deaccessionError={deaccessionError}
+        show={showConfirmationModal}
+        onConfirm={handleConfirmDeaccession}
+        onCancel={handleCancelConfirmation}
+      />
+    </>
   )
 }
+
+const DeaccessionDatasetModalSkeleton = () => (
+  <SkeletonTheme>
+    <div data-testid="deaccession-dataset-modal-skeleton">
+      <Skeleton width="100%" height={82} style={{ marginBottom: 16 }} />
+      <Col style={{ marginBottom: 16 }}>
+        <Skeleton width={160} />
+        <Skeleton width="100%" height={38} />
+      </Col>
+      <Col style={{ marginBottom: 16 }}>
+        <Skeleton width={260} />
+        <Skeleton width="100%" height={62} />
+      </Col>
+      <Col style={{ marginBottom: 16 }}>
+        <Skeleton width={260} />
+        <Skeleton width="100%" height={38} />
+      </Col>
+    </div>
+  </SkeletonTheme>
+)

--- a/src/sections/dataset/publish-dataset/PublishDatasetModal.tsx
+++ b/src/sections/dataset/publish-dataset/PublishDatasetModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { Button, Modal, Stack } from '@iqss/dataverse-design-system'
+import { Button, Modal, Spinner, Stack } from '@iqss/dataverse-design-system'
 import { Form } from '@iqss/dataverse-design-system'
 import type { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
 import { VersionUpdateType } from '@/dataset/domain/models/VersionUpdateType'
@@ -157,8 +157,14 @@ export function PublishDatasetModal({
               : selectedVersionUpdateType
             submitPublish(versionUpdateType)
           }}
-          type="submit">
-          {t('publish.continueButton')}
+          type="submit"
+          disabled={submissionStatus === SubmissionStatus.IsSubmitting}>
+          <Stack direction="horizontal" gap={1}>
+            {t('publish.continueButton')}
+            {submissionStatus === SubmissionStatus.IsSubmitting && (
+              <Spinner variant="light" animation="border" size="sm" />
+            )}
+          </Stack>
         </Button>
         <Button
           withSpacing

--- a/src/stories/dataset/DatasetLoadingMockRepository.ts
+++ b/src/stories/dataset/DatasetLoadingMockRepository.ts
@@ -1,6 +1,7 @@
 import { DatasetMockRepository } from './DatasetMockRepository'
 import { DatasetPaginationInfo } from '../../dataset/domain/models/DatasetPaginationInfo'
 import { DatasetsWithCount } from '../../dataset/domain/models/DatasetsWithCount'
+import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 
 export class DatasetLoadingMockRepository extends DatasetMockRepository {
   getDatasetsWithCount: (
@@ -10,6 +11,10 @@ export class DatasetLoadingMockRepository extends DatasetMockRepository {
     _collectionId: string,
     _paginationInfo: DatasetPaginationInfo
   ) => {
+    return new Promise(() => {})
+  }
+
+  getDatasetVersionsSummaries(_datasetId: number | string): Promise<DatasetVersionSummaryInfo[]> {
     return new Promise(() => {})
   }
 }

--- a/src/stories/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.stories.tsx
+++ b/src/stories/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.stories.tsx
@@ -45,7 +45,6 @@ export const WithAllPermissionsDraftVersionOnly: Story = {
           latestVersionPublishingStatus: DatasetPublishingStatus.DRAFT
         }),
         permissions: DatasetPermissionsMother.createWithAllAllowed(),
-        versionsSummaries: [],
         hasValidTermsOfAccess: true
       })}
     />

--- a/src/stories/dataset/dataset-versions/DatasetVersions.stories.tsx
+++ b/src/stories/dataset/dataset-versions/DatasetVersions.stories.tsx
@@ -17,7 +17,11 @@ type Story = StoryObj<typeof DatasetVersions>
 
 export const Default: Story = {
   render: () => (
-    <DatasetVersions datasetRepository={new DatasetMockRepository()} datasetId="test-dataset-id" />
+    <DatasetVersions
+      datasetRepository={new DatasetMockRepository()}
+      datasetId="test-dataset-id"
+      isInView
+    />
   )
 }
 

--- a/src/stories/dataset/deaccession-dataset/DeaccessionDatasetModal.stories.tsx
+++ b/src/stories/dataset/deaccession-dataset/DeaccessionDatasetModal.stories.tsx
@@ -2,8 +2,9 @@ import { Meta, StoryObj } from '@storybook/react'
 import { DeaccessionDatasetModal } from '../../../sections/dataset/deaccession-dataset/DeaccessionDatasetModal'
 import { WithI18next } from '../../WithI18next'
 import { WithLoggedInUser } from '../../WithLoggedInUser'
-import { DeaccessionFormData } from '@/sections/dataset/deaccession-dataset/DeaccessionFormData'
-import { useForm } from 'react-hook-form'
+import { DatasetMockRepository } from '../DatasetMockRepository'
+import { DatasetVersionSummaryStringValues } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { DatasetLoadingMockRepository } from '../DatasetLoadingMockRepository'
 
 const meta: Meta<typeof DeaccessionDatasetModal> = {
   title: 'Sections/Dataset Page/Deaccession Dataset/DeaccessionDatasetModal',
@@ -18,36 +19,12 @@ type Story = StoryObj<typeof DeaccessionDatasetModal>
 export const Default: Story = {
   decorators: [WithLoggedInUser],
   render: () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { control } = useForm<DeaccessionFormData>({
-      defaultValues: {
-        deaccessionReason: '',
-        versions: ['1.0']
-      }
-    })
     return (
       <DeaccessionDatasetModal
         show={true}
-        handleSubmitForm={() => {}}
-        handleClose={() => {}}
-        control={control}
-        errors={{}}
-        publishedVersions={[
-          {
-            id: 1,
-            contributors: 'contributors',
-            versionNumber: '1.0',
-            publishedOn: '2023-01-01',
-            summary: {}
-          },
-          {
-            id: 2,
-            contributors: 'contributors',
-            versionNumber: '1.1',
-            publishedOn: '2023-02-01',
-            summary: {}
-          }
-        ]}
+        datasetRepository={new DatasetMockRepository()}
+        datasetPersistentId="test-dataset-id"
+        handleCloseDeaccessionModal={() => {}}
       />
     )
   }
@@ -56,23 +33,42 @@ export const Default: Story = {
 export const WithOneVersion: Story = {
   decorators: [WithLoggedInUser],
   render: () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const { control } = useForm<DeaccessionFormData>({
-      defaultValues: {
-        deaccessionReason: '',
-        versions: ['1.0']
-      }
-    })
+    const datasetMockRepository = new DatasetMockRepository()
+    datasetMockRepository.getDatasetVersionsSummaries = () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve([
+            {
+              id: 1,
+              contributors: 'contributors',
+              versionNumber: '1.0',
+              publishedOn: '2023-01-01',
+              summary: DatasetVersionSummaryStringValues.firstPublished
+            }
+          ])
+        }, 1_000)
+      })
+    }
+
     return (
       <DeaccessionDatasetModal
         show={true}
-        handleSubmitForm={() => {}}
-        handleClose={() => {}}
-        control={control}
-        errors={{}}
-        publishedVersions={[
-          { id: 1, contributors: 'contributors', versionNumber: '1.0', publishedOn: '2023-01-01' }
-        ]}></DeaccessionDatasetModal>
+        datasetRepository={datasetMockRepository}
+        datasetPersistentId="test-dataset-id"
+        handleCloseDeaccessionModal={() => {}}
+      />
     )
   }
+}
+
+export const LoadingDatasetVersionSummaries: Story = {
+  decorators: [WithLoggedInUser],
+  render: () => (
+    <DeaccessionDatasetModal
+      show={true}
+      datasetRepository={new DatasetLoadingMockRepository()}
+      datasetPersistentId="test-dataset-id"
+      handleCloseDeaccessionModal={() => {}}
+    />
+  )
 }

--- a/tests/component/dataset/domain/models/DatasetMother.ts
+++ b/tests/component/dataset/domain/models/DatasetMother.ts
@@ -439,7 +439,6 @@ export class DatasetMother {
       dataset.downloadUrls,
       dataset.fileDownloadSizes,
       dataset.hierarchy,
-      dataset.versionsSummaries,
       dataset.license,
       dataset.thumbnail,
       dataset.privateUrl,

--- a/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
+++ b/tests/component/dataset/infrastructure/mappers/JSDatasetMapper.spec.ts
@@ -211,34 +211,7 @@ const jsDatasetVersionDiff = {
 }
 const jsDatasetFilesTotalOriginalDownloadSize = 5
 const jsDatasetFilesTotalArchivalDownloadSize = 7
-const jsDatasetVersionSummaries = [
-  {
-    id: 101,
-    versionNumber: '1.0',
-    summary: {
-      citation: {
-        added: 1,
-        deleted: 0,
-        changed: 1
-      }
-    },
-    contributors: 'John Doe',
-    publishedOn: '2023-01-01'
-  },
-  {
-    id: 102,
-    versionNumber: '2.0',
-    summary: {
-      citation: {
-        added: 1,
-        deleted: 0,
-        changed: 1
-      }
-    },
-    contributors: 'Jane Doe',
-    publishedOn: '2023-02-01'
-  }
-]
+
 const expectedDataset = {
   persistentId: 'doi:10.5072/FK2/B4B2MJ',
   version: {
@@ -354,35 +327,7 @@ const expectedDataset = {
   ),
   nextMajorVersion: undefined,
   nextMinorVersion: undefined,
-  requiresMajorVersionUpdate: false,
-  versionsSummaries: [
-    {
-      id: 101,
-      versionNumber: '1.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'John Doe',
-      publishedOn: '2023-01-01'
-    },
-    {
-      id: 102,
-      versionNumber: '2.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'Jane Doe',
-      publishedOn: '2023-02-01'
-    }
-  ]
+  requiresMajorVersionUpdate: false
 }
 const expectedDatasetWithPublicationDate = {
   persistentId: 'doi:10.5072/FK2/B4B2MJ',
@@ -497,35 +442,7 @@ const expectedDatasetWithPublicationDate = {
   ),
   nextMajorVersion: undefined,
   nextMinorVersion: undefined,
-  requiresMajorVersionUpdate: false,
-  versionsSummaries: [
-    {
-      id: 101,
-      versionNumber: '1.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'John Doe',
-      publishedOn: '2023-01-01'
-    },
-    {
-      id: 102,
-      versionNumber: '2.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'Jane Doe',
-      publishedOn: '2023-02-01'
-    }
-  ]
+  requiresMajorVersionUpdate: false
 }
 const expectedDatasetWithNextVersionNumbers = {
   persistentId: 'doi:10.5072/FK2/B4B2MJ',
@@ -640,35 +557,7 @@ const expectedDatasetWithNextVersionNumbers = {
   ),
   nextMajorVersion: '2.0',
   nextMinorVersion: '1.3',
-  requiresMajorVersionUpdate: false,
-  versionsSummaries: [
-    {
-      id: 101,
-      versionNumber: '1.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'John Doe',
-      publishedOn: '2023-01-01'
-    },
-    {
-      id: 102,
-      versionNumber: '2.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'Jane Doe',
-      publishedOn: '2023-02-01'
-    }
-  ]
+  requiresMajorVersionUpdate: false
 }
 
 const expectedDatasetAlternateVersion = {
@@ -797,35 +686,7 @@ const expectedDatasetAlternateVersion = {
   ),
   nextMajorVersion: undefined,
   nextMinorVersion: undefined,
-  requiresMajorVersionUpdate: false,
-  versionsSummaries: [
-    {
-      id: 101,
-      versionNumber: '1.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'John Doe',
-      publishedOn: '2023-01-01'
-    },
-    {
-      id: 102,
-      versionNumber: '2.0',
-      summary: {
-        citation: {
-          added: 1,
-          deleted: 0,
-          changed: 1
-        }
-      },
-      contributors: 'Jane Doe',
-      publishedOn: '2023-02-01'
-    }
-  ]
+  requiresMajorVersionUpdate: false
 }
 
 describe('JS Dataset Mapper', () => {
@@ -837,8 +698,7 @@ describe('JS Dataset Mapper', () => {
       jsDatasetPermissions,
       jsDatasetLocks,
       jsDatasetFilesTotalOriginalDownloadSize,
-      jsDatasetFilesTotalArchivalDownloadSize,
-      jsDatasetVersionSummaries
+      jsDatasetFilesTotalArchivalDownloadSize
     )
     expect(mapped).to.deep.equal(expectedDataset)
   })
@@ -852,7 +712,6 @@ describe('JS Dataset Mapper', () => {
       jsDatasetLocks,
       jsDatasetFilesTotalOriginalDownloadSize,
       jsDatasetFilesTotalArchivalDownloadSize,
-      jsDatasetVersionSummaries,
       '4.0'
     )
 
@@ -896,8 +755,7 @@ describe('JS Dataset Mapper', () => {
         jsDatasetPermissions,
         jsDatasetLocks,
         jsDatasetFilesTotalOriginalDownloadSize,
-        jsDatasetFilesTotalArchivalDownloadSize,
-        jsDatasetVersionSummaries
+        jsDatasetFilesTotalArchivalDownloadSize
       )
     )
   })
@@ -939,8 +797,7 @@ describe('JS Dataset Mapper', () => {
         jsDatasetPermissions,
         jsDatasetLocks,
         jsDatasetFilesTotalOriginalDownloadSize,
-        jsDatasetFilesTotalArchivalDownloadSize,
-        jsDatasetVersionSummaries
+        jsDatasetFilesTotalArchivalDownloadSize
       )
     )
   })
@@ -958,8 +815,7 @@ describe('JS Dataset Mapper', () => {
       jsDatasetPermissions,
       jsDatasetLocks,
       jsDatasetFilesTotalOriginalDownloadSize,
-      jsDatasetFilesTotalArchivalDownloadSize,
-      jsDatasetVersionSummaries
+      jsDatasetFilesTotalArchivalDownloadSize
     )
 
     expect(expectedDatasetWithPublicationDate).to.deep.equal(actual)
@@ -981,7 +837,6 @@ describe('JS Dataset Mapper', () => {
       jsDatasetLocks,
       jsDatasetFilesTotalOriginalDownloadSize,
       jsDatasetFilesTotalArchivalDownloadSize,
-      jsDatasetVersionSummaries,
       undefined,
       undefined,
       latestPublishedVersionMajorNumber,
@@ -1005,7 +860,6 @@ describe('JS Dataset Mapper', () => {
       jsDatasetLocks,
       jsDatasetFilesTotalOriginalDownloadSize,
       jsDatasetFilesTotalArchivalDownloadSize,
-      jsDatasetVersionSummaries,
       undefined,
       undefined,
       latestPublishedVersionMajorNumber,

--- a/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/DeaccessionDatasetButton.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/DeaccessionDatasetButton.spec.tsx
@@ -10,6 +10,30 @@ import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersio
 
 describe('DeaccessionDatasetButton', () => {
   const repository: DatasetRepository = {} as DatasetRepository
+  const versionSummaries = [
+    DatasetVersionSummaryInfoMother.create({
+      versionNumber: '1.0',
+      publishedOn: '2021-01-01',
+      contributors: 'Contributors',
+      summary: {}
+    }),
+    DatasetVersionSummaryInfoMother.create({
+      versionNumber: '2.0',
+      publishedOn: '2021-01-02',
+      contributors: 'Contributors',
+      summary: {}
+    }),
+    DatasetVersionSummaryInfoMother.create({
+      versionNumber: '3.0',
+      publishedOn: '2021-01-22',
+      contributors: 'Contributors',
+      summary: {}
+    })
+  ]
+
+  beforeEach(() => {
+    repository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaries)
+  })
 
   it('renders the DeaccessionDatasetButton if the user has publish dataset permissions and the dataset is released', () => {
     const dataset = DatasetMother.create({
@@ -49,8 +73,7 @@ describe('DeaccessionDatasetButton', () => {
     it('renders the DeaccessionDatasetButton and opens the modal on click', () => {
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: DatasetVersionSummaryInfoMother.createList(3)
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -60,7 +83,7 @@ describe('DeaccessionDatasetButton', () => {
       cy.get('div').contains('Deaccession Dataset').should('exist')
       cy.get('div').contains('Deaccession is permanent.').should('exist')
       cy.get('form').should('exist')
-      cy.get('input[type="checkbox"]').should('have.length', dataset.versionsSummaries?.length)
+      cy.get('input[type="checkbox"]').should('have.length', 3)
       cy.get('select').should('exist')
       cy.get('textarea').should('exist')
     })
@@ -76,37 +99,37 @@ describe('DeaccessionDatasetButton', () => {
       cy.findByRole('button', { name: 'Deaccession Dataset' }).click()
       cy.get('select').select('IRB request.')
       cy.get('input[type="checkbox"]').first().check()
-      cy.get('button').contains('Continue').click()
+      cy.findByRole('button', { name: 'Continue' }).click()
       cy.findByText('Confirm Deaccession').should('exist')
     })
 
     it('does not render versionList if it only contains one published element', () => {
       repository.deaccession = cy.stub().resolves()
-      const singleVersionList = DatasetVersionSummaryInfoMother.createList(2)
-      singleVersionList[0].publishedOn = '2021-01-01'
-      singleVersionList[1].publishedOn = undefined
+      const singleVersionList = [
+        DatasetVersionSummaryInfoMother.create({
+          versionNumber: '1.0',
+          publishedOn: '2021-01-01'
+        }),
+        DatasetVersionSummaryInfoMother.create({
+          versionNumber: undefined,
+          publishedOn: undefined,
+          contributors: 'Contributors',
+          summary: {}
+        })
+      ]
+
+      repository.getDatasetVersionsSummaries = cy.stub().resolves(singleVersionList)
+
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: singleVersionList
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
 
       cy.findByRole('button', { name: 'Deaccession Dataset' }).click()
       cy.get('form').should('exist')
-      cy.get('input[type="checkbox"]').should('not.exist')
-      cy.get('select').select('IRB request.')
-      cy.get('button[type="submit"]').click()
-      cy.get('button').contains('Yes').should('exist').click()
-      cy.wrap(repository.deaccession).should(
-        'be.calledWithMatch',
-        dataset.persistentId,
-        dataset.versionsSummaries?.[0].versionNumber,
-        {
-          deaccessionReason: 'IRB request.'
-        }
-      )
+      cy.findByTestId('published-versions').should('not.exist')
     })
 
     it('only renders version if it is published', () => {
@@ -133,10 +156,11 @@ describe('DeaccessionDatasetButton', () => {
           summary: {}
         }
       ]
+      repository.getDatasetVersionsSummaries = cy.stub().resolves(singleVersionList)
+
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: singleVersionList
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -151,8 +175,7 @@ describe('DeaccessionDatasetButton', () => {
     it('displays validation error messages', () => {
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: DatasetVersionSummaryInfoMother.createList(3)
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -160,7 +183,7 @@ describe('DeaccessionDatasetButton', () => {
       cy.findByRole('button', { name: 'Deaccession Dataset' }).click()
       cy.get('form').should('exist')
       cy.findByTestId('deaccession-forward-url').type('bad-url')
-      cy.get('button[type="submit"]').click()
+      cy.findByRole('button', { name: 'Continue' }).click()
       cy.get('div').contains('Please select at least one version to deaccession.').should('exist')
       cy.get('div')
         .contains('Please select a reason for deaccessioning this dataset.')
@@ -172,8 +195,7 @@ describe('DeaccessionDatasetButton', () => {
       repository.deaccession = cy.stub().resolves()
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: DatasetVersionSummaryInfoMother.createList(3)
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -184,12 +206,12 @@ describe('DeaccessionDatasetButton', () => {
       cy.get('select').select('IRB request.')
       cy.get('textarea').type('Additional information')
       cy.findByTestId('deaccession-forward-url').type('https://example.com')
-      cy.get('button[type="submit"]').click()
+      cy.findByRole('button', { name: 'Continue' }).click()
       cy.get('button').contains('Yes', { timeout: 10000 }).should('exist').click()
       cy.wrap(repository.deaccession).should(
         'be.calledWithMatch',
         dataset.persistentId,
-        dataset.versionsSummaries?.[0].versionNumber,
+        versionSummaries[0].versionNumber,
         {
           deaccessionReason: 'IRB request. Additional information',
           deaccessionForwardUrl: 'https://example.com'
@@ -201,8 +223,7 @@ describe('DeaccessionDatasetButton', () => {
       repository.deaccession = cy.stub().rejects(new Error('Deaccession error'))
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: DatasetVersionSummaryInfoMother.createList(3)
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -212,17 +233,29 @@ describe('DeaccessionDatasetButton', () => {
       cy.get('select').select('IRB request.')
       cy.get('textarea').type('Additional information')
       cy.findByTestId('deaccession-forward-url').type('https://example.com')
-      cy.get('button[type="submit"]').click()
+      cy.findByRole('button', { name: 'Continue' }).click()
       cy.get('button').contains('Yes').should('exist').click()
       cy.get('div').contains('Deaccession error').should('exist')
     })
 
     it('calls the repository.deaccession once for every version selected', () => {
+      const versionSummary1 = DatasetVersionSummaryInfoMother.create({
+        versionNumber: '1.0',
+        publishedOn: '2021-01-01',
+        id: 1
+      })
+      const versionSummary2 = DatasetVersionSummaryInfoMother.create({
+        versionNumber: '2.0',
+        publishedOn: '2021-01-02',
+        id: 2
+      })
+      repository.getDatasetVersionsSummaries = cy
+        .stub()
+        .resolves([versionSummary1, versionSummary2])
       repository.deaccession = cy.stub().resolves()
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: DatasetVersionSummaryInfoMother.createList(2)
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -233,9 +266,9 @@ describe('DeaccessionDatasetButton', () => {
       cy.get('select').select('IRB request.')
       cy.get('textarea').type('Additional information')
       cy.findByTestId('deaccession-forward-url').type('https://example.com')
-      cy.get('button[type="submit"]').click()
+      cy.findByRole('button', { name: 'Continue' }).click()
       cy.get('button').contains('Yes').should('exist').click()
-      cy.wrap(repository.deaccession).should('have.been.called')
+      cy.wrap(repository.deaccession).should('have.callCount', 2)
     })
 
     it('does not show deaccessioned versions in the version list', () => {
@@ -267,11 +300,10 @@ describe('DeaccessionDatasetButton', () => {
           summary: {}
         }
       ]
-
+      repository.getDatasetVersionsSummaries = cy.stub().resolves(versionsSummaries)
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: versionsSummaries
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)
@@ -284,7 +316,7 @@ describe('DeaccessionDatasetButton', () => {
       cy.get('input[type="checkbox"]').should('have.length', 2)
     })
 
-    it('does not show versions list in the version list if there is only one deaccessioned version available', () => {
+    it('does not show versions list if there is only one deaccessioned version available', () => {
       const versionsSummaries: DatasetVersionSummaryInfo[] = [
         {
           id: 1,
@@ -307,10 +339,11 @@ describe('DeaccessionDatasetButton', () => {
         }
       ]
 
+      repository.getDatasetVersionsSummaries = cy.stub().resolves(versionsSummaries)
+
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
-        version: DatasetVersionMother.createReleased(),
-        versionsSummaries: versionsSummaries
+        version: DatasetVersionMother.createReleased()
       })
 
       cy.customMount(<DeaccessionDatasetButton dataset={dataset} datasetRepository={repository} />)

--- a/tests/component/sections/dataset/dataset-files/DatasetFilesScrollable.spec.tsx
+++ b/tests/component/sections/dataset/dataset-files/DatasetFilesScrollable.spec.tsx
@@ -495,6 +495,7 @@ describe('DatasetFilesScrollable', () => {
           expect(count).to.be.gte(10)
         })
       cy.findByTestId('header-checkbox').should('be.visible').uncheck({ force: true })
+      cy.wait(300)
       cy.findByText('10 files are currently selected.').should('not.exist')
     })
 

--- a/tests/component/sections/dataset/dataset-versions/DatasetVersions.spec.tsx
+++ b/tests/component/sections/dataset/dataset-versions/DatasetVersions.spec.tsx
@@ -53,7 +53,7 @@ describe('DatasetVersions', () => {
 
   beforeEach(() => {
     cy.customMount(
-      <DatasetVersions datasetId={'datasetId'} datasetRepository={datasetsRepository} />
+      <DatasetVersions datasetId={'datasetId'} datasetRepository={datasetsRepository} isInView />
     )
     datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
     datasetsRepository.getVersionDiff = cy.stub().resolves(datasetVersionDiff)
@@ -131,21 +131,25 @@ describe('DatasetVersions', () => {
   })
 
   it('should not render the dataset version table if dataset is undefined', () => {
-    cy.customMount(<DatasetVersions datasetId={''} datasetRepository={datasetsRepository} />)
+    cy.customMount(
+      <DatasetVersions datasetId={''} datasetRepository={datasetsRepository} isInView />
+    )
     cy.findByTestId('dataset-versions-table').should('not.exist')
   })
 
   it('should render loading skeleton if the dataset version is loading', () => {
     datasetsRepository.getDatasetVersionsSummaries = cy.stub().returns(new Promise(() => {}))
     cy.customMount(
-      <DatasetVersions datasetId={'datasetId'} datasetRepository={datasetsRepository} />
+      <DatasetVersions datasetId={'datasetId'} datasetRepository={datasetsRepository} isInView />
     )
     cy.findByTestId('dataset-loading-skeleton').should('exist')
     cy.findByTestId('dataset-versions-table').should('not.exist')
   })
 
   it('should render view differences button, open a modal if click', () => {
-    cy.customMount(<DatasetVersions datasetId={''} datasetRepository={datasetsRepository} />)
+    cy.customMount(
+      <DatasetVersions datasetId={''} datasetRepository={datasetsRepository} isInView />
+    )
 
     cy.findAllByTestId('select-checkbox').first().should('exist').check().should('be.checked')
     cy.findAllByTestId('select-checkbox').last().should('exist').check().should('be.checked')
@@ -155,7 +159,9 @@ describe('DatasetVersions', () => {
   })
 
   it('should render view differences button, close modal if cancel', () => {
-    cy.customMount(<DatasetVersions datasetId={''} datasetRepository={datasetsRepository} />)
+    cy.customMount(
+      <DatasetVersions datasetId={''} datasetRepository={datasetsRepository} isInView />
+    )
 
     cy.findAllByTestId('select-checkbox').first().should('exist').check().should('be.checked')
     cy.findAllByTestId('select-checkbox').last().should('exist').check().should('be.checked')
@@ -167,7 +173,9 @@ describe('DatasetVersions', () => {
   })
 
   it('should render view differences button, close modal if click outside', () => {
-    cy.customMount(<DatasetVersions datasetId={''} datasetRepository={datasetsRepository} />)
+    cy.customMount(
+      <DatasetVersions datasetId={''} datasetRepository={datasetsRepository} isInView />
+    )
     cy.get('input[type="checkbox"]').first().check()
     cy.get('input[type="checkbox"]').last().check()
     cy.findByRole('button', { name: 'View Differences' }).should('exist').click()

--- a/tests/component/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.spec.tsx
+++ b/tests/component/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.spec.tsx
@@ -16,7 +16,8 @@ describe('useGetDatasetVersionDiff', () => {
     const { result } = renderHook(() =>
       useGetDatasetVersionsSummaries({
         datasetRepository,
-        persistentId: 'doi:10.5072/FK2/ABC123'
+        persistentId: 'doi:10.5072/FK2/ABC123',
+        autoFetch: true
       })
     )
 
@@ -37,7 +38,8 @@ describe('useGetDatasetVersionDiff', () => {
     const { result } = renderHook(() =>
       useGetDatasetVersionsSummaries({
         datasetRepository,
-        persistentId: 'doi:10.5072/FK2/ABC123'
+        persistentId: 'doi:10.5072/FK2/ABC123',
+        autoFetch: true
       })
     )
     await act(() => {
@@ -56,7 +58,8 @@ describe('useGetDatasetVersionDiff', () => {
     const { result } = renderHook(() =>
       useGetDatasetVersionsSummaries({
         datasetRepository,
-        persistentId: 'doi:10.5072/FK2/ABC123'
+        persistentId: 'doi:10.5072/FK2/ABC123',
+        autoFetch: true
       })
     )
 
@@ -71,6 +74,62 @@ describe('useGetDatasetVersionDiff', () => {
       return expect(result.current.error).to.deep.equal(
         'Something went wrong getting the information from the dataset versions summaries. Try again later.'
       )
+    })
+  })
+
+  it('should fetch summaries when fetchSummaries is called', () => {
+    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(datasetVersionsSummariesMock)
+
+    const { result } = renderHook(() =>
+      useGetDatasetVersionsSummaries({
+        datasetRepository,
+        persistentId: 'doi:10.5072/FK2/ABC123',
+        autoFetch: false
+      })
+    )
+
+    expect(result.current.isLoading).to.equal(false)
+    expect(result.current.datasetVersionSummaries).to.be.undefined
+    expect(result.current.error).to.be.null
+
+    act(() => {
+      return void result.current.fetchSummaries()
+    })
+
+    cy.wrap(null).should(() => {
+      expect(result.current.isLoading).to.equal(true)
+    })
+
+    cy.wrap(null).should(() => {
+      expect(result.current.isLoading).to.equal(false)
+      expect(result.current.datasetVersionSummaries).to.deep.equal(datasetVersionsSummariesMock)
+      expect(datasetRepository.getDatasetVersionsSummaries).to.have.been.calledOnce
+    })
+  })
+
+  it('should not fetch summaries if autoFetch is false', async () => {
+    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(datasetVersionsSummariesMock)
+
+    const { result } = renderHook(() =>
+      useGetDatasetVersionsSummaries({
+        datasetRepository,
+        persistentId: 'doi:10.5072/FK2/ABC123',
+        autoFetch: false
+      })
+    )
+
+    await act(() => {
+      expect(result.current.isLoading).to.deep.equal(false)
+      expect(result.current.error).to.deep.equal(null)
+      expect(result.current.datasetVersionSummaries).to.deep.equal(undefined)
+      return expect(datasetRepository.getDatasetVersionsSummaries).not.to.have.been.called
+    })
+
+    await act(() => {
+      expect(result.current.isLoading).to.deep.equal(false)
+      expect(result.current.error).to.deep.equal(null)
+      expect(result.current.datasetVersionSummaries).to.deep.equal(undefined)
+      return expect(datasetRepository.getDatasetVersionsSummaries).not.to.have.been.called
     })
   })
 })

--- a/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
+++ b/tests/e2e-integration/integration/datasets/DatasetJSDataverseRepository.spec.ts
@@ -140,15 +140,6 @@ const datasetData = (persistentId: string, versionId: number) => {
       termsOfAccess: termsOfUse,
       deaccessionNote: undefined
     },
-    versionsSummaries: [
-      {
-        id: versionId,
-        versionNumber: 'DRAFT',
-        publishedOn: '',
-        summary: 'firstDraft',
-        contributors: 'Dataverse Admin'
-      }
-    ],
     permissions: {
       canDownloadFiles: true,
       canUpdateDataset: true,
@@ -200,7 +191,6 @@ describe('Dataset JSDataverse Repository', () => {
         expect(dataset.locks).to.deep.equal(datasetExpected.locks)
         expect(dataset.downloadUrls).to.deep.equal(datasetExpected.downloadUrls)
         expect(dataset.fileDownloadSizes).to.deep.equal(datasetExpected.fileDownloadSizes)
-        expect(dataset.versionsSummaries).to.deep.equal(datasetExpected.versionsSummaries)
       })
   })
 


### PR DESCRIPTION
## What this PR does / why we need it:

> Depending on the size of the Dataset, sometimes the version summary info API can be slow. So to improve performance of the Dataset Page, we need to remove the API call, and execute it only when the user clicks on the Dataset Versions tab.
Also the version summary info was fetched in parallel when getting the dataset details, I removed that.
There was another place where this info was used which is the deaccession dataset modal, now we are only fetching the version summaries info when the modal is opened and only once, meaning that if it was opened before and the internal version number of the dataset remains the same it will use the info that was already fetched before.

## Which issue(s) this PR closes:

- Closes #704 

## Special notes for your reviewer:

## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
