### PR TITLE
Fix CollectionItemsPanel flaky test

### DIFF
--- a/tests/e2e-integration/e2e/sections/collection/CollectionItemsPanel.spec.ts
+++ b/tests/e2e-integration/e2e/sections/collection/CollectionItemsPanel.spec.ts
@@ -2,6 +2,7 @@ import { CollectionItem } from '@/collection/domain/models/CollectionItemSubset'
 import { CollectionItemType } from '@/collection/domain/models/CollectionItemType'
 import { CollectionItemsQueryParams } from '@/collection/domain/models/CollectionItemsQueryParams'
 import { DatasetHelper } from '@tests/e2e-integration/shared/datasets/DatasetHelper'
+import { CollectionHelper } from '@tests/e2e-integration/shared/collection/CollectionHelper'
 import { FileHelper } from '@tests/e2e-integration/shared/files/FileHelper'
 import { TestsUtils } from '@tests/e2e-integration/shared/TestsUtils'
 import { Interception } from 'cypress/types/net-stubbing'
@@ -49,11 +50,14 @@ describe('Collection Items Panel', () => {
 
         cy.intercept(SEARCH_ENDPOINT_REGEX).as('getCollectionItems')
 
+        const collectionName = 'ItemsTestCollection'
+        const collection = await CollectionHelper.create(`${collectionName}-${Date.now()}`)
         // Creates 8 datasets with 1 file each
         for (const _number of numbersOfDatasetsToCreate) {
           await DatasetHelper.createWithFileAndTitle(
             FileHelper.create(),
-            datasetTitles[_number - 1]
+            datasetTitles[_number - 1],
+            collection.id
           )
         }
       })


### PR DESCRIPTION
CollectionItemsPanel.spec.ts was failing intermittently on Github actions.  I was able to reproduce it consistently by using this command, which runs the test 5 times in a row:

`npx cypress run --env burn=5 --spec tests/e2e-integration/e2e/sections/collection/CollectionItemsPanel.spec.ts
`

After making the fix, this test passes.

## What this PR does / why we need it:

## Which issue(s) this PR closes:

- Closes #724 


## Suggestions on how to test this:
Try running the batch test locally, and check that the github test also succeeds.

