### PR TITLE
 FileCard thumbnail 403 Forbidden

### DIFF
--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -179,7 +179,7 @@ export class FileJSDataverseRepository implements FileRepository {
     return Promise.all(jsFiles.map((jsFile) => this.getThumbnailById(jsFile.id)))
   }
 
-  private static getThumbnailById(id: number): Promise<string | undefined> {
+  public static getThumbnailById(id: number): Promise<string | undefined> {
     return axiosInstance
       .get(`${this.DATAVERSE_BACKEND_URL}/api/access/datafile/${id}?imageThumb=400`, {
         responseType: 'blob'

--- a/src/sections/collection/collection-items-panel/items-list/file-card/FileCardThumbnail.tsx
+++ b/src/sections/collection/collection-items-panel/items-list/file-card/FileCardThumbnail.tsx
@@ -1,5 +1,8 @@
+import { useCallback, useEffect, useState } from 'react'
+import Skeleton from 'react-loading-skeleton'
 import { Icon, IconName, Tooltip } from '@iqss/dataverse-design-system'
 import { FileItemTypePreview } from '@/files/domain/models/FileItemTypePreview'
+import { FileJSDataverseRepository } from '@/files/infrastructure/FileJSDataverseRepository'
 import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus'
 import { DvObjectType } from '@/shared/hierarchy/domain/models/UpwardHierarchyNode'
 import { FileType } from '@/files/domain/models/FileMetadata'
@@ -27,16 +30,7 @@ export function FileCardThumbnail({ filePreview }: FileCardThumbnailProps) {
           filePreview.publicationStatuses.includes(PublicationStatus.Draft)
         )}>
         {filePreview.thumbnail ? (
-          <Tooltip
-            overlay={
-              <div className={styles.tooltip}>
-                <img src={filePreview.thumbnail} alt={filePreview.name} />
-              </div>
-            }
-            placement="top"
-            maxWidth={430}>
-            <img src={filePreview.thumbnail} alt={filePreview.name} />
-          </Tooltip>
+          <FileThumbnail fileId={filePreview.id} fileName={filePreview.name} iconName={iconName} />
         ) : (
           <div className={styles.icon}>
             <Icon name={iconName} />
@@ -44,5 +38,58 @@ export function FileCardThumbnail({ filePreview }: FileCardThumbnailProps) {
         )}
       </LinkToPage>
     </div>
+  )
+}
+
+interface FileThumbnailProps {
+  fileId: number
+  fileName: string
+  iconName: IconName
+}
+
+const FileThumbnail = ({ fileId, fileName, iconName }: FileThumbnailProps) => {
+  const [loadingThumbnailObjectURL, setLoadingThumbnailObjectURL] = useState(true)
+  const [thumbnailObjectURL, setThumbnailObjectURL] = useState<string>()
+
+  const getThumbnailObjectURL = useCallback(async () => {
+    const thumbnailObjectUrl = await FileJSDataverseRepository.getThumbnailById(fileId)
+
+    setThumbnailObjectURL(thumbnailObjectUrl)
+
+    setLoadingThumbnailObjectURL(false)
+  }, [fileId])
+
+  useEffect(() => {
+    void getThumbnailObjectURL()
+  }, [getThumbnailObjectURL])
+
+  if (loadingThumbnailObjectURL) {
+    return (
+      <div data-testid="file-thumbnail-skeleton">
+        <Skeleton width={64} height={48} />
+      </div>
+    )
+  }
+
+  // Fallback to icon if thumbnailObjectURL is still undefined after fetching it
+  if (!thumbnailObjectURL) {
+    return (
+      <div className={styles.icon} data-testid="icon-fallback">
+        <Icon name={iconName} />
+      </div>
+    )
+  }
+
+  return (
+    <Tooltip
+      overlay={
+        <div className={styles.tooltip}>
+          <img src={thumbnailObjectURL} alt={fileName} />
+        </div>
+      }
+      placement="top"
+      maxWidth={430}>
+      <img src={thumbnailObjectURL} alt={fileName} />
+    </Tooltip>
   )
 }

--- a/src/sections/file/file-preview/FileTypeToFileIconMap.ts
+++ b/src/sections/file/file-preview/FileTypeToFileIconMap.ts
@@ -190,6 +190,7 @@ export const FileTypeToFileIconMap: Record<string, IconName> = {
   'application/photoshop': IconName.IMAGE,
   'image/vnd.adobe.photoshop': IconName.IMAGE,
   'application/x-photoshop': IconName.IMAGE,
+  'image/webp': IconName.IMAGE,
   'audio/x-aiff': IconName.AUDIO,
   'audio/mp3': IconName.AUDIO,
   'audio/mpeg': IconName.AUDIO,

--- a/tests/component/sections/collection/collection-items-panel/file-card/FileCardThumbnail.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/file-card/FileCardThumbnail.spec.tsx
@@ -3,6 +3,12 @@ import { FileItemTypePreviewMother } from '@tests/component/files/domain/models/
 import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus'
 
 describe('FileCardThumbnail', () => {
+  beforeEach(() => {
+    cy.intercept('GET', '/api/access/datafile/*?imageThumb=400', {
+      fixture: 'images/harvard_uni.png'
+    }).as('getFileThumbnail')
+  })
+
   it('should render the correct link to the file preview page', () => {
     const filePreview = FileItemTypePreviewMother.create()
     cy.customMount(<FileCardThumbnail filePreview={filePreview} />)
@@ -23,9 +29,29 @@ describe('FileCardThumbnail', () => {
 
   it('should render the thumbnail if it has one', () => {
     const filePreview = FileItemTypePreviewMother.create()
+
     cy.customMount(<FileCardThumbnail filePreview={filePreview} />)
 
+    cy.findByTestId('file-thumbnail-skeleton').should('exist')
+
+    cy.wait('@getFileThumbnail')
+
+    cy.findByTestId('file-thumbnail-skeleton').should('not.exist')
+    cy.findByRole('img', { name: filePreview.name }).should('exist')
     cy.findByAltText(filePreview.name).should('exist')
+  })
+
+  it('should render the icon as fallback if fetching the thumbnail fails', () => {
+    const filePreview = FileItemTypePreviewMother.create()
+    cy.intercept('GET', `/api/access/datafile/${filePreview.id}?imageThumb=400`, {
+      statusCode: 500
+    }).as('getFileThumbnailError')
+
+    cy.customMount(<FileCardThumbnail filePreview={filePreview} />)
+
+    cy.wait('@getFileThumbnailError')
+    cy.findByRole('img', { name: filePreview.name }).should('not.exist')
+    cy.findByTestId('icon-fallback').should('exist')
   })
 
   it('should not render the thumbnail if it does not have one', () => {


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes a 403 forbidden error on collection page file cards thumbnails, more details in [original issue](https://github.com/IQSS/dataverse-frontend/issues/716).

## Which issue(s) this PR closes:

- Closes #716

## Special notes for your reviewer:
Instead of relying on the thumbnail URL directly in the `<img>` tag `src` attribute, this update utilizes the same API call that's employed in the dataset files table.
To achieve this, I've made the relevant static method public and am now calling it directly within the `FileCardThumbnail` component.
I know that this approach deviates from our standard practices. However, given that this method doesn't depend on `js-dataverse`, and passing the `FileRepository` down through props to the `FileCard` seemed like unnecessary prop drilling, this felt like a more straightforward solution.

## Suggestions on how to test this:
Step 1: Run the Development Environment

1. Execute npm i.
2. Navigate with cd packages/design-system && npm i && npm run build.
3. Return with cd ../../.
4. Ensure you have a .env file similar to .env.example
5. Navigate with cd dev-env.
6. Before running next step, be sure have a fresh unstable dataverse image.
7. Start the environment using ./run-env.sh unstable.
8. To verify the environment, visit http://localhost:8000/ and check your local Dataverse installation.

Step 2: Test the feature

1. Login within the SPA.
2. Create a dataset (don't publish it) and upload a `.jpg` file.
3. Navigate to the root collection page and filter by files, you should be able to see the correct file thumbnail in the file card.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
