### PR TITLE
Keep account tabs in sync with tab query param in the URL

### DIFF
--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19.6.1-alpine as BUILD_IMAGE
+FROM node:19.6.1-alpine AS build_image
 
 RUN apk --no-cache add python3 make g++
 
@@ -17,7 +17,7 @@ RUN npm install
 FROM node:19.6.1-alpine 
 
 WORKDIR /usr/src/app
-COPY --from=BUILD_IMAGE /usr/src/app/node_modules ./node_modules
+COPY --from=build_image /usr/src/app/node_modules ./node_modules
 
 EXPOSE 5173
 CMD ["npm", "start"]

--- a/src/sections/account/Account.tsx
+++ b/src/sections/account/Account.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSearchParams } from 'react-router-dom'
 import { Tabs } from '@iqss/dataverse-design-system'
@@ -5,6 +6,7 @@ import { AccountHelper, AccountPanelTabKey } from './AccountHelper'
 import { UserJSDataverseRepository } from '@/users/infrastructure/repositories/UserJSDataverseRepository'
 import { ApiTokenSection } from './api-token-section/ApiTokenSection'
 import { AccountInfoSection } from './account-info-section/AccountInfoSection'
+import { useLoading } from '../loading/LoadingContext'
 import styles from './Account.module.scss'
 
 const tabsKeys = AccountHelper.ACCOUNT_PANEL_TABS_KEYS
@@ -17,6 +19,9 @@ interface AccountProps {
 export const Account = ({ defaultActiveTabKey, userRepository }: AccountProps) => {
   const { t } = useTranslation('account')
   const [_, setSearchParams] = useSearchParams()
+  const { setIsLoading } = useLoading()
+
+  useEffect(() => setIsLoading(false), [setIsLoading])
 
   const updateSearchParamTabKeyOnSelect = (keySelected: string | null) => {
     if (keySelected !== defaultActiveTabKey) {

--- a/src/sections/account/Account.tsx
+++ b/src/sections/account/Account.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next'
+import { useSearchParams } from 'react-router-dom'
 import { Tabs } from '@iqss/dataverse-design-system'
 import { AccountHelper, AccountPanelTabKey } from './AccountHelper'
 import { UserJSDataverseRepository } from '@/users/infrastructure/repositories/UserJSDataverseRepository'
@@ -15,6 +16,15 @@ interface AccountProps {
 
 export const Account = ({ defaultActiveTabKey, userRepository }: AccountProps) => {
   const { t } = useTranslation('account')
+  const [_, setSearchParams] = useSearchParams()
+
+  const updateSearchParamTabKeyOnSelect = (keySelected: string | null) => {
+    if (keySelected !== defaultActiveTabKey) {
+      setSearchParams({
+        [AccountHelper.ACCOUNT_PANEL_TAB_QUERY_KEY]: keySelected as string
+      })
+    }
+  }
 
   return (
     <section>
@@ -22,7 +32,7 @@ export const Account = ({ defaultActiveTabKey, userRepository }: AccountProps) =
         <h1>{t('pageTitle')}</h1>
       </header>
 
-      <Tabs defaultActiveKey={defaultActiveTabKey}>
+      <Tabs activeKey={defaultActiveTabKey} onSelect={updateSearchParamTabKeyOnSelect}>
         <Tabs.Tab eventKey={tabsKeys.myData} title={t('tabs.myData')} disabled>
           <div className={styles['tab-container']}></div>
         </Tabs.Tab>

--- a/tests/component/sections/account/Account.spec.tsx
+++ b/tests/component/sections/account/Account.spec.tsx
@@ -17,4 +17,15 @@ describe('Account', () => {
     cy.findByRole('tab', { name: 'Account Information' }).should('exist')
     cy.findByRole('tab', { name: 'API Token' }).should('be.enabled')
   })
+
+  it('clicks on the Account Information tab', () => {
+    cy.mountAuthenticated(
+      <Account
+        defaultActiveTabKey={AccountHelper.ACCOUNT_PANEL_TABS_KEYS.apiToken}
+        userRepository={new UserJSDataverseRepository()}
+      />
+    )
+
+    cy.findByRole('tab', { name: 'Account Information' }).click()
+  })
 })


### PR DESCRIPTION
## What this PR does / why we need it:
Keeps in sync the selected tab in the Account page with the tab query param in the URL.

Note also I just modified the docker file because we had these warnings from Docker, now they are gone:
- FromAsCasing: 'as' and 'FROM' keywords' casing do not match
- StageNameCasing: Stage name 'BUILD_IMAGE' should be lowercase

## Which issue(s) this PR closes:

- Closes #712 



