### PR TITLE
Show "New Review" button, when enabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.62",
+        "@iqss/dataverse-client-javascript": "2.0.0-pr360.cc77995",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3561,9 +3561,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.62",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.62/61ac45ca90983c86af8adb443bc013ea929db0ad",
-      "integrity": "sha512-BtblnMfg6a0m6E8bbcwkZ7aEOBHeLzRbkaJVcKFybxWz33h76Xjr1TIOKcd9cwGNoaAFxReigGGp8EWmWwqehA==",
+      "version": "2.0.0-pr360.cc77995",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-pr360.cc77995/cccbeda63b46082266f04f8d0c7f9b3ce24099a2",
+      "integrity": "sha512-MpzTc5dcMbkhJE+U3ulSIR/3oit0wNV4ZudEtNG3PZrkhYq46ut1uOw1wuRFt6BHLv0vIJ0KevKc58EEflYlkQ==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.62",
+    "@iqss/dataverse-client-javascript": "2.0.0-pr360.cc77995",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/public/locales/en/header.json
+++ b/public/locales/en/header.json
@@ -8,6 +8,7 @@
     "addData": "Add Data",
     "newCollection": "New Collection",
     "newDataset": "New Dataset",
+    "newReview": "New Review",
     "accountInfo": "Account Information",
     "apiToken": "API Token",
     "myData": "My Data"

--- a/src/dataset/domain/repositories/DatasetRepository.ts
+++ b/src/dataset/domain/repositories/DatasetRepository.ts
@@ -25,7 +25,11 @@ export interface DatasetRepository {
     includeDeaccessioned: boolean
   ) => Promise<DatasetVersionDiff>
 
-  create: (dataset: DatasetDTO, collectionId: string) => Promise<{ persistentId: string }>
+  create: (
+    dataset: DatasetDTO,
+    collectionId: string,
+    datasetType?: string
+  ) => Promise<{ persistentId: string }>
   updateMetadata: (
     datasetId: string | number,
     datasetDTO: DatasetDTO,

--- a/src/dataset/domain/useCases/createDataset.ts
+++ b/src/dataset/domain/useCases/createDataset.ts
@@ -4,9 +4,10 @@ import { DatasetDTO } from './DTOs/DatasetDTO'
 export function createDataset(
   datasetRepository: DatasetRepository,
   dataset: DatasetDTO,
-  collectionId: string
+  collectionId: string,
+  datasetType?: string
 ): Promise<{ persistentId: string }> {
-  return datasetRepository.create(dataset, collectionId).catch((error: Error) => {
+  return datasetRepository.create(dataset, collectionId, datasetType).catch((error: Error) => {
     throw new Error(error.message)
   })
 }

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -310,9 +310,13 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       })
   }
 
-  create(dataset: DatasetDTO, collectionId: string): Promise<{ persistentId: string }> {
+  create(
+    dataset: DatasetDTO,
+    collectionId: string,
+    datasetType?: string
+  ): Promise<{ persistentId: string }> {
     return createDataset
-      .execute(DatasetDTOMapper.toJSDatasetDTO(dataset), collectionId)
+      .execute(DatasetDTOMapper.toJSDatasetDTO(dataset), collectionId, datasetType)
       .then((jsDatasetIdentifiers: JSDatasetIdentifiers) => ({
         persistentId: jsDatasetIdentifiers.persistentId
       }))

--- a/src/sections/layout/header/LoggedInHeaderActions.tsx
+++ b/src/sections/layout/header/LoggedInHeaderActions.tsx
@@ -38,6 +38,9 @@ export const LoggedInHeaderActions = ({
 
   const canUserAddCollectionToRoot = Boolean(collectionUserPermissions?.canAddCollection)
   const canUserAddDatasetToRoot = Boolean(collectionUserPermissions?.canAddDataset)
+  // TODO: Enable/disable review creation based on config setting. See also AddDataActionsButton.tsx
+  // TODO: Longer term, query /api/datasets/datasetTypes and show those
+  const reviewCreationEnabled = false
 
   return (
     <>
@@ -51,6 +54,14 @@ export const LoggedInHeaderActions = ({
         <Navbar.Dropdown.Item as={Link} to={createDatasetRoute} disabled={!canUserAddDatasetToRoot}>
           {t('navigation.newDataset')}
         </Navbar.Dropdown.Item>
+        {reviewCreationEnabled && (
+          <Navbar.Dropdown.Item
+            as={Link}
+            to={`${createDatasetRoute}?datasetType=review`}
+            disabled={!canUserAddDatasetToRoot}>
+            {t('navigation.newReview')}
+          </Navbar.Dropdown.Item>
+        )}
       </Navbar.Dropdown>
       <Navbar.Dropdown title={user.displayName} id="dropdown-user">
         <Navbar.Dropdown.Item

--- a/src/sections/shared/add-data-actions/AddDataActionsButton.tsx
+++ b/src/sections/shared/add-data-actions/AddDataActionsButton.tsx
@@ -21,6 +21,9 @@ export default function AddDataActionsButton({
 
   const createCollectionRoute = RouteWithParams.CREATE_COLLECTION(collectionId)
   const createDatasetRoute = RouteWithParams.CREATE_DATASET(collectionId)
+  // TODO: Enable/disable review creation based on config setting. See also LoggedInHeaderActions.tsx
+  // TODO: Longer term, query /api/datasets/datasetTypes and show those
+  const reviewCreationEnabled = false
 
   return (
     <DropdownButton
@@ -34,6 +37,14 @@ export default function AddDataActionsButton({
       <Dropdown.Item to={createDatasetRoute} as={Link} disabled={!canAddDataset}>
         {t('navigation.newDataset')}
       </Dropdown.Item>
+      {reviewCreationEnabled && (
+        <Dropdown.Item
+          to={`${createDatasetRoute}?datasetType=review`}
+          as={Link}
+          disabled={!canAddDataset}>
+          {t('navigation.newReview')}
+        </Dropdown.Item>
+      )}
     </DropdownButton>
   )
 }

--- a/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
+++ b/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
@@ -61,7 +61,13 @@ export function useSubmitDataset(
     )
 
     if (mode === 'create') {
-      createDataset(datasetRepository, formattedFormValues, collectionId)
+      let datasetType = 'dataset'
+      const urlParams = new URLSearchParams(window.location.search)
+      const datasetTypeIn = urlParams.get('datasetType')
+      if (datasetTypeIn) {
+        datasetType = datasetTypeIn
+      }
+      createDataset(datasetRepository, formattedFormValues, collectionId, datasetType)
         .then(({ persistentId }) => {
           setSubmitError(null)
           setSubmissionStatus(SubmissionStatus.SubmitComplete)


### PR DESCRIPTION
## What this PR does / why we need it:

For an upcoming Trusted Data demo, we need to show a "New Review" button. This PR includes a couple booleans that can be flipped to true to show the button and conduct the demo.

Longer term, instead of hard-coding "review", we should be querying https://demo.dataverse.org/api/datasets/datasetTypes (on the target server, of course) to decide which extra dataset types to offer the user. Perhaps that will be in scope for a larger, related issue:

- #797

## Which issue(s) this PR closes:

-related #797

## Special notes for your reviewer:

This PR depends on the following js-dataverse PR:

- https://github.com/IQSS/dataverse-client-javascript/pull/360

I tried to add a variable to the .env file but I couldn't get this working. I think this would be preferable to having hard-coded booleans. I added some TODOs to this part of the code.

## Suggestions on how to test this:

- Flip the reviewCreationEnabled boolean to true
- Build and deploy as normal
- On the backend, create a dataset type of "review". See https://guides.dataverse.org/en/6.7.1/api/native-api.html#add-dataset-type
- Click "New Review" and observe that the datasetType is passed as a query parameter
- Save the review and observe that Dataset Type facet is incremented for the "review" type.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

Yes, when the creation of reviews are enabled, you'll see a "New Review" button:

<img width="447" height="458" alt="Screenshot 2025-09-08 at 3 52 48 PM" src="https://github.com/user-attachments/assets/b5b7ce09-6bdd-425e-8be8-2722b3e60475" />
<img width="447" height="458" alt="Screenshot 2025-09-08 at 3 52 54 PM" src="https://github.com/user-attachments/assets/25465da1-3d10-4691-9b68-d96123c39e0c" />

Clicking this button will add `datasetType=review` as a query parameter for the "create dataset" page:

<img width="613" height="350" alt="Screenshot 2025-09-08 at 3 53 19 PM" src="https://github.com/user-attachments/assets/e50e395a-cd04-48b6-a2d6-8a0967b7d8ec" />

Once you click save, you will see the "Dataset Type" facet incremented by the type you chose (note that if you have all one type, the facet is not shown):

<img width="261" height="276" alt="Screenshot 2025-09-08 at 3 54 00 PM" src="https://github.com/user-attachments/assets/35a3f84e-fa1d-42f9-ac5b-2baf78fcb6d9" />

There is a related issue about how this Dataset Type facet doesn't work (which might be a backend problem):

- https://github.com/IQSS/dataverse-frontend/issues/809

## Is there a release notes update needed for this change?:

Yes, something like this:

"Experimental support for creating a review as a type of dataset has been added."

## Additional documentation:

None.