### PR TITLE
recommend latest LTS version of node

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -73,7 +73,7 @@ _To get a local copy up and running follow these simple example steps._
 
 [![DockerDesktop][_shield_docker]][_uses_docker_url]
 
-1. **Node &amp; NPM**: `node >= v16` and `npm >= v8`. Recommended versions for this project are `node v19` and `npm v9`.
+1. **Node &amp; NPM**: `node >= v16` and `npm >= v8`. Recommended versions for this project are `node v22` and `npm v10`.
 2. **Docker**: We use Docker Desktop, but the Docker CLI will also work.
 3. **Create a Copy of .npmrc**: In the project directory root, duplicate `.npmrc.example`, saving the copy as `.npmrc`.
 


### PR DESCRIPTION
## What this PR does / why we need it:

v19 is EOL according to https://nodejs.org/en/about/previous-releases

## Which issue(s) this PR closes:

None.

## Special notes for your reviewer:

I picked v10 for npm because it's what came along with node when I installed the LTS of node (v22).

I noticed that in GitHub Actions we use v18, which is also EOL, but I'd suggest a different pull request for that:

```
% grep -r node-version .github/workflows 
.github/workflows/lint.yml:          node-version: 18
.github/workflows/accessibility.yml:          node-version: 18
.github/workflows/test.yml:          node-version: 18
.github/workflows/test.yml:          node-version: 18
.github/workflows/deploy.yml:          node-version: 18
.github/workflows/deploy-beta-testing.yml:          node-version: 18
```

@g-saracca noticed that the Docker environment is using v19:

```
% grep FROM dev.Dockerfile
FROM node:19.6.1-alpine AS build_image
FROM node:19.6.1-alpine 
```