### PR TITLE
Fix: add line break to all items' title and description for long text w/o spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 ### Fixed
 
 - Upgrade dependencies to drastically reduce vulnerabilities flagged by `npm audit`. Reduced from +100 including 12 critical and 33 high to only 2 moderate.
-- Add word-break to the the items to fix UI wrappers break when entering long descriptions without spacing. (#839)
+- Add word-break to the items to fix UI wrappers break when entering long descriptions without spacing. (#839)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 ### Fixed
 
 - Upgrade dependencies to drastically reduce vulnerabilities flagged by `npm audit`. Reduced from +100 including 12 critical and 33 high to only 2 moderate.
+- Add word-break to the the items to fix UI wrappers break when entering long descriptions without spacing. (#839)
 
 ### Removed
 

--- a/src/sections/collection/collection-items-panel/filter-panel/facets-filters/FacetsFilters.module.scss
+++ b/src/sections/collection/collection-items-panel/filter-panel/facets-filters/FacetsFilters.module.scss
@@ -9,6 +9,7 @@
 
 .facets-list {
   padding-top: 1rem;
+  word-break: break-word;
 
   &:empty {
     padding-top: 0;

--- a/src/sections/collection/collection-items-panel/items-list/collection-card/CollectionCard.module.scss
+++ b/src/sections/collection/collection-items-panel/items-list/collection-card/CollectionCard.module.scss
@@ -15,6 +15,7 @@
   display: flex;
   gap: 1rem;
   justify-content: space-between;
+  word-break: break-word;
 
   a {
     @include link-hover-underlined;

--- a/src/sections/collection/collection-items-panel/items-list/dataset-card/DatasetCard.module.scss
+++ b/src/sections/collection/collection-items-panel/items-list/dataset-card/DatasetCard.module.scss
@@ -19,7 +19,7 @@
   justify-content: space-between;
 
   a {
-    @include link-hover-underlined;  
+    @include link-hover-underlined;
   }
 
   .left-side-content {

--- a/src/sections/collection/collection-items-panel/items-list/dataset-card/DatasetCard.module.scss
+++ b/src/sections/collection/collection-items-panel/items-list/dataset-card/DatasetCard.module.scss
@@ -10,6 +10,7 @@
   padding: 6px 10px;
   border: 1px solid $dv-dataset-border-color;
   border-radius: 4px;
+  word-break: break-word;
 }
 
 .card-header-container {
@@ -18,7 +19,7 @@
   justify-content: space-between;
 
   a {
-    @include link-hover-underlined;
+    @include link-hover-underlined;  
   }
 
   .left-side-content {

--- a/src/sections/collection/collection-items-panel/items-list/file-card/FileCard.module.scss
+++ b/src/sections/collection/collection-items-panel/items-list/file-card/FileCard.module.scss
@@ -10,6 +10,7 @@
   padding: 6px 10px;
   border: 1px solid $dv-file-border-color;
   border-radius: 4px;
+  word-break: break-word;
 }
 
 .card-header-container {

--- a/src/sections/shared/citation/Citation.module.scss
+++ b/src/sections/shared/citation/Citation.module.scss
@@ -26,5 +26,3 @@
 .styledCitationButton {
   color: $dv-link-color !important;
 }
-
-

--- a/src/sections/shared/citation/Citation.module.scss
+++ b/src/sections/shared/citation/Citation.module.scss
@@ -25,3 +25,7 @@
 .styledCitationButton {
   color: $dv-link-color !important;
 }
+
+.description {
+  word-break: break-word;
+}

--- a/src/sections/shared/citation/Citation.module.scss
+++ b/src/sections/shared/citation/Citation.module.scss
@@ -2,6 +2,7 @@
 
 .description {
   margin-bottom: 1em;
+  word-break: break-word;
 }
 
 .text {
@@ -26,6 +27,4 @@
   color: $dv-link-color !important;
 }
 
-.description {
-  word-break: break-word;
-}
+

--- a/src/sections/shared/hierarchy/BreadcrumbsGenerator.module.scss
+++ b/src/sections/shared/hierarchy/BreadcrumbsGenerator.module.scss
@@ -1,3 +1,4 @@
 .breadcrumb-generator {
   padding-top: 0.5rem;
+  word-break: break-word;
 }

--- a/tests/component/sections/collection/collection-items-panel/collection-card/CollectionCard.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/collection-card/CollectionCard.spec.tsx
@@ -27,6 +27,7 @@ describe('CollectionCard', () => {
 
     cy.findByAltText(collectionPreview.name).should('exist')
   })
+
   it('should render the card with user roles', () => {
     const userRoles = ['Admin', 'Contributor', 'Curator']
     const collectionPreview = CollectionItemTypePreviewMother.create({ userRoles: userRoles })
@@ -35,6 +36,24 @@ describe('CollectionCard', () => {
 
     userRoles.map((role) => {
       cy.findByText(role).should('exist')
+    })
+  })
+
+  it('should not overflow horizontally with long unspaced titles', () => {
+    const longName = 'abc'.repeat(50)
+    const collectionPreview = CollectionItemTypePreviewMother.create({
+      name: longName
+    })
+
+    cy.customMount(
+      <CollectionCard collectionPreview={collectionPreview} parentCollectionAlias="" />
+    )
+
+    cy.contains(longName).should('exist')
+    // Ensure the title wraps within the available width (no horizontal overflow)
+    cy.get('[data-testid="collection-card"] header a').then(($a) => {
+      const el = $a[0]
+      expect(el.scrollWidth).to.be.lte(el.clientWidth)
     })
   })
 })


### PR DESCRIPTION
## What this PR does / why we need it:
add a word-break of long text to the collection&dataset&file card and breadcrumb, to prevent a UI break. 

The card extends too long if we have a long text without space
<img width="1478" height="607" alt="image" src="https://github.com/user-attachments/assets/1de0ae8f-33c7-4c3c-99c4-29d6c1098375" />

## Which issue(s) this PR closes:

- Closes #839 

## Special notes for your reviewer:

## Suggestions on how to test this:
entering a long title/description to collection, dataset and file
<img width="2236" height="1178" alt="image" src="https://github.com/user-attachments/assets/f5485599-dd2e-4393-bdb5-3c848c175bd2" />


## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes or changelog update needed for this change?:

## Additional documentation:
