### PR TITLE
Double Asterisk in Required Field Labels on Mobile

### DIFF
--- a/packages/design-system/src/lib/components/form/form-group-multiple-fields/FormGroupWithMultipleFields.tsx
+++ b/packages/design-system/src/lib/components/form/form-group-multiple-fields/FormGroupWithMultipleFields.tsx
@@ -9,10 +9,16 @@ interface FormGroupWithMultipleFieldsProps {
   title: string
   required?: boolean
   message?: string
+  titleClassName?: string
 }
 
-const Title = ({ title, required, message }: Partial<FormGroupWithMultipleFieldsProps>) => (
-  <span className={styles.title}>
+const Title = ({
+  title,
+  required,
+  message,
+  titleClassName
+}: Partial<FormGroupWithMultipleFieldsProps>) => (
+  <span className={`${styles.title} ${titleClassName ?? ''}`}>
     {title} {required && <RequiredInputSymbol />}{' '}
     {message && <QuestionMarkTooltip placement="right" message={message}></QuestionMarkTooltip>}
   </span>
@@ -22,12 +28,18 @@ export function FormGroupWithMultipleFields({
   title,
   required,
   message,
+  titleClassName,
   children
 }: PropsWithChildren<FormGroupWithMultipleFieldsProps>) {
   return (
     <Row className="mb-3">
       <Col sm={3}>
-        <Title title={title} required={required} message={message} />
+        <Title
+          title={title}
+          required={required}
+          message={message}
+          titleClassName={titleClassName}
+        />
       </Col>
       <Col sm={9} className="mb-3">
         {children}

--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/Fields/ComposeFieldMultiple.tsx
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/Fields/ComposeFieldMultiple.tsx
@@ -77,7 +77,8 @@ export const ComposedFieldMultiple = ({
     <Form.GroupWithMultipleFields
       title={title}
       message={description}
-      required={Boolean(rulesToApply?.required)}>
+      required={Boolean(rulesToApply?.required)}
+      titleClassName={styles['composed-field-title']}>
       {notRequiredWithChildFieldsRequired && (
         <Col sm={9} className={styles['may-become-required-help-text']}>
           <Form.Group.Text>{t('mayBecomeRequired')}</Form.Group.Text>

--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/Fields/ComposedField.tsx
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/Fields/ComposedField.tsx
@@ -48,7 +48,8 @@ export const ComposedField = ({
     <Form.GroupWithMultipleFields
       title={title}
       message={description}
-      required={Boolean(rulesToApply?.required)}>
+      required={Boolean(rulesToApply?.required)}
+      titleClassName={styles['composed-field-title']}>
       {notRequiredWithChildFieldsRequired && (
         <Col sm={9} className={styles['may-become-required-help-text']}>
           <Form.Group.Text>{t('mayBecomeRequired')}</Form.Group.Text>

--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/index.module.scss
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/index.module.scss
@@ -9,10 +9,10 @@
   @media screen and (min-width: 768px) {
     grid-template-columns: 1fr 1fr;
     column-gap: 1rem;
-  }
 
-  & > div:has(textarea) {
-    grid-column: span 2;
+    & > div:has(textarea) {
+      grid-column: span 2;
+    }
   }
 }
 

--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/index.module.scss
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/index.module.scss
@@ -38,6 +38,12 @@
   height: fit-content;
 }
 
+.composed-field-title {
+  @media (max-width: 575px) {
+    font-size: 18px;
+  }
+}
+
 .may-become-required-help-text {
   margin-bottom: 0.5rem;
 }


### PR DESCRIPTION
## What this PR does / why we need it:
Fixes mobile style issues.

- Increased the font size of composed fields titles to differentiate parent and child labels as recommended [here](https://github.com/IQSS/dataverse-frontend/issues/720#issuecomment-2913630620).
- Fix for the Identifier and Identifier type fields on mobile.

## Which issue(s) this PR closes:

- Closes #720 

## Special notes for your reviewer:

## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

<img width="376" alt="composed-fields-label" src="https://github.com/user-attachments/assets/2c96c446-4eef-4cf8-949c-7af43bba67bc" />


## Is there a release notes update needed for this change?:

## Additional documentation:
