### PR TITLE
Dataset Page: hide deaccessioned button if the current version is Deaccessioned

### DIFF
--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -35,6 +35,7 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
   const { t } = useTranslation('dataset')
   const navigate = useNavigate()
   const { showModal } = useNotImplementedModal()
+  const isDeaccessioned = dataset.version.publishingStatus === DatasetPublishingStatus.DEACCESSIONED
 
   const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
     const searchParams = new URLSearchParams()
@@ -108,7 +109,9 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
         {t('datasetActionButtons.editDataset.thumbnailsPlusWidgets')}
       </DropdownButtonItem>
       <DeleteDraftDatasetButton dataset={dataset} datasetRepository={datasetRepository} />
-      <DeaccessionDatasetButton datasetRepository={datasetRepository} dataset={dataset} />
+      {!isDeaccessioned && (
+        <DeaccessionDatasetButton datasetRepository={datasetRepository} dataset={dataset} />
+      )}
     </DropdownButton>
   )
 }

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -36,6 +36,7 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
   const navigate = useNavigate()
   const { showModal } = useNotImplementedModal()
   const isDeaccessioned = dataset.version.publishingStatus === DatasetPublishingStatus.DEACCESSIONED
+  const isDraft = dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT
 
   const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
     const searchParams = new URLSearchParams()
@@ -109,7 +110,7 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
         {t('datasetActionButtons.editDataset.thumbnailsPlusWidgets')}
       </DropdownButtonItem>
       <DeleteDraftDatasetButton dataset={dataset} datasetRepository={datasetRepository} />
-      {!isDeaccessioned && (
+      {!isDeaccessioned && !isDraft && (
         <DeaccessionDatasetButton datasetRepository={datasetRepository} dataset={dataset} />
       )}
     </DropdownButton>

--- a/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
@@ -36,7 +36,6 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
   const navigate = useNavigate()
   const { showModal } = useNotImplementedModal()
   const isDeaccessioned = dataset.version.publishingStatus === DatasetPublishingStatus.DEACCESSIONED
-  const isDraft = dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT
 
   const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
     const searchParams = new URLSearchParams()
@@ -110,7 +109,7 @@ export function EditDatasetMenu({ dataset, datasetRepository }: EditDatasetMenuP
         {t('datasetActionButtons.editDataset.thumbnailsPlusWidgets')}
       </DropdownButtonItem>
       <DeleteDraftDatasetButton dataset={dataset} datasetRepository={datasetRepository} />
-      {!isDeaccessioned && !isDraft && (
+      {!isDeaccessioned && (
         <DeaccessionDatasetButton datasetRepository={datasetRepository} dataset={dataset} />
       )}
     </DropdownButton>

--- a/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
@@ -191,6 +191,22 @@ describe('EditDatasetMenu', () => {
     cy.findByRole('button', { name: 'Deaccession Dataset' }).should('not.exist')
   })
 
+  it('hides Deaccession button if current version is draft', () => {
+    const dataset = DatasetMother.create({
+      version: DatasetVersionMother.createDraft(),
+      permissions: DatasetPermissionsMother.createWithAllAllowed(),
+      locks: [],
+      hasValidTermsOfAccess: true
+    })
+
+    cy.mountAuthenticated(
+      <EditDatasetMenu datasetRepository={new DatasetMockRepository()} dataset={dataset} />
+    )
+
+    cy.findByRole('button', { name: 'Edit Dataset' }).click()
+    cy.findByRole('button', { name: 'Deaccession Dataset' }).should('not.exist')
+  })
+
   it('clicks on the Delete button', () => {
     const dataset = DatasetMother.create({
       version: DatasetVersionMother.createNotReleased(),

--- a/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
@@ -175,6 +175,22 @@ describe('EditDatasetMenu', () => {
     cy.findByText('Deaccession is permanent.').should('exist')
   })
 
+  it('hides Deaccession button if current version is deaccessioned', () => {
+    const dataset = DatasetMother.create({
+      version: DatasetVersionMother.createDeaccessioned(),
+      permissions: DatasetPermissionsMother.createWithAllAllowed(),
+      locks: [],
+      hasValidTermsOfAccess: true
+    })
+
+    cy.mountAuthenticated(
+      <EditDatasetMenu datasetRepository={new DatasetMockRepository()} dataset={dataset} />
+    )
+
+    cy.findByRole('button', { name: 'Edit Dataset' }).click()
+    cy.findByRole('button', { name: 'Deaccession Dataset' }).should('not.exist')
+  })
+
   it('clicks on the Delete button', () => {
     const dataset = DatasetMother.create({
       version: DatasetVersionMother.createNotReleased(),

--- a/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.spec.tsx
@@ -191,22 +191,6 @@ describe('EditDatasetMenu', () => {
     cy.findByRole('button', { name: 'Deaccession Dataset' }).should('not.exist')
   })
 
-  it('hides Deaccession button if current version is draft', () => {
-    const dataset = DatasetMother.create({
-      version: DatasetVersionMother.createDraft(),
-      permissions: DatasetPermissionsMother.createWithAllAllowed(),
-      locks: [],
-      hasValidTermsOfAccess: true
-    })
-
-    cy.mountAuthenticated(
-      <EditDatasetMenu datasetRepository={new DatasetMockRepository()} dataset={dataset} />
-    )
-
-    cy.findByRole('button', { name: 'Edit Dataset' }).click()
-    cy.findByRole('button', { name: 'Deaccession Dataset' }).should('not.exist')
-  })
-
   it('clicks on the Delete button', () => {
     const dataset = DatasetMother.create({
       version: DatasetVersionMother.createNotReleased(),


### PR DESCRIPTION
## What this PR does / why we need it:
If current version is deaccessioned or a draft, hide the Deaccessioned button.

## Which issue(s) this PR closes:

- Closes #752 

## Special notes for your reviewer:

## Suggestions on how to test this:
Deaccessioned a dataset, and check if the Deaccessioned button is hidden when the current version is deaccessioned

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
