### PR TITLE
Prevent Numeric-Only Aliases in Create Collection Form

### DIFF
--- a/public/locales/en/shared.json
+++ b/public/locales/en/shared.json
@@ -102,6 +102,7 @@
         "required": "Identifier is required",
         "invalid": {
           "format": "Identifier is not valid. Valid characters are a-Z, 0-9, '_', and '-'.",
+          "numberOnly": "Identifier should not be numeric only.",
           "maxLength": "Identifier must be at most {{maxLength}} characters."
         },
         "suggestion": "Psst... try this"

--- a/src/sections/shared/form/EditCreateCollectionForm/collection-form/top-fields-section/TopFieldsSection.tsx
+++ b/src/sections/shared/form/EditCreateCollectionForm/collection-form/top-fields-section/TopFieldsSection.tsx
@@ -41,6 +41,10 @@ export const TopFieldsSection = ({ isEditingRootCollection }: TopFieldsSectionPr
       message: t('fields.alias.invalid.maxLength', { maxLength: 60 })
     },
     validate: (value: string) => {
+      if (Validator.isNumberOnly(value)) {
+        return t('fields.alias.invalid.numberOnly')
+      }
+
       if (!Validator.isValidIdentifier(value)) {
         return t('fields.alias.invalid.format')
       }

--- a/src/shared/helpers/Validator.ts
+++ b/src/shared/helpers/Validator.ts
@@ -7,7 +7,18 @@ export class Validator {
 
   static isValidIdentifier(input: string): boolean {
     const IDENTIFIER_REGEX = /^[a-zA-Z0-9_-]+$/
-    return IDENTIFIER_REGEX.test(input)
+    // Valid characters are a-Z, 0-9, '_', and '-'
+    if (!IDENTIFIER_REGEX.test(input)) return false
+
+    // Reject numeric-only identifiers (e.g., "3838")
+    if (this.isNumberOnly(input)) return false
+
+    return true
+  }
+
+  static isNumberOnly(input: string): boolean {
+    const REGEX = /^\d+$/
+    return REGEX.test(input)
   }
 
   static isValidUsername(input: string): boolean {

--- a/tests/component/sections/shared/edit-create-collection-form/EditCreateCollectionForm.spec.tsx
+++ b/tests/component/sections/shared/edit-create-collection-form/EditCreateCollectionForm.spec.tsx
@@ -214,7 +214,7 @@ describe('EditCreateCollectionForm', () => {
       cy.findByText('Email is not a valid email').should('exist')
     })
 
-    it('shows error message when form is submitted with invalid identifier', () => {
+    it('shows error message when form is submitted with invalid identifier with spaces', () => {
       cy.customMount(
         <EditCreateCollectionForm
           mode="create"
@@ -230,6 +230,24 @@ describe('EditCreateCollectionForm', () => {
       cy.findByRole('button', { name: 'Create Collection' }).click()
 
       cy.findByText(/Identifier is not valid./).should('exist')
+    })
+
+    it('shows error message when form is submitted with invalid numeric-only identifier', () => {
+      cy.customMount(
+        <EditCreateCollectionForm
+          mode="create"
+          user={testUser}
+          parentCollection={rootCollection}
+          collectionRepository={collectionRepository}
+          metadataBlockInfoRepository={metadataBlockInfoRepository}
+        />
+      )
+
+      cy.findByLabelText(/^Identifier/i).type('3535')
+
+      cy.findByRole('button', { name: 'Create Collection' }).click()
+
+      cy.findByText(/Identifier should not be numeric only./).should('exist')
     })
 
     it('submits a valid form and succeed', () => {


### PR DESCRIPTION
## What this PR does / why we need it:
Adds a client side form validation to avoid numeric only aliases, otherwise the API fails and shows an ugly error on the UI.

<img width="506" height="172" alt="Screenshot 2025-08-15 at 11 22 57" src="https://github.com/user-attachments/assets/4ad48a0a-ec32-4f53-8f98-48985c65a66d" />

## Which issue(s) this PR closes:

- Closes #798 

