### PR TITLE
Collection Page - Sort type as relevance when searching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.47",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr310.b7bec74",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3561,9 +3561,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.47",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.47/5f461fe665457557d60dcbcea0eaaf052a17e662",
-      "integrity": "sha512-MckQVEFFHYDqcuWZVo6iuOyFffp8us9nrUHup2U1NyuWsoKQvX43+p4PN16G2oCbjzn9xC+Bpzpto4OtJujUiQ==",
+      "version": "2.0.0-pr310.b7bec74",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr310.b7bec74/fd5fc58bc71f92c7f905be673d6901076d5b89b0",
+      "integrity": "sha512-g338oI6zZE2dRGIGhuA2SUmHQJ95zm7Hw0rYUWJsdze9QaebXHs0tWvDiVdDMoUU5kP82GhKFUpOEwCxZIAY6g==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.47",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr310.b7bec74",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/collection/domain/models/CollectionSearchCriteria.ts
+++ b/src/collection/domain/models/CollectionSearchCriteria.ts
@@ -2,7 +2,8 @@ import { type CollectionItemType } from './CollectionItemType'
 
 export enum SortType {
   NAME = 'name',
-  DATE = 'date'
+  DATE = 'date',
+  SCORE = 'score'
 }
 
 export enum OrderType {

--- a/src/sections/collection/CollectionHelper.ts
+++ b/src/sections/collection/CollectionHelper.ts
@@ -36,9 +36,13 @@ export class CollectionHelper {
           .filter((decodedFilter) => /^[^:]+:[^:]+$/.test(decodedFilter)) as FilterQuery[])
       : undefined
 
-    const sortQuery = (searchParams.get(CollectionItemsQueryParams.SORT) as SortType) ?? undefined
+    // If we don't have a sort query parameter, we default to RELEVANCE if there is a search query or DATE otherwise.
+    const sortQuery =
+      (searchParams.get(CollectionItemsQueryParams.SORT) as SortType) ??
+      (searchQuery && searchQuery.length > 0 ? SortType.SCORE : SortType.DATE)
+
     const orderQuery =
-      (searchParams.get(CollectionItemsQueryParams.ORDER) as OrderType) ?? undefined
+      (searchParams.get(CollectionItemsQueryParams.ORDER) as OrderType) ?? OrderType.DESC
 
     return { pageQuery, searchQuery, typesQuery, filtersQuery, sortQuery, orderQuery }
   }

--- a/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
+++ b/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
@@ -108,6 +108,8 @@ export const CollectionItemsPanel = ({
   }
 
   const handleSearchSubmit = async (searchValue: string) => {
+    const isSearchValueEmpty = searchValue === ''
+
     itemsListContainerRef.current?.scrollTo({ top: 0 })
 
     const resetPaginationInfo = new CollectionItemsPaginationInfo()
@@ -115,7 +117,7 @@ export const CollectionItemsPanel = ({
 
     // When searching, we reset the item types to COLLECTION, DATASET and FILE. Other filters are cleared
     setSearchParams((currentSearchParams) => {
-      if (searchValue === '') {
+      if (isSearchValueEmpty) {
         currentSearchParams.delete(CollectionItemsQueryParams.QUERY)
       } else {
         currentSearchParams.set(CollectionItemsQueryParams.QUERY, searchValue)
@@ -133,12 +135,12 @@ export const CollectionItemsPanel = ({
       return currentSearchParams
     })
 
-    // WHEN SEARCHING, WE RESET THE PAGINATION INFO AND KEEP ALL ITEM TYPES!!
+    // WHEN SEARCHING, WE RESET THE PAGINATION INFO AND KEEP ALL ITEM TYPES AND SORT TYPE AS RELEVANCE ORDER DESC
     const newCollectionSearchCriteria = new CollectionSearchCriteria(
       searchValue === '' ? undefined : searchValue,
       [CollectionItemType.COLLECTION, CollectionItemType.DATASET, CollectionItemType.FILE],
-      undefined,
-      undefined,
+      isSearchValueEmpty ? undefined : SortType.SCORE,
+      OrderType.DESC,
       undefined
     )
 

--- a/src/sections/collection/collection-items-panel/items-list/ItemsSortBy.tsx
+++ b/src/sections/collection/collection-items-panel/items-list/ItemsSortBy.tsx
@@ -1,10 +1,10 @@
 import { ArrowDownUp } from 'react-bootstrap-icons'
-import styles from './ItemsList.module.scss'
 import { DropdownButton, DropdownButtonItem } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
 import { useState, useEffect } from 'react'
 import { SortType } from '@/collection/domain/models/CollectionSearchCriteria'
 import { OrderType } from '@/collection/domain/models/CollectionSearchCriteria'
+import styles from './ItemsList.module.scss'
 
 export enum SortOption {
   NAME_ASC = 'nameAsc',
@@ -31,14 +31,14 @@ export function ItemsSortBy({
 }: ItemsSortByProps) {
   const { t } = useTranslation('collection')
   const [selectedOption, setSelectedOption] = useState<SortOption>(
-    convertToSortOption(currentSortType, currentSortOrder, hasSearchValue)
+    convertToSortOption(currentSortType, currentSortOrder)
   )
   useEffect(() => {
-    const newSortOption = convertToSortOption(currentSortType, currentSortOrder, hasSearchValue)
+    const newSortOption = convertToSortOption(currentSortType, currentSortOrder)
     if (newSortOption !== selectedOption) {
       setSelectedOption(newSortOption)
     }
-  }, [currentSortType, currentSortOrder, hasSearchValue, selectedOption])
+  }, [currentSortType, currentSortOrder, selectedOption])
 
   const handleSortChange = (eventKey: string | null) => {
     const newSortOption = eventKey as SortOption
@@ -75,22 +75,18 @@ export function ItemsSortBy({
     </DropdownButton>
   )
 }
-function convertToSortOption(
-  sortType?: SortType,
-  orderType?: OrderType,
-  hasSearchValue?: boolean
-): SortOption {
-  let sortOption: SortOption
+function convertToSortOption(sortType?: SortType, orderType?: OrderType): SortOption {
   if (sortType === SortType.NAME) {
-    sortOption = orderType === OrderType.ASC ? SortOption.NAME_ASC : SortOption.NAME_DESC
-  } else if (sortType === SortType.DATE) {
-    sortOption = orderType === OrderType.ASC ? SortOption.DATE_ASC : SortOption.DATE_DESC
-  } else if (hasSearchValue) {
-    sortOption = SortOption.RELEVANCE
-  } else {
-    sortOption = SortOption.DATE_DESC
+    return orderType === OrderType.ASC ? SortOption.NAME_ASC : SortOption.NAME_DESC
   }
-  return sortOption
+  if (sortType === SortType.DATE) {
+    return orderType === OrderType.ASC ? SortOption.DATE_ASC : SortOption.DATE_DESC
+  }
+  if (sortType === SortType.SCORE) {
+    return SortOption.RELEVANCE
+  }
+
+  return SortOption.NAME_DESC
 }
 function convertFromSortOption(sortOption: SortOption): {
   sortType?: SortType
@@ -106,6 +102,6 @@ function convertFromSortOption(sortOption: SortOption): {
     case SortOption.DATE_DESC:
       return { sortType: SortType.DATE, orderType: OrderType.DESC }
     case SortOption.RELEVANCE:
-      return { sortType: undefined, orderType: undefined }
+      return { sortType: SortType.SCORE, orderType: OrderType.DESC }
   }
 }

--- a/tests/component/sections/collection/collection-items-panel/ItemsSortBy.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/ItemsSortBy.spec.tsx
@@ -33,7 +33,7 @@ describe('ItemsSortBy', () => {
     cy.findByRole('button', { name: /Name \(Z-A\)/ }).click({ force: true })
     cy.wrap(onSortChange).should('be.calledWith', 'name', 'desc')
   })
-  it('should set sort type and order to undefined when Relevance is selected', () => {
+  it('should set sort type and order correctly when Relevance is selected', () => {
     const onSortChange = cy.stub().as('onSortChange')
 
     cy.customMount(
@@ -48,7 +48,7 @@ describe('ItemsSortBy', () => {
     cy.findByRole('button', { name: /Relevance/ }).should('exist')
 
     cy.findByText(/Relevance/).click()
-    cy.wrap(onSortChange).should('be.calledWith', undefined, undefined)
+    cy.wrap(onSortChange).should('be.calledWith', SortType.SCORE, OrderType.DESC)
   })
   it('should set sort type and order correctly  when Newest is selected', () => {
     const onSortChange = cy.stub().as('onSortChange')


### PR DESCRIPTION
## What this PR does / why we need it:
We need to sort by relevance (score) when searching in the collection page.
The Sort By dropdown was showing the "Relevance" option as selected but we were not actually sending that parameter to the Search API.

## Which issue(s) this PR closes:

- Closes #723 

## Special notes for your reviewer:
⚠️ This depends on this [JS-Dataverse PR](https://github.com/IQSS/dataverse-client-javascript/pull/310) 

## Suggestions on how to test this:
Validate that this fixes the behaviour found in #723 

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
