### PR TITLE
My Data - search for username when component renders

### DIFF
--- a/src/collection/domain/repositories/CollectionRepository.ts
+++ b/src/collection/domain/repositories/CollectionRepository.ts
@@ -8,6 +8,8 @@ import { CollectionSearchCriteria } from '../models/CollectionSearchCriteria'
 import { CollectionUserPermissions } from '../models/CollectionUserPermissions'
 import { CollectionDTO } from '../useCases/DTOs/CollectionDTO'
 import { CollectionFeaturedItemsDTO } from '../useCases/DTOs/CollectionFeaturedItemsDTO'
+import { CollectionItemType } from '@/collection/domain/models/CollectionItemType'
+import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus'
 
 export interface CollectionRepository {
   getById: (id?: string) => Promise<Collection>
@@ -21,15 +23,15 @@ export interface CollectionRepository {
     paginationInfo: CollectionItemsPaginationInfo,
     searchCriteria?: CollectionSearchCriteria
   ): Promise<CollectionItemSubset>
-  getMyDataItems(
+  getMyDataItems: (
     roleIds: number[],
-    collectionItemTypes: string[],
-    publicationStatuses: string[],
+    collectionItemTypes: CollectionItemType[],
+    publicationStatuses: PublicationStatus[],
     limit?: number,
     selectedPage?: number,
     searchText?: string,
     otherUserName?: string
-  ): Promise<MyDataCollectionItemSubset>
+  ) => Promise<MyDataCollectionItemSubset>
   edit(collectionIdOrAlias: string, updatedCollection: CollectionDTO): Promise<void>
   getFeaturedItems(collectionIdOrAlias?: number | string): Promise<CollectionFeaturedItem[]>
   updateFeaturedItems(

--- a/src/collection/domain/useCases/getMyDataCollectionItems.ts
+++ b/src/collection/domain/useCases/getMyDataCollectionItems.ts
@@ -1,12 +1,13 @@
 import { CollectionRepository } from '../repositories/CollectionRepository'
 import { MyDataCollectionItemSubset } from '../models/MyDataCollectionItemSubset'
 import { PublicationStatus } from '../../../shared/core/domain/models/PublicationStatus'
+import { CollectionItemType } from '@/collection/domain/models/CollectionItemType'
 
 export async function getMyDataCollectionItems(
   collectionRepository: CollectionRepository,
   roleIds: number[],
-  collectionItemTypes: string[],
-  publicationStatuses: string[],
+  collectionItemTypes: CollectionItemType[],
+  publicationStatuses: PublicationStatus[],
   limit?: number,
   selectedPage?: number,
   searchText?: string,

--- a/src/sections/account/my-data-section/MyDataItemsPanel.tsx
+++ b/src/sections/account/my-data-section/MyDataItemsPanel.tsx
@@ -143,7 +143,8 @@ export const MyDataItemsPanel = ({ collectionRepository }: MyDataItemsPanelProps
       [CollectionItemType.COLLECTION, CollectionItemType.DATASET, CollectionItemType.FILE],
       roleIds,
       AllPublicationStatuses,
-      searchValue === '' ? undefined : searchValue
+      searchValue === '' ? undefined : searchValue,
+      currentSearchCriteria.otherUserName
     )
 
     const totalItemsCount = await loadMore(resetPaginationInfo, newCollectionSearchCriteria, true)
@@ -194,7 +195,8 @@ export const MyDataItemsPanel = ({ collectionRepository }: MyDataItemsPanelProps
       newItemsTypes,
       currentSearchCriteria.roleIds,
       currentSearchCriteria.publicationStatuses,
-      currentSearchCriteria.searchText
+      currentSearchCriteria.searchText,
+      currentSearchCriteria.otherUserName
     )
 
     const totalItemsCount = await loadMore(resetPaginationInfo, newMyDataSearchCriteria, true)
@@ -223,7 +225,8 @@ export const MyDataItemsPanel = ({ collectionRepository }: MyDataItemsPanelProps
       currentSearchCriteria.itemTypes,
       newRoleIds,
       currentSearchCriteria.publicationStatuses,
-      currentSearchCriteria.searchText
+      currentSearchCriteria.searchText,
+      currentSearchCriteria.otherUserName
     )
 
     const totalItemsCount = await loadMore(resetPaginationInfo, newMyDataSearchCriteria, true)

--- a/src/sections/account/my-data-section/MyDataItemsPanel.tsx
+++ b/src/sections/account/my-data-section/MyDataItemsPanel.tsx
@@ -57,7 +57,8 @@ export const MyDataItemsPanel = ({ collectionRepository }: MyDataItemsPanelProps
       [CollectionItemType.COLLECTION, CollectionItemType.DATASET],
       roleIds,
       AllPublicationStatuses,
-      undefined
+      undefined,
+      user?.superuser ? user.identifier : undefined
     )
   )
 

--- a/src/sections/account/my-data-section/useGetMyDataAccumulatedItems.tsx
+++ b/src/sections/account/my-data-section/useGetMyDataAccumulatedItems.tsx
@@ -119,7 +119,7 @@ async function loadNextItems(
   paginationInfo: CollectionItemsPaginationInfo,
   searchCriteria: MyDataSearchCriteria
 ): Promise<MyDataCollectionItemSubset> {
-  const publicationStatuses = (searchCriteria.publicationStatuses as string[]) ?? []
+  const publicationStatuses = searchCriteria.publicationStatuses ?? []
   return await getMyDataCollectionItems(
     collectionRepository,
     searchCriteria.roleIds,

--- a/tests/component/sections/account/MyDataItemsPanel.spec.tsx
+++ b/tests/component/sections/account/MyDataItemsPanel.spec.tsx
@@ -89,6 +89,48 @@ describe('MyDataItemsPanel', () => {
         .invoke('val')
         .should('equal', 'jamespotts')
     })
+
+    it('calls the repository with the default username when rendering', () => {
+      cy.mountSuperuser(<MyDataItemsPanel collectionRepository={collectionRepository} />)
+      const otherUsername = 'jamespotts'
+      cy.findByPlaceholderText('Search by username...')
+        .should('exist')
+        .invoke('val')
+        .should('equal', otherUsername)
+
+      cy.wrap(collectionRepository.getMyDataItems).should(
+        'be.calledWithMatch',
+        Cypress.sinon.match.any,
+        Cypress.sinon.match.any,
+        Cypress.sinon.match.any,
+        10,
+        1,
+        undefined,
+        otherUsername
+      )
+    })
+    it('calls the repository with the correct username when searching', () => {
+      collectionRepository.getMyDataItems = cy.stub().callsFake((...args) => {
+        return Cypress.Promise.resolve(itemsWithCount)
+      })
+      cy.mountSuperuser(<MyDataItemsPanel collectionRepository={collectionRepository} />)
+
+      cy.findByPlaceholderText('Search by username...')
+        .should('exist')
+        .clear()
+        .type('testUserName{enter}')
+
+      cy.wrap(collectionRepository.getMyDataItems).should(
+        'be.calledWithMatch',
+        Cypress.sinon.match.any,
+        Cypress.sinon.match.any,
+        Cypress.sinon.match.any,
+        10,
+        1,
+        undefined,
+        'testUserName'
+      )
+    })
     it('shows the correct message when there are no results for user', () => {
       collectionRepository.getMyDataItems = cy.stub().resolves(emptyItemsWithCount)
 

--- a/tests/component/sections/account/MyDataItemsPanel.spec.tsx
+++ b/tests/component/sections/account/MyDataItemsPanel.spec.tsx
@@ -110,9 +110,8 @@ describe('MyDataItemsPanel', () => {
       )
     })
     it('calls the repository with the correct username when searching', () => {
-      collectionRepository.getMyDataItems = cy.stub().callsFake((...args) => {
-        return Cypress.Promise.resolve(itemsWithCount)
-      })
+      collectionRepository.getMyDataItems = cy.stub().resolves(itemsWithCount)
+
       cy.mountSuperuser(<MyDataItemsPanel collectionRepository={collectionRepository} />)
 
       cy.findByPlaceholderText('Search by username...')


### PR DESCRIPTION
## What this PR does / why we need it:

## Which issue(s) this PR closes:

- Closes #738 

## Special notes for your reviewer: 
I also updated the parameter types for GetMyDataCollectionItems, to match js-dataverse
Note that there is an issue with the MyData API call (https://github.com/IQSS/dataverse/issues/11519), where it uses the jsf user session.  So it's best to test this without also having a JSF tab open in the browser. 

For the Chromatic tests: The deposit date is different because it is set in the component, not by mock data.  I'm not sure what is happening with the FileInfoCell story, because it uses the same static static seed, maybe because the stories were executed in a different order, I'm not sure.

## Suggestions on how to test this: 

1. Login as a superuser, for example dataverseAdmin. 
2. Go To Accounts -> My Data
3. Check that the API call made when My Data is displayed includes the username, 'dataverseAdmin'


