### PR TITLE
Added environments section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,24 +134,32 @@ The Dataverse Frontend project uses several environments to support different st
 All environments follow an “all-in-one” setup, where the frontend and backend applications run together on a Payara server. Although these environments use the all-in-one setup, the SPA is infrastructure-agnostic and could also be deployed independently on other platforms, such as Docker containers, object storage services (e.g., Amazon S3 buckets), or any static hosting service/CDN, as long as it can communicate with the backend APIs.
 
 #### Beta
-The **Beta** environment provides a remote space for testing the latest changes. GitHub Actions automatically deploy the current `develop` branches of both the frontend and backend.  
-- **Audience:** Development team, QA analysts, project managers, selected users for early feedback  
+
+The **Beta** environment provides a remote space for testing the latest changes. GitHub Actions automatically deploy the current `develop` branches of both the frontend and backend.
+
+- **Audience:** Development team, QA analysts, project managers, selected users for early feedback
 - **URL:** [beta.dataverse.org/spa][dv_app_beta_spa_url]
 
 #### Demo
-The **Demo** environment showcases the latest officially released version of the SPA, compatible with the latest Dataverse backend release. Deployments target specific tagged releases (e.g., `0.1.0`) and are performed on demand.  
-- **Audience:** Project managers, curation team, early adoption testers  
+
+The **Demo** environment showcases the latest officially released version of the SPA, compatible with the latest Dataverse backend release. Deployments target specific tagged releases (e.g., `0.1.0`) and are performed on demand.
+
+- **Audience:** Project managers, curation team, early adoption testers
 - **URL:** [demo.dataverse.org/spa][dv_app_demo_spa_url]
 
 #### QA
-The **QA** environment is a dedicated, short-lived testing space. It is deployed on demand with feature branches (e.g., `feature/xxx`), frequently overwritten, and used for validating new features and bug fixes before merging into development.  
-- **Audience:** QA analysts, development team  
+
+The **QA** environment is a dedicated, short-lived testing space. It is deployed on demand with feature branches (e.g., `feature/xxx`), frequently overwritten, and used for validating new features and bug fixes before merging into development.
+
+- **Audience:** QA analysts, development team
 - **URL:** [qa.dataverse.org/spa][dv_app_qa_spa_url]
 
 #### Spike Environments
-**Spike Environments** are temporary, project-specific deployments tied to individual branches. They are used to prototype new ideas and gather early feedback on unstable or in-progress work. Deployments can occur automatically on merge or on demand.  
-- **Audience:** Development team, project managers  
-- **URLs:** Unique per project, e.g., `project-foo.dataverse.org` or `project-abc.dataverse.org`  
+
+**Spike Environments** are temporary, project-specific deployments tied to individual branches. They are used to prototype new ideas and gather early feedback on unstable or in-progress work. Deployments can occur automatically on merge or on demand.
+
+- **Audience:** Development team, project managers
+- **URLs:** Unique per project, e.g., `project-foo.dataverse.org` or `project-abc.dataverse.org`
 - **Note:** Setting up a Spike Environment requires a working Keycloak instance. See [Keycloak Deployment](./docs/KEYCLOAK_DEPLOYMENT.md) for details.
 
 ### How Existing Dataverse Installations May Be Affected

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To stay up-to-date with all the latest changes, join the [Google Group][dv_commu
         <li><a href="#what-is-dataverse">What is Dataverse?</a></li>
         <li><a href="#what-is-dataverse-frontend">What Is Dataverse Frontend &amp; How Do They Differ?</a></li>
         <li><a href="#demo-videos">Demo Videos</a></li>
-        <li><a href="#beta-testing-environment">Beta Testing Environment</a></li>
+        <li><a href="#dataverse-frontend-environments">Dataverse Frontend Environments</a></li>
       </ul>
     </li>
     <li><a href="#roadmap">Roadmap</a></li>

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The Dataverse Frontend project uses several environments to support different st
 All environments follow an “all-in-one” setup, where the frontend and backend applications run together on a Payara server.  
 
 #### Beta
-The **Beta** environment provides a remote space for testing the latest changes. It automatically deploys the current `develop` branches of both the frontend and backend through GitHub Actions.  
+The **Beta** environment provides a remote space for testing the latest changes. GitHub Actions automatically deploy the current `develop` branches of both the frontend and backend.  
 - **Audience:** Development team, QA analysts, project managers, selected users for early feedback  
 - **URL:** [beta.dataverse.org/spa][dv_app_beta_spa_url]
 

--- a/README.md
+++ b/README.md
@@ -127,23 +127,32 @@ and utilize the JavaScript framework of their choice.
 - 2023-12-13: [Files table on the dataset page](https://groups.google.com/g/dataverse-community/c/w_rEMddESYc/m/6F7QC1p-AgAJ)
 - 2024-09-13: [Collection page, collection and dataset creation and file uploading](https://groups.google.com/g/dataverse-community/c/heSnBRhhriM/m/bFgLDvvZAQAJ)
 
-### Beta Testing Environment
+### Dataverse Frontend Environments
 
-_Track our progress and compare it to the current Dataverse application!_
+The Dataverse Frontend project uses several environments to support different stages of development, testing, and deployment. Each environment serves a specific purpose for stakeholders ranging from developers to end users.
 
-To make the SPA Frontend accessible and testable by people interested in the project, there is a remote beta testing
-environment that includes the latest changes developed both for the frontend application and the Dataverse backend
-application (develop branches).
+All environments follow an “all-in-one” setup, where the frontend and backend applications run together on a Payara server.  
 
-This environment follows the "all-in-one" solution described above, where both applications coexist on a Payara server.
+#### Beta
+The **Beta** environment provides a remote space for testing the latest changes. It automatically deploys the current `develop` branches of both the frontend and backend through GitHub Actions.  
+- **Audience:** Development team, QA analysts, project managers, selected users for early feedback  
+- **URL:** [beta.dataverse.org/spa][dv_app_beta_spa_url]
 
-Environment updates are carried out automatically through GitHub actions, present both in this repository and in the
-Dataverse backend repository, which deploy the develop branches when any change is pushed to them.
+#### Demo
+The **Demo** environment showcases the latest officially released version of the SPA, compatible with the latest Dataverse backend release. Deployments target specific tagged releases (e.g., `0.1.0`) and are performed on demand.  
+- **Audience:** Project managers, curation team, early adoption testers  
+- **URL:** [demo.dataverse.org/spa][dv_app_demo_spa_url]
 
-The environment is accessible through the following URLs:
+#### QA
+The **QA** environment is a dedicated, short-lived testing space. It is deployed on demand with feature branches (e.g., `feature/xxx`), frequently overwritten, and used for validating new features and bug fixes before merging into development.  
+- **Audience:** QA analysts, development team  
+- **URL:** [qa.dataverse.org/spa][dv_app_qa_spa_url]
 
-- Dataverse Frontend SPA: [beta.dataverse.org/spa][dv_app_beta_spa_url]
-- Dataverse JSF: [beta.dataverse.org][dv_app_beta_legacyjsf_url]
+#### Spike Environments
+**Spike Environments** are temporary, project-specific deployments tied to individual branches. They are used to prototype new ideas and gather early feedback on unstable or in-progress work. Deployments can occur automatically on merge or on demand.  
+- **Audience:** Development team, project managers  
+- **URLs:** Unique per project, e.g., `project-foo.dataverse.org` or `project-abc.dataverse.org`  
+- **Note:** Setting up a Spike Environment requires a working Keycloak instance. See [Keycloak Deployment](./docs/KEYCLOAK_DEPLOYMENT.md) for details.
 
 ### How Existing Dataverse Installations May Be Affected
 
@@ -365,6 +374,8 @@ Distributed under the Apache License, Version 2.0. See [LICENSE](LICENSE) for mo
 <!-- [dv_app_] -->
 
 [dv_app_beta_spa_url]: https://beta.dataverse.org/spa
+[dv_app_demo_spa_url]: https://demo.dataverse.org/spa
+[dv_app_qa_spa_url]: https://qa.dataverse.org/spa
 [dv_app_beta_legacyjsf_url]: https://beta.dataverse.org
 [dv_app_legacyjsf_demo_url]: https://demo.dataverse.org/
 [dv_app_localhost_build_url]: http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ and utilize the JavaScript framework of their choice.
 
 The Dataverse Frontend project uses several environments to support different stages of development, testing, and deployment. Each environment serves a specific purpose for stakeholders ranging from developers to end users.
 
-All environments follow an “all-in-one” setup, where the frontend and backend applications run together on a Payara server.  
+All environments follow an “all-in-one” setup, where the frontend and backend applications run together on a Payara server. Although these environments use the all-in-one setup, the SPA is infrastructure-agnostic and could also be deployed independently on other platforms, such as Docker containers, object storage services (e.g., Amazon S3 buckets), or any static hosting service/CDN, as long as it can communicate with the backend APIs.
 
 #### Beta
 The **Beta** environment provides a remote space for testing the latest changes. GitHub Actions automatically deploy the current `develop` branches of both the frontend and backend.  


### PR DESCRIPTION
## What this PR does / why we need it:

Includes a new section in the README file describing the purpose of each SPA environment based on the consensus reached on https://github.com/IQSS/dataverse-frontend/issues/803

## Which issue(s) this PR closes:

- Closes #803 

## Special notes for your reviewer:

## Suggestions on how to test this:

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes update needed for this change?:

## Additional documentation:
