### PR TITLE
ignore onClick logOut when calculating code coverage

### DIFF
--- a/src/sections/layout/header/LoggedInHeaderActions.tsx
+++ b/src/sections/layout/header/LoggedInHeaderActions.tsx
@@ -69,7 +69,10 @@ export const LoggedInHeaderActions = ({
           {t('navigation.apiToken')}
         </Navbar.Dropdown.Item>
 
-        <Navbar.Dropdown.Item href="#" onClick={() => logOut()} data-testid="oidc-logout">
+        <Navbar.Dropdown.Item
+          href="#"
+          onClick={/* istanbul ignore next */ () => logOut()}
+          data-testid="oidc-logout">
           {t('logOut')}
         </Navbar.Dropdown.Item>
       </Navbar.Dropdown>


### PR DESCRIPTION
## What this PR does / why we need it:

Ignores the following line when calculating code coverage:

<img width="846" height="167" alt="Screenshot 2025-10-06 at 2 42 26 PM" src="https://github.com/user-attachments/assets/a7fce196-e140-44a7-b5fc-f9d55d6650fa" />

## Which issue(s) this PR closes:

None. Relates to:

- #866

## Special notes for your reviewer:

If we can write a test to exercise logOut, that would probably be better.

## Suggestions on how to test this:

Interact with the header.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

No.

## Is there a release notes or changelog update needed for this change?:

No.

## Additional documentation:

None.