### PR TITLE
Fix: Files Table should always show action buttons

### DIFF
--- a/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
+++ b/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
@@ -8,7 +8,7 @@
     min-height: auto;
   }
 
-  .criteria-form-container { 
+  .criteria-form-container {
     position: sticky;
     top: 0;
     z-index: 2;

--- a/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
+++ b/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
@@ -8,7 +8,7 @@
     min-height: auto;
   }
 
-  .criteria-form-container {
+  .criteria-form-container { 
     position: sticky;
     top: 0;
     z-index: 2;
@@ -18,5 +18,10 @@
 
   table {
     margin-bottom: 0;
+  }
+
+  .files-scrollable-container__content {
+    overflow-x: auto;
+    overflow-y: auto;
   }
 }

--- a/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
+++ b/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
@@ -1,7 +1,7 @@
 .files-scrollable-container {
   min-height: 400px;
   max-height: 650px;
-  overflow-x: hidden;
+  overflow-x: auto;
   overflow-y: auto;
 
   &--empty {
@@ -11,6 +11,8 @@
   .criteria-form-container {
     position: sticky;
     top: 0;
+    right: 0;
+    left: 0;
     z-index: 2;
     padding: 0.25rem 0.5rem 1rem 0.25rem;
     background: var(--bs-white);
@@ -18,10 +20,5 @@
 
   table {
     margin-bottom: 0;
-  }
-
-  .files-scrollable-container__content {
-    overflow-x: auto;
-    overflow-y: auto;
   }
 }

--- a/src/sections/dataset/dataset-files/DatasetFilesScrollable.tsx
+++ b/src/sections/dataset/dataset-files/DatasetFilesScrollable.tsx
@@ -173,23 +173,24 @@ export function DatasetFilesScrollable({
             onInfiniteScrollMode
           />
         </header>
-
-        <FilesContext.Provider
-          value={{ files: accumulatedFiles, isLoading, refreshFiles: refreshFiles }}>
-          <FilesTableScrollable
-            files={accumulatedFiles}
-            paginationInfo={paginationInfo}
-            filesTotalDownloadSize={filesTotalDownloadSize}
-            criteria={criteria}
-            criteriaContainerHeight={criteriaContainerSize.height}
-            sentryRef={sentryRef}
-            showSentryRef={showSentryRef}
-            isEmptyFiles={isEmptyFiles}
-            accumulatedCount={accumulatedCount}
-            fileRepository={filesRepository}
-            datasetRepository={datasetRepository}
-          />
-        </FilesContext.Provider>
+        <div className={styles['files-scrollable-container__content']}>
+          <FilesContext.Provider
+            value={{ files: accumulatedFiles, isLoading, refreshFiles: refreshFiles }}>
+            <FilesTableScrollable
+              files={accumulatedFiles}
+              paginationInfo={paginationInfo}
+              filesTotalDownloadSize={filesTotalDownloadSize}
+              criteria={criteria}
+              criteriaContainerHeight={criteriaContainerSize.height}
+              sentryRef={sentryRef}
+              showSentryRef={showSentryRef}
+              isEmptyFiles={isEmptyFiles}
+              accumulatedCount={accumulatedCount}
+              fileRepository={filesRepository}
+              datasetRepository={datasetRepository}
+            />
+          </FilesContext.Provider>
+        </div>
       </div>
     </section>
   )

--- a/src/sections/dataset/dataset-files/DatasetFilesScrollable.tsx
+++ b/src/sections/dataset/dataset-files/DatasetFilesScrollable.tsx
@@ -13,8 +13,8 @@ import { useObserveElementSize } from '../../../shared/hooks/useObserveElementSi
 import { FilesTableScrollable } from './files-table/FilesTableScrollable'
 import { FileCriteriaForm } from './file-criteria-form/FileCriteriaForm'
 import { FilesContext } from '@/sections/file/FilesContext'
-import styles from './DatasetFilesScrollable.module.scss'
 import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
+import styles from './DatasetFilesScrollable.module.scss'
 
 interface DatasetFilesScrollableProps {
   filesRepository: FileRepository
@@ -173,24 +173,23 @@ export function DatasetFilesScrollable({
             onInfiniteScrollMode
           />
         </header>
-        <div className={styles['files-scrollable-container__content']}>
-          <FilesContext.Provider
-            value={{ files: accumulatedFiles, isLoading, refreshFiles: refreshFiles }}>
-            <FilesTableScrollable
-              files={accumulatedFiles}
-              paginationInfo={paginationInfo}
-              filesTotalDownloadSize={filesTotalDownloadSize}
-              criteria={criteria}
-              criteriaContainerHeight={criteriaContainerSize.height}
-              sentryRef={sentryRef}
-              showSentryRef={showSentryRef}
-              isEmptyFiles={isEmptyFiles}
-              accumulatedCount={accumulatedCount}
-              fileRepository={filesRepository}
-              datasetRepository={datasetRepository}
-            />
-          </FilesContext.Provider>
-        </div>
+
+        <FilesContext.Provider
+          value={{ files: accumulatedFiles, isLoading, refreshFiles: refreshFiles }}>
+          <FilesTableScrollable
+            files={accumulatedFiles}
+            paginationInfo={paginationInfo}
+            filesTotalDownloadSize={filesTotalDownloadSize}
+            criteria={criteria}
+            criteriaContainerHeight={criteriaContainerSize.height}
+            sentryRef={sentryRef}
+            showSentryRef={showSentryRef}
+            isEmptyFiles={isEmptyFiles}
+            accumulatedCount={accumulatedCount}
+            fileRepository={filesRepository}
+            datasetRepository={datasetRepository}
+          />
+        </FilesContext.Provider>
       </div>
     </section>
   )

--- a/src/sections/dataset/dataset-files/files-table/FilesTableScrollable.tsx
+++ b/src/sections/dataset/dataset-files/files-table/FilesTableScrollable.tsx
@@ -55,8 +55,6 @@ export const FilesTableScrollable = ({
   const tableTopMessagesRef = useRef<HTMLDivElement | null>(null)
   const tableTopMessagesSize = useObserveElementSize(tableTopMessagesRef)
 
-  const tableHeaderStickyTopValue = criteriaContainerHeight + tableTopMessagesSize.height
-
   useEffect(() => {
     if (previousCriteria != criteria) {
       clearRowsSelection()
@@ -85,7 +83,7 @@ export const FilesTableScrollable = ({
       <Table>
         <FilesTableHeader
           headers={table.getHeaderGroups()}
-          topStickyValue={tableHeaderStickyTopValue}
+          topStickyValue={tableTopMessagesSize.height}
         />
 
         <FilesTableBody

--- a/src/sections/dataset/dataset-files/files-table/FilesTableScrollable.tsx
+++ b/src/sections/dataset/dataset-files/files-table/FilesTableScrollable.tsx
@@ -55,6 +55,8 @@ export const FilesTableScrollable = ({
   const tableTopMessagesRef = useRef<HTMLDivElement | null>(null)
   const tableTopMessagesSize = useObserveElementSize(tableTopMessagesRef)
 
+  const tableHeaderStickyTopValue = criteriaContainerHeight + tableTopMessagesSize.height
+
   useEffect(() => {
     if (previousCriteria != criteria) {
       clearRowsSelection()
@@ -83,7 +85,7 @@ export const FilesTableScrollable = ({
       <Table>
         <FilesTableHeader
           headers={table.getHeaderGroups()}
-          topStickyValue={tableTopMessagesSize.height}
+          topStickyValue={tableHeaderStickyTopValue}
         />
 
         <FilesTableBody


### PR DESCRIPTION
## What this PR does / why we need it:
The files table in dataset prevents to be scrolled horizontally, so when the file name is long, the action button is hidden. 

Mock the behavior of JSF, allow to scroll horizontally

## Which issue(s) this PR closes:

- Closes #800 

## Special notes for your reviewer:

## Suggestions on how to test this:
When you have a file name longer than expected, the scroll bar should appear. 

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
<img width="346" height="539" alt="image" src="https://github.com/user-attachments/assets/617e292d-6046-4770-901f-4007131d64d0" />
## Is there a release notes update needed for this change?:

## Additional documentation:
