### PR TITLE
Update query parameters to Dataset&File Version Summaries use case 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Changed
 
+- BREAKING CHANGE: add pagination support to the Dataset and File Version Summaries use cases by introducing optional limit and offset query parameters. #885
+
 - Use of the new `sourceLastUpdateTime` query parameter from update dataset and file metadata endpoints to support optimistic concurrency control during editing operations. See [Edit Dataset Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#edit-dataset-metadata) and [Updating File Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#updating-file-metadata) guides for more details.
 - Changed the way we were handling DATE type metadata field validation to better match the backend validation and give users better error messages. For example, for an input like “foo AD”, we now show “Production Date is not a valid date. The AD year must be numeric.“. For an input like “99999 AD”, we now show “Production Date is not a valid date. The AD year cant be higher than 9999.“. For an input like “[-9999?], we now show “Production Date is not a valid date. The year in brackets cannot be negative.“, etc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 ### Changed
 
 - Add pagination support to the Dataset Version Summaries and File Version Summaries use cases by introducing optional pagination object. #885
-
+- Refactored pagination to use consistent `CollectionItemsPaginationInfo` object in getMyDataColletionItems, instead of individual limit/selectedPage parameters.
 - Use of the new `sourceLastUpdateTime` query parameter from update dataset and file metadata endpoints to support optimistic concurrency control during editing operations. See [Edit Dataset Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#edit-dataset-metadata) and [Updating File Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#updating-file-metadata) guides for more details.
 - Changed the way we were handling DATE type metadata field validation to better match the backend validation and give users better error messages. For example, for an input like “foo AD”, we now show “Production Date is not a valid date. The AD year must be numeric.“. For an input like “99999 AD”, we now show “Production Date is not a valid date. The AD year cant be higher than 9999.“. For an input like “[-9999?], we now show “Production Date is not a valid date. The year in brackets cannot be negative.“, etc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 ### Changed
 
 - Add pagination support to the Dataset Version Summaries and File Version Summaries use cases by introducing optional pagination object. #885
-- Refactored pagination to use consistent `CollectionItemsPaginationInfo` object in getMyDataColletionItems, instead of individual limit/selectedPage parameters.
+- Refactored pagination to use consistent `CollectionItemsPaginationInfo` object in getMyDataCollectionItems, instead of individual limit/selectedPage parameters.
 - Use of the new `sourceLastUpdateTime` query parameter from update dataset and file metadata endpoints to support optimistic concurrency control during editing operations. See [Edit Dataset Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#edit-dataset-metadata) and [Updating File Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#updating-file-metadata) guides for more details.
 - Changed the way we were handling DATE type metadata field validation to better match the backend validation and give users better error messages. For example, for an input like “foo AD”, we now show “Production Date is not a valid date. The AD year must be numeric.“. For an input like “99999 AD”, we now show “Production Date is not a valid date. The AD year cant be higher than 9999.“. For an input like “[-9999?], we now show “Production Date is not a valid date. The year in brackets cannot be negative.“, etc.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Changed
 
-- BREAKING CHANGE: add pagination support to the Dataset and File Version Summaries use cases by introducing optional limit and offset query parameters. #885
+- Add pagination support to the Dataset Version Summaries and File Version Summaries use cases by introducing optional pagination object. #885
 
 - Use of the new `sourceLastUpdateTime` query parameter from update dataset and file metadata endpoints to support optimistic concurrency control during editing operations. See [Edit Dataset Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#edit-dataset-metadata) and [Updating File Metadata](https://guides.dataverse.org/en/6.8/api/native-api.html#updating-file-metadata) guides for more details.
 - Changed the way we were handling DATE type metadata field validation to better match the backend validation and give users better error messages. For example, for an input like “foo AD”, we now show “Production Date is not a valid date. The AD year must be numeric.“. For an input like “99999 AD”, we now show “Production Date is not a valid date. The AD year cant be higher than 9999.“. For an input like “[-9999?], we now show “Production Date is not a valid date. The year in brackets cannot be negative.“, etc.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.1.0-pr395.061ad8e",
+        "@iqss/dataverse-client-javascript": "2.0.0-alpha.79",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -1954,9 +1954,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.1.0-pr395.061ad8e",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.1.0-pr395.061ad8e/7572037bdd5d62b4672421f948ce08dffe2ff2ef",
-      "integrity": "sha512-wgQT4y5QSrzVIylI5NL9xiak6VjJd8f5haTydsLOy6qZy50tZDMscTi39akdSg36zUOKh/OTQ/BFPYHIysz+dw==",
+      "version": "2.0.0-alpha.79",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.79/4128665172f9569fa40f60ca1c1d205f7fe8a401",
+      "integrity": "sha512-NfjzwOz06QJzSYAQ2eZ20tRINO49LrBaWQ9JTQNK0cLPTRdmYzUJgB2zzGzH/c/bi7LfGgfkPqO+6MH9HPFxpg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.0.0-alpha.77",
+        "@iqss/dataverse-client-javascript": "2.1.0-pr395.061ad8e",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -1954,9 +1954,9 @@
     },
     "node_modules/@iqss/dataverse-client-javascript": {
       "name": "@IQSS/dataverse-client-javascript",
-      "version": "2.0.0-alpha.77",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.0.0-alpha.77/a12678016bb88b43b940910a1d55b65518e38691",
-      "integrity": "sha512-mGbm5Wd+jU9H0w2x4iyCLX8VwIAy7oYSH4juZlYuCcLbftmIObyLVcspxJ61XINColLfZY6Rs63+lOWBwYktZg==",
+      "version": "2.1.0-pr395.061ad8e",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.1.0-pr395.061ad8e/7572037bdd5d62b4672421f948ce08dffe2ff2ef",
+      "integrity": "sha512-wgQT4y5QSrzVIylI5NL9xiak6VjJd8f5haTydsLOy6qZy50tZDMscTi39akdSg36zUOKh/OTQ/BFPYHIysz+dw==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.1.0-pr395.061ad8e",
+    "@iqss/dataverse-client-javascript": "2.0.0-alpha.79",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.0.0-alpha.77",
+    "@iqss/dataverse-client-javascript": "2.1.0-pr395.061ad8e",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/src/collection/domain/models/MyDataCollectionItemsPaginationInfo.ts
+++ b/src/collection/domain/models/MyDataCollectionItemsPaginationInfo.ts
@@ -1,0 +1,7 @@
+import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
+
+export class MyDataCollectionItemsPaginationInfo extends PaginationInfo<MyDataCollectionItemsPaginationInfo> {
+  constructor(page = 1, pageSize = 10, totalItems = 0, itemName = 'Item') {
+    super(page, pageSize, totalItems, itemName)
+  }
+}

--- a/src/collection/domain/models/MyDataCollectionItemsPaginationInfo.ts
+++ b/src/collection/domain/models/MyDataCollectionItemsPaginationInfo.ts
@@ -1,7 +1,0 @@
-import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
-
-export class MyDataCollectionItemsPaginationInfo extends PaginationInfo<MyDataCollectionItemsPaginationInfo> {
-  constructor(page = 1, pageSize = 10, totalItems = 0, itemName = 'Item') {
-    super(page, pageSize, totalItems, itemName)
-  }
-}

--- a/src/collection/domain/repositories/CollectionRepository.ts
+++ b/src/collection/domain/repositories/CollectionRepository.ts
@@ -13,7 +13,6 @@ import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus
 import { LinkingObjectType } from '../useCases/getCollectionsForLinking'
 import { CollectionSummary } from '../models/CollectionSummary'
 import { CollectionLinks } from '../models/CollectionLinks'
-import { MyDataCollectionItemsPaginationInfo } from '../models/MyDataCollectionItemsPaginationInfo'
 
 export interface CollectionRepository {
   getById: (id?: string) => Promise<Collection>
@@ -32,7 +31,7 @@ export interface CollectionRepository {
     roleIds: number[],
     collectionItemTypes: CollectionItemType[],
     publicationStatuses: PublicationStatus[],
-    paginationInfo?: MyDataCollectionItemsPaginationInfo,
+    paginationInfo?: CollectionItemsPaginationInfo,
     searchText?: string,
     otherUserName?: string
   ) => Promise<MyDataCollectionItemSubset>

--- a/src/collection/domain/repositories/CollectionRepository.ts
+++ b/src/collection/domain/repositories/CollectionRepository.ts
@@ -13,6 +13,7 @@ import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus
 import { LinkingObjectType } from '../useCases/getCollectionsForLinking'
 import { CollectionSummary } from '../models/CollectionSummary'
 import { CollectionLinks } from '../models/CollectionLinks'
+import { MyDataCollectionItemsPaginationInfo } from '../models/MyDataCollectionItemsPaginationInfo'
 
 export interface CollectionRepository {
   getById: (id?: string) => Promise<Collection>
@@ -31,8 +32,7 @@ export interface CollectionRepository {
     roleIds: number[],
     collectionItemTypes: CollectionItemType[],
     publicationStatuses: PublicationStatus[],
-    limit?: number,
-    selectedPage?: number,
+    paginationInfo?: MyDataCollectionItemsPaginationInfo,
     searchText?: string,
     otherUserName?: string
   ) => Promise<MyDataCollectionItemSubset>

--- a/src/collection/domain/useCases/getMyDataCollectionItems.ts
+++ b/src/collection/domain/useCases/getMyDataCollectionItems.ts
@@ -2,14 +2,14 @@ import { CollectionRepository } from '../repositories/CollectionRepository'
 import { MyDataCollectionItemSubset } from '../models/MyDataCollectionItemSubset'
 import { PublicationStatus } from '../../../shared/core/domain/models/PublicationStatus'
 import { CollectionItemType } from '@/collection/domain/models/CollectionItemType'
-import { MyDataCollectionItemsPaginationInfo } from '../models/MyDataCollectionItemsPaginationInfo'
+import { CollectionItemsPaginationInfo } from '../models/CollectionItemsPaginationInfo'
 
 export async function getMyDataCollectionItems(
   collectionRepository: CollectionRepository,
   roleIds: number[],
   collectionItemTypes: CollectionItemType[],
   publicationStatuses: PublicationStatus[],
-  paginationInfo?: MyDataCollectionItemsPaginationInfo,
+  paginationInfo?: CollectionItemsPaginationInfo,
   searchText?: string,
   otherUserName?: string
 ): Promise<MyDataCollectionItemSubset> {

--- a/src/collection/domain/useCases/getMyDataCollectionItems.ts
+++ b/src/collection/domain/useCases/getMyDataCollectionItems.ts
@@ -2,14 +2,14 @@ import { CollectionRepository } from '../repositories/CollectionRepository'
 import { MyDataCollectionItemSubset } from '../models/MyDataCollectionItemSubset'
 import { PublicationStatus } from '../../../shared/core/domain/models/PublicationStatus'
 import { CollectionItemType } from '@/collection/domain/models/CollectionItemType'
+import { MyDataCollectionItemsPaginationInfo } from '../models/MyDataCollectionItemsPaginationInfo'
 
 export async function getMyDataCollectionItems(
   collectionRepository: CollectionRepository,
   roleIds: number[],
   collectionItemTypes: CollectionItemType[],
   publicationStatuses: PublicationStatus[],
-  limit?: number,
-  selectedPage?: number,
+  paginationInfo?: MyDataCollectionItemsPaginationInfo,
   searchText?: string,
   otherUserName?: string
 ): Promise<MyDataCollectionItemSubset> {
@@ -18,8 +18,7 @@ export async function getMyDataCollectionItems(
       roleIds,
       collectionItemTypes,
       publicationStatuses,
-      limit,
-      selectedPage,
+      paginationInfo,
       searchText,
       otherUserName
     )

--- a/src/collection/infrastructure/repositories/CollectionJSDataverseRepository.ts
+++ b/src/collection/infrastructure/repositories/CollectionJSDataverseRepository.ts
@@ -34,6 +34,7 @@ import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { LinkingObjectType } from '@/collection/domain/useCases/getCollectionsForLinking'
 import { CollectionLinks } from '@/collection/domain/models/CollectionLinks'
+import { MyDataCollectionItemsPaginationInfo } from '@/collection/domain/models/MyDataCollectionItemsPaginationInfo'
 
 export class CollectionJSDataverseRepository implements CollectionRepository {
   getById(id?: string): Promise<Collection> {
@@ -93,8 +94,7 @@ export class CollectionJSDataverseRepository implements CollectionRepository {
     roleIds: number[],
     collectionItemTypes: CollectionItemType[],
     publicationStatuses: PublicationStatus[],
-    limit?: number,
-    selectedPage?: number,
+    paginationInfo?: MyDataCollectionItemsPaginationInfo,
     searchText?: string,
     otherUserName?: string
   ): Promise<MyDataCollectionItemSubset> {
@@ -103,8 +103,8 @@ export class CollectionJSDataverseRepository implements CollectionRepository {
         roleIds,
         collectionItemTypes,
         publicationStatuses,
-        limit,
-        selectedPage,
+        paginationInfo?.pageSize,
+        paginationInfo?.page,
         searchText,
         otherUserName
       )

--- a/src/collection/infrastructure/repositories/CollectionJSDataverseRepository.ts
+++ b/src/collection/infrastructure/repositories/CollectionJSDataverseRepository.ts
@@ -34,7 +34,6 @@ import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { LinkingObjectType } from '@/collection/domain/useCases/getCollectionsForLinking'
 import { CollectionLinks } from '@/collection/domain/models/CollectionLinks'
-import { MyDataCollectionItemsPaginationInfo } from '@/collection/domain/models/MyDataCollectionItemsPaginationInfo'
 
 export class CollectionJSDataverseRepository implements CollectionRepository {
   getById(id?: string): Promise<Collection> {
@@ -94,7 +93,7 @@ export class CollectionJSDataverseRepository implements CollectionRepository {
     roleIds: number[],
     collectionItemTypes: CollectionItemType[],
     publicationStatuses: PublicationStatus[],
-    paginationInfo?: MyDataCollectionItemsPaginationInfo,
+    paginationInfo?: CollectionItemsPaginationInfo,
     searchText?: string,
     otherUserName?: string
   ): Promise<MyDataCollectionItemSubset> {

--- a/src/dataset/domain/models/DatasetVersionPaginationInfo.ts
+++ b/src/dataset/domain/models/DatasetVersionPaginationInfo.ts
@@ -5,4 +5,3 @@ export class DatasetVersionPaginationInfo extends PaginationInfo<DatasetVersionP
     super(page, pageSize, totalItems, itemName)
   }
 }
-

--- a/src/dataset/domain/models/DatasetVersionPaginationInfo.ts
+++ b/src/dataset/domain/models/DatasetVersionPaginationInfo.ts
@@ -1,0 +1,8 @@
+import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
+
+export class DatasetVersionPaginationInfo extends PaginationInfo<DatasetVersionPaginationInfo> {
+  constructor(page = 1, pageSize = 10, totalItems = 0, itemName = 'Version') {
+    super(page, pageSize, totalItems, itemName)
+  }
+}
+

--- a/src/dataset/domain/models/DatasetVersionSummaryInfo.ts
+++ b/src/dataset/domain/models/DatasetVersionSummaryInfo.ts
@@ -1,3 +1,8 @@
+export interface DatasetVersionSummarySubset {
+  summaries: DatasetVersionSummaryInfo[]
+  totalCount: number
+}
+
 export interface DatasetVersionSummaryInfo {
   id: number
   versionNumber: string

--- a/src/dataset/domain/repositories/DatasetRepository.ts
+++ b/src/dataset/domain/repositories/DatasetRepository.ts
@@ -10,6 +10,7 @@ import { DatasetDownloadCount } from '../models/DatasetDownloadCount'
 import { FormattedCitation, CitationFormat } from '../models/DatasetCitation'
 import { DatasetTemplate } from '../models/DatasetTemplate'
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
+import { DatasetVersionPaginationInfo } from '../models/DatasetVersionPaginationInfo'
 
 export interface DatasetRepository {
   getByPersistentId: (
@@ -46,8 +47,7 @@ export interface DatasetRepository {
   publish(persistentId: string, versionUpdateType: VersionUpdateType): Promise<void>
   getDatasetVersionsSummaries: (
     datasetId: number | string,
-    limit?: number,
-    offset?: number
+    paginationInfo?: DatasetVersionPaginationInfo
   ) => Promise<DatasetVersionSummarySubset>
   getDownloadCount: (
     datasetId: string | number,

--- a/src/dataset/domain/repositories/DatasetRepository.ts
+++ b/src/dataset/domain/repositories/DatasetRepository.ts
@@ -4,7 +4,7 @@ import { DatasetPaginationInfo } from '../models/DatasetPaginationInfo'
 import { DatasetDTO } from '../useCases/DTOs/DatasetDTO'
 import { DatasetsWithCount } from '../models/DatasetsWithCount'
 import { VersionUpdateType } from '../models/VersionUpdateType'
-import { DatasetVersionSummaryInfo } from '../models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '../models/DatasetVersionSummaryInfo'
 import { DatasetDeaccessionDTO } from '../useCases/DTOs/DatasetDTO'
 import { DatasetDownloadCount } from '../models/DatasetDownloadCount'
 import { FormattedCitation, CitationFormat } from '../models/DatasetCitation'
@@ -44,7 +44,11 @@ export interface DatasetRepository {
     paginationInfo: DatasetPaginationInfo
   ) => Promise<DatasetsWithCount>
   publish(persistentId: string, versionUpdateType: VersionUpdateType): Promise<void>
-  getDatasetVersionsSummaries: (datasetId: number | string) => Promise<DatasetVersionSummaryInfo[]>
+  getDatasetVersionsSummaries: (
+    datasetId: number | string,
+    limit?: number,
+    offset?: number
+  ) => Promise<DatasetVersionSummarySubset>
   getDownloadCount: (
     datasetId: string | number,
     includeMDC?: boolean

--- a/src/dataset/domain/useCases/getDatasetVersionsSummaries.ts
+++ b/src/dataset/domain/useCases/getDatasetVersionsSummaries.ts
@@ -1,11 +1,13 @@
 import { DatasetRepository } from '../repositories/DatasetRepository'
-import { DatasetVersionSummaryInfo } from '../models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '../models/DatasetVersionSummaryInfo'
 
 export function getDatasetVersionsSummaries(
   datasetRepository: DatasetRepository,
-  datasetId: number | string
-): Promise<DatasetVersionSummaryInfo[]> {
-  return datasetRepository.getDatasetVersionsSummaries(datasetId).catch((error) => {
+  datasetId: number | string,
+  limit?: number,
+  offset?: number
+): Promise<DatasetVersionSummarySubset> {
+  return datasetRepository.getDatasetVersionsSummaries(datasetId, limit, offset).catch((error) => {
     throw error
   })
 }

--- a/src/dataset/domain/useCases/getDatasetVersionsSummaries.ts
+++ b/src/dataset/domain/useCases/getDatasetVersionsSummaries.ts
@@ -1,13 +1,13 @@
 import { DatasetRepository } from '../repositories/DatasetRepository'
 import { DatasetVersionSummarySubset } from '../models/DatasetVersionSummaryInfo'
+import { DatasetVersionPaginationInfo } from '../models/DatasetVersionPaginationInfo'
 
 export function getDatasetVersionsSummaries(
   datasetRepository: DatasetRepository,
   datasetId: number | string,
-  limit?: number,
-  offset?: number
+  paginationInfo?: DatasetVersionPaginationInfo
 ): Promise<DatasetVersionSummarySubset> {
-  return datasetRepository.getDatasetVersionsSummaries(datasetId, limit, offset).catch((error) => {
+  return datasetRepository.getDatasetVersionsSummaries(datasetId, paginationInfo).catch((error) => {
     throw error
   })
 }

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -48,6 +48,7 @@ import { DatasetsWithCount } from '../../domain/models/DatasetsWithCount'
 import { VersionUpdateType } from '../../domain/models/VersionUpdateType'
 import { DatasetVersionSummarySubset } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetDownloadCount } from '@/dataset/domain/models/DatasetDownloadCount'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 import { FormattedCitation, CitationFormat } from '@/dataset/domain/models/DatasetCitation'
 import { axiosInstance } from '@/axiosInstance'
 import { DATAVERSE_BACKEND_URL } from '../../../config'
@@ -375,11 +376,10 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
   }
   getDatasetVersionsSummaries(
     datasetId: number | string,
-    limit?: number,
-    offset?: number
+    paginationInfo?: DatasetVersionPaginationInfo
   ): Promise<DatasetVersionSummarySubset> {
     return getDatasetVersionsSummaries
-      .execute(datasetId, limit, offset)
+      .execute(datasetId, paginationInfo?.pageSize, paginationInfo?.offset)
       .catch((error: ReadError) => {
         throw error
       })

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -46,7 +46,7 @@ import { DatasetDTO } from '../../domain/useCases/DTOs/DatasetDTO'
 import { DatasetDTOMapper } from '../mappers/DatasetDTOMapper'
 import { DatasetsWithCount } from '../../domain/models/DatasetsWithCount'
 import { VersionUpdateType } from '../../domain/models/VersionUpdateType'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetDownloadCount } from '@/dataset/domain/models/DatasetDownloadCount'
 import { FormattedCitation, CitationFormat } from '@/dataset/domain/models/DatasetCitation'
 import { axiosInstance } from '@/axiosInstance'
@@ -373,10 +373,16 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
         throw new Error(error.message)
       })
   }
-  getDatasetVersionsSummaries(datasetId: number | string): Promise<DatasetVersionSummaryInfo[]> {
-    return getDatasetVersionsSummaries.execute(datasetId).catch((error: ReadError) => {
-      throw error
-    })
+  getDatasetVersionsSummaries(
+    datasetId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<DatasetVersionSummarySubset> {
+    return getDatasetVersionsSummaries
+      .execute(datasetId, limit, offset)
+      .catch((error: ReadError) => {
+        throw error
+      })
   }
   getDownloadCount(
     datasetId: string | number,

--- a/src/files/domain/models/FileVersionPaginationInfo.ts
+++ b/src/files/domain/models/FileVersionPaginationInfo.ts
@@ -1,0 +1,7 @@
+import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
+
+export class FileVersionPaginationInfo extends PaginationInfo<FileVersionPaginationInfo> {
+  constructor(page = 1, pageSize = 10, totalItems = 0, itemName = 'Version') {
+    super(page, pageSize, totalItems, itemName)
+  }
+}

--- a/src/files/domain/models/FileVersionSummaryInfo.ts
+++ b/src/files/domain/models/FileVersionSummaryInfo.ts
@@ -1,5 +1,10 @@
 import { DatasetVersionState } from '@/dataset/domain/models/Dataset'
 
+export interface FileVersionSummarySubset {
+  summaries: FileVersionSummaryInfo[]
+  totalCount: number
+}
+
 export interface FileVersionSummaryInfo {
   datasetVersion: string
   contributors?: string

--- a/src/files/domain/repositories/FileRepository.ts
+++ b/src/files/domain/repositories/FileRepository.ts
@@ -12,6 +12,7 @@ import { FixityAlgorithm } from '../models/FixityAlgorithm'
 import { FileMetadataDTO } from '@/files/domain/useCases/DTOs/FileMetadataDTO'
 import { RestrictFileDTO } from '../useCases/restrictFileDTO'
 import { FileVersionSummarySubset } from '../models/FileVersionSummaryInfo'
+import { FileVersionPaginationInfo } from '../models/FileVersionPaginationInfo'
 
 export interface FileRepository {
   getAllByDatasetPersistentId: (
@@ -34,8 +35,7 @@ export interface FileRepository {
   ) => Promise<number>
   getFileVersionSummaries: (
     fileId: number | string,
-    limit?: number,
-    offset?: number
+    paginationInfo?: FileVersionPaginationInfo
   ) => Promise<FileVersionSummarySubset>
   getById: (id: number, datasetVersionNumber?: string) => Promise<File | undefined>
   getMultipleFileDownloadUrl: (ids: number[], downloadMode: FileDownloadMode) => string

--- a/src/files/domain/repositories/FileRepository.ts
+++ b/src/files/domain/repositories/FileRepository.ts
@@ -11,7 +11,7 @@ import { UploadedFileDTO } from '@iqss/dataverse-client-javascript'
 import { FixityAlgorithm } from '../models/FixityAlgorithm'
 import { FileMetadataDTO } from '@/files/domain/useCases/DTOs/FileMetadataDTO'
 import { RestrictFileDTO } from '../useCases/restrictFileDTO'
-import { FileVersionSummaryInfo } from '../models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../models/FileVersionSummaryInfo'
 
 export interface FileRepository {
   getAllByDatasetPersistentId: (
@@ -32,7 +32,11 @@ export interface FileRepository {
     criteria?: FileCriteria,
     includeDeaccessioned?: boolean
   ) => Promise<number>
-  getFileVersionSummaries: (fileId: number | string) => Promise<FileVersionSummaryInfo[]>
+  getFileVersionSummaries: (
+    fileId: number | string,
+    limit?: number,
+    offset?: number
+  ) => Promise<FileVersionSummarySubset>
   getById: (id: number, datasetVersionNumber?: string) => Promise<File | undefined>
   getMultipleFileDownloadUrl: (ids: number[], downloadMode: FileDownloadMode) => string
   getFileDownloadUrl: (id: number, downloadMode: FileDownloadMode) => string

--- a/src/files/domain/useCases/getFileVersionSummaries.ts
+++ b/src/files/domain/useCases/getFileVersionSummaries.ts
@@ -1,11 +1,11 @@
 import { FileRepository } from '../repositories/FileRepository'
 import { FileVersionSummarySubset } from '../models/FileVersionSummaryInfo'
+import { FileVersionPaginationInfo } from '../models/FileVersionPaginationInfo'
 
 export function getFileVersionSummaries(
   fileRepository: FileRepository,
   fileId: number | string,
-  limit?: number,
-  offset?: number
+  paginationInfo?: FileVersionPaginationInfo
 ): Promise<FileVersionSummarySubset> {
-  return fileRepository.getFileVersionSummaries(fileId, limit, offset)
+  return fileRepository.getFileVersionSummaries(fileId, paginationInfo)
 }

--- a/src/files/domain/useCases/getFileVersionSummaries.ts
+++ b/src/files/domain/useCases/getFileVersionSummaries.ts
@@ -1,9 +1,11 @@
 import { FileRepository } from '../repositories/FileRepository'
-import { FileVersionSummaryInfo } from '../models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../models/FileVersionSummaryInfo'
 
 export function getFileVersionSummaries(
   fileRepository: FileRepository,
-  fileId: number | string
-): Promise<FileVersionSummaryInfo[]> {
-  return fileRepository.getFileVersionSummaries(fileId)
+  fileId: number | string,
+  limit?: number,
+  offset?: number
+): Promise<FileVersionSummarySubset> {
+  return fileRepository.getFileVersionSummaries(fileId, limit, offset)
 }

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -46,6 +46,7 @@ import { RestrictFileDTO } from '../domain/useCases/restrictFileDTO'
 import { FileMetadataDTO } from '@/files/domain/useCases/DTOs/FileMetadataDTO'
 import { JSDataverseReadErrorHandler } from '@/shared/helpers/JSDataverseReadErrorHandler'
 import { FileVersionSummarySubset } from '../domain/models/FileVersionSummaryInfo'
+import { FileVersionPaginationInfo } from '../domain/models/FileVersionPaginationInfo'
 
 const includeDeaccessioned = true
 
@@ -251,10 +252,9 @@ export class FileJSDataverseRepository implements FileRepository {
   }
   getFileVersionSummaries(
     fileId: number | string,
-    limit?: number,
-    offset?: number
+    paginationInfo?: FileVersionPaginationInfo
   ): Promise<FileVersionSummarySubset> {
-    return getFileVersionSummaries.execute(fileId, limit, offset)
+    return getFileVersionSummaries.execute(fileId, paginationInfo?.pageSize, paginationInfo?.offset)
   }
 
   getById(id: number, datasetVersionNumber?: string): Promise<File> {

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -45,7 +45,7 @@ import { FixityAlgorithm } from '../domain/models/FixityAlgorithm'
 import { RestrictFileDTO } from '../domain/useCases/restrictFileDTO'
 import { FileMetadataDTO } from '@/files/domain/useCases/DTOs/FileMetadataDTO'
 import { JSDataverseReadErrorHandler } from '@/shared/helpers/JSDataverseReadErrorHandler'
-import { FileVersionSummaryInfo } from '../domain/models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '../domain/models/FileVersionSummaryInfo'
 
 const includeDeaccessioned = true
 
@@ -249,8 +249,12 @@ export class FileJSDataverseRepository implements FileRepository {
         throw new Error(error.message)
       })
   }
-  getFileVersionSummaries(fileId: number | string): Promise<FileVersionSummaryInfo[]> {
-    return getFileVersionSummaries.execute(fileId)
+  getFileVersionSummaries(
+    fileId: number | string,
+    limit?: number,
+    offset?: number
+  ): Promise<FileVersionSummarySubset> {
+    return getFileVersionSummaries.execute(fileId, limit, offset)
   }
 
   getById(id: number, datasetVersionNumber?: string): Promise<File> {

--- a/src/sections/account/my-data-section/useGetMyDataAccumulatedItems.tsx
+++ b/src/sections/account/my-data-section/useGetMyDataAccumulatedItems.tsx
@@ -8,6 +8,7 @@ import {
   MyDataCollectionItemSubset,
   PublicationStatusCount
 } from '@/collection/domain/models/MyDataCollectionItemSubset'
+import { MyDataCollectionItemsPaginationInfo } from '@/collection/domain/models/MyDataCollectionItemsPaginationInfo'
 
 export const NO_COLLECTION_ITEMS = 0
 
@@ -120,13 +121,17 @@ async function loadNextItems(
   searchCriteria: MyDataSearchCriteria
 ): Promise<MyDataCollectionItemSubset> {
   const publicationStatuses = searchCriteria.publicationStatuses ?? []
+  const myDataPaginationInfo = new MyDataCollectionItemsPaginationInfo(
+    paginationInfo.page,
+    paginationInfo.pageSize,
+    paginationInfo.totalItems
+  )
   return await getMyDataCollectionItems(
     collectionRepository,
     searchCriteria.roleIds,
     searchCriteria.itemTypes,
     publicationStatuses,
-    paginationInfo.pageSize,
-    paginationInfo.page,
+    myDataPaginationInfo,
     searchCriteria.searchText,
     searchCriteria.otherUserName
   )

--- a/src/sections/account/my-data-section/useGetMyDataAccumulatedItems.tsx
+++ b/src/sections/account/my-data-section/useGetMyDataAccumulatedItems.tsx
@@ -8,7 +8,6 @@ import {
   MyDataCollectionItemSubset,
   PublicationStatusCount
 } from '@/collection/domain/models/MyDataCollectionItemSubset'
-import { MyDataCollectionItemsPaginationInfo } from '@/collection/domain/models/MyDataCollectionItemsPaginationInfo'
 
 export const NO_COLLECTION_ITEMS = 0
 
@@ -121,17 +120,12 @@ async function loadNextItems(
   searchCriteria: MyDataSearchCriteria
 ): Promise<MyDataCollectionItemSubset> {
   const publicationStatuses = searchCriteria.publicationStatuses ?? []
-  const myDataPaginationInfo = new MyDataCollectionItemsPaginationInfo(
-    paginationInfo.page,
-    paginationInfo.pageSize,
-    paginationInfo.totalItems
-  )
   return await getMyDataCollectionItems(
     collectionRepository,
     searchCriteria.roleIds,
     searchCriteria.itemTypes,
     publicationStatuses,
-    myDataPaginationInfo,
+    paginationInfo,
     searchCriteria.searchText,
     searchCriteria.otherUserName
   )

--- a/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
+++ b/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
@@ -7,7 +7,7 @@ interface UseGetDatasetVersionsSummaries {
   datasetVersionSummaries: DatasetVersionSummaryInfo[] | undefined
   error: string | null
   isLoading: boolean
-  fetchSummaries: () => Promise<void>
+  fetchSummaries: (limit?: number, offset?: number) => Promise<void>
 }
 
 interface Props {
@@ -25,23 +25,31 @@ export const useGetDatasetVersionsSummaries = ({
   const [isLoading, setIsLoading] = useState<boolean>(autoFetch)
   const [error, setError] = useState<string | null>(null)
 
-  const fetchSummaries = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
+  const fetchSummaries = useCallback(
+    async (limit?: number, offset?: number) => {
+      setIsLoading(true)
+      setError(null)
 
-    try {
-      const versionSummaries = await getDatasetVersionsSummaries(datasetRepository, persistentId)
-      setSummaries(versionSummaries)
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error && err.message
-          ? err.message
-          : 'Something went wrong getting the information from the dataset versions summaries. Try again later.'
-      setError(errorMessage)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [datasetRepository, persistentId])
+      try {
+        const versionSummaries = await getDatasetVersionsSummaries(
+          datasetRepository,
+          persistentId,
+          limit,
+          offset
+        )
+        setSummaries(versionSummaries.summaries)
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error && err.message
+            ? err.message
+            : 'Something went wrong getting the information from the dataset versions summaries. Try again later.'
+        setError(errorMessage)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [datasetRepository, persistentId]
+  )
 
   useEffect(() => {
     if (autoFetch) {

--- a/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
+++ b/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useState } from 'react'
 import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
 import { getDatasetVersionsSummaries } from '@/dataset/domain/useCases/getDatasetVersionsSummaries'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 
 interface UseGetDatasetVersionsSummaries {
   datasetVersionSummaries: DatasetVersionSummaryInfo[] | undefined
   error: string | null
   isLoading: boolean
-  fetchSummaries: (limit?: number, offset?: number) => Promise<void>
+  fetchSummaries: (paginationInfo?: DatasetVersionPaginationInfo) => Promise<void>
 }
 
 interface Props {
@@ -26,7 +27,7 @@ export const useGetDatasetVersionsSummaries = ({
   const [error, setError] = useState<string | null>(null)
 
   const fetchSummaries = useCallback(
-    async (limit?: number, offset?: number) => {
+    async (paginationInfo?: DatasetVersionPaginationInfo) => {
       setIsLoading(true)
       setError(null)
 
@@ -34,8 +35,7 @@ export const useGetDatasetVersionsSummaries = ({
         const versionSummaries = await getDatasetVersionsSummaries(
           datasetRepository,
           persistentId,
-          limit,
-          offset
+          paginationInfo
         )
         setSummaries(versionSummaries.summaries)
       } catch (err) {

--- a/src/sections/file/file-version/useGetFileVersionsSummaries.ts
+++ b/src/sections/file/file-version/useGetFileVersionsSummaries.ts
@@ -7,7 +7,7 @@ interface UseGetFileVersionsSummaries {
   fileVersionSummaries: FileVersionSummaryInfo[] | undefined
   error: string | null
   isLoading: boolean
-  fetchSummaries: () => Promise<void>
+  fetchSummaries: (limit?: number, offset?: number) => Promise<void>
 }
 
 interface Props {
@@ -25,22 +25,30 @@ export const useGetFileVersionsSummaries = ({
   const [isLoading, setIsLoading] = useState<boolean>(autoFetch)
   const [error, setError] = useState<string | null>(null)
 
-  const fetchSummaries = useCallback(async () => {
-    setIsLoading(true)
-    setError(null)
-    try {
-      const versionSummaries = await getFileVersionSummaries(fileRepository, fileId)
-      setSummaries(versionSummaries)
-    } catch (err) {
-      const errorMessage =
-        err instanceof Error && err.message
-          ? err.message
-          : 'Something went wrong getting the information from the file versions summaries. Try again later.'
-      setError(errorMessage)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [fileRepository, fileId])
+  const fetchSummaries = useCallback(
+    async (limit?: number, offset?: number) => {
+      setIsLoading(true)
+      setError(null)
+      try {
+        const versionSummaries = await getFileVersionSummaries(
+          fileRepository,
+          fileId,
+          limit,
+          offset
+        )
+        setSummaries(versionSummaries.summaries)
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error && err.message
+            ? err.message
+            : 'Something went wrong getting the information from the file versions summaries. Try again later.'
+        setError(errorMessage)
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [fileRepository, fileId]
+  )
 
   useEffect(() => {
     if (autoFetch) {

--- a/src/sections/file/file-version/useGetFileVersionsSummaries.ts
+++ b/src/sections/file/file-version/useGetFileVersionsSummaries.ts
@@ -2,12 +2,13 @@ import { useCallback, useEffect, useState } from 'react'
 import { FileVersionSummaryInfo } from '@/files/domain/models/FileVersionSummaryInfo'
 import { FileRepository } from '@/files/domain/repositories/FileRepository'
 import { getFileVersionSummaries } from '@/files/domain/useCases/getFileVersionSummaries'
+import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
 
 interface UseGetFileVersionsSummaries {
   fileVersionSummaries: FileVersionSummaryInfo[] | undefined
   error: string | null
   isLoading: boolean
-  fetchSummaries: (limit?: number, offset?: number) => Promise<void>
+  fetchSummaries: (paginationInfo?: FileVersionPaginationInfo) => Promise<void>
 }
 
 interface Props {
@@ -26,15 +27,14 @@ export const useGetFileVersionsSummaries = ({
   const [error, setError] = useState<string | null>(null)
 
   const fetchSummaries = useCallback(
-    async (limit?: number, offset?: number) => {
+    async (paginationInfo?: FileVersionPaginationInfo) => {
       setIsLoading(true)
       setError(null)
       try {
         const versionSummaries = await getFileVersionSummaries(
           fileRepository,
           fileId,
-          limit,
-          offset
+          paginationInfo
         )
         setSummaries(versionSummaries.summaries)
       } catch (err) {

--- a/src/stories/collection/CollectionMockRepository.ts
+++ b/src/stories/collection/CollectionMockRepository.ts
@@ -19,6 +19,7 @@ import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { LinkingObjectType } from '@/collection/domain/useCases/getCollectionsForLinking'
 import { CollectionSummaryMother } from '@tests/component/collection/domain/models/CollectionSummaryMother'
 import { CollectionLinks } from '@/collection/domain/models/CollectionLinks'
+import { MyDataCollectionItemsPaginationInfo } from '@/collection/domain/models/MyDataCollectionItemsPaginationInfo'
 
 export class CollectionMockRepository implements CollectionRepository {
   getById(_id?: string): Promise<Collection> {
@@ -101,14 +102,11 @@ export class CollectionMockRepository implements CollectionRepository {
     _roleIds: number[],
     collectionItemTypes: CollectionItemType[],
     _publicationStatuses: string[],
-    limit?: number,
-    _selectedPage?: number,
+    paginationInfo?: MyDataCollectionItemsPaginationInfo,
     _searchText?: string,
     _otherUserName?: string
   ): Promise<MyDataCollectionItemSubset> {
-    if (!limit) {
-      limit = 10
-    }
+    const limit = paginationInfo?.pageSize ?? 10
     const numberOfCollections = Math.floor(limit / 3)
     const numberOfDatasets = Math.floor(limit / 3)
     const numberOfFiles = limit - numberOfCollections - numberOfDatasets

--- a/src/stories/collection/CollectionMockRepository.ts
+++ b/src/stories/collection/CollectionMockRepository.ts
@@ -19,7 +19,6 @@ import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { LinkingObjectType } from '@/collection/domain/useCases/getCollectionsForLinking'
 import { CollectionSummaryMother } from '@tests/component/collection/domain/models/CollectionSummaryMother'
 import { CollectionLinks } from '@/collection/domain/models/CollectionLinks'
-import { MyDataCollectionItemsPaginationInfo } from '@/collection/domain/models/MyDataCollectionItemsPaginationInfo'
 
 export class CollectionMockRepository implements CollectionRepository {
   getById(_id?: string): Promise<Collection> {
@@ -102,7 +101,7 @@ export class CollectionMockRepository implements CollectionRepository {
     _roleIds: number[],
     collectionItemTypes: CollectionItemType[],
     _publicationStatuses: string[],
-    paginationInfo?: MyDataCollectionItemsPaginationInfo,
+    paginationInfo?: CollectionItemsPaginationInfo,
     _searchText?: string,
     _otherUserName?: string
   ): Promise<MyDataCollectionItemSubset> {

--- a/src/stories/dataset/DatasetErrorMockRepository.ts
+++ b/src/stories/dataset/DatasetErrorMockRepository.ts
@@ -6,8 +6,8 @@ import { DatasetDTO } from '../../dataset/domain/useCases/DTOs/DatasetDTO'
 import { FakerHelper } from '../../../tests/component/shared/FakerHelper'
 import { VersionUpdateType } from '../../dataset/domain/models/VersionUpdateType'
 import { DatasetVersionDiff } from '@/dataset/domain/models/DatasetVersionDiff'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetDeaccessionDTO } from '@iqss/dataverse-client-javascript'
+import { DatasetVersionSummarySubset } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetDownloadCount } from '@/dataset/domain/models/DatasetDownloadCount'
 import { CitationFormat, FormattedCitation } from '@/dataset/domain/models/DatasetCitation'
 import { DatasetTemplate } from '@/dataset/domain/models/DatasetTemplate'
@@ -87,7 +87,11 @@ export class DatasetErrorMockRepository implements DatasetMockRepository {
     })
   }
 
-  getDatasetVersionsSummaries(_datasetId: number | string): Promise<DatasetVersionSummaryInfo[]> {
+  getDatasetVersionsSummaries(
+    _datasetId: number | string,
+    _limit?: number,
+    _offset?: number
+  ): Promise<DatasetVersionSummarySubset> {
     return new Promise((_resolve, reject) => {
       setTimeout(() => {
         reject('Error thrown from mock')

--- a/src/stories/dataset/DatasetErrorMockRepository.ts
+++ b/src/stories/dataset/DatasetErrorMockRepository.ts
@@ -12,6 +12,7 @@ import { DatasetDownloadCount } from '@/dataset/domain/models/DatasetDownloadCou
 import { CitationFormat, FormattedCitation } from '@/dataset/domain/models/DatasetCitation'
 import { DatasetTemplate } from '@/dataset/domain/models/DatasetTemplate'
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 
 export class DatasetErrorMockRepository implements DatasetMockRepository {
   getAllWithCount: (
@@ -89,8 +90,7 @@ export class DatasetErrorMockRepository implements DatasetMockRepository {
 
   getDatasetVersionsSummaries(
     _datasetId: number | string,
-    _limit?: number,
-    _offset?: number
+    _paginationInfo?: DatasetVersionPaginationInfo
   ): Promise<DatasetVersionSummarySubset> {
     return new Promise((_resolve, reject) => {
       setTimeout(() => {

--- a/src/stories/dataset/DatasetLoadingMockRepository.ts
+++ b/src/stories/dataset/DatasetLoadingMockRepository.ts
@@ -2,6 +2,7 @@ import { DatasetMockRepository } from './DatasetMockRepository'
 import { DatasetPaginationInfo } from '../../dataset/domain/models/DatasetPaginationInfo'
 import { DatasetsWithCount } from '../../dataset/domain/models/DatasetsWithCount'
 import { DatasetVersionSummarySubset } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 
 export class DatasetLoadingMockRepository extends DatasetMockRepository {
   getDatasetsWithCount: (
@@ -16,8 +17,7 @@ export class DatasetLoadingMockRepository extends DatasetMockRepository {
 
   getDatasetVersionsSummaries(
     _datasetId: number | string,
-    _limit?: number,
-    _offset?: number
+    _paginationInfo?: DatasetVersionPaginationInfo
   ): Promise<DatasetVersionSummarySubset> {
     return new Promise(() => {})
   }

--- a/src/stories/dataset/DatasetLoadingMockRepository.ts
+++ b/src/stories/dataset/DatasetLoadingMockRepository.ts
@@ -1,7 +1,7 @@
 import { DatasetMockRepository } from './DatasetMockRepository'
 import { DatasetPaginationInfo } from '../../dataset/domain/models/DatasetPaginationInfo'
 import { DatasetsWithCount } from '../../dataset/domain/models/DatasetsWithCount'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 
 export class DatasetLoadingMockRepository extends DatasetMockRepository {
   getDatasetsWithCount: (
@@ -14,7 +14,11 @@ export class DatasetLoadingMockRepository extends DatasetMockRepository {
     return new Promise(() => {})
   }
 
-  getDatasetVersionsSummaries(_datasetId: number | string): Promise<DatasetVersionSummaryInfo[]> {
+  getDatasetVersionsSummaries(
+    _datasetId: number | string,
+    _limit?: number,
+    _offset?: number
+  ): Promise<DatasetVersionSummarySubset> {
     return new Promise(() => {})
   }
 }

--- a/src/stories/dataset/DatasetMockRepository.ts
+++ b/src/stories/dataset/DatasetMockRepository.ts
@@ -19,6 +19,7 @@ import { DatasetTemplate } from '@/dataset/domain/models/DatasetTemplate'
 import { DatasetTemplateMother } from '@tests/component/dataset/domain/models/DatasetTemplateMother'
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { CollectionSummaryMother } from '@tests/component/collection/domain/models/CollectionSummaryMother'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 
 export class DatasetMockRepository implements DatasetRepository {
   getAllWithCount: (
@@ -100,8 +101,7 @@ export class DatasetMockRepository implements DatasetRepository {
 
   getDatasetVersionsSummaries(
     _datasetId: number | string,
-    _limit?: number,
-    _offset?: number
+    _paginationInfo?: DatasetVersionPaginationInfo
   ): Promise<DatasetVersionSummarySubset> {
     return new Promise((resolve) => {
       setTimeout(() => {

--- a/src/stories/dataset/DatasetMockRepository.ts
+++ b/src/stories/dataset/DatasetMockRepository.ts
@@ -10,7 +10,7 @@ import { DatasetDTO } from '../../dataset/domain/useCases/DTOs/DatasetDTO'
 import { DatasetsWithCount } from '../../dataset/domain/models/DatasetsWithCount'
 import { FakerHelper } from '../../../tests/component/shared/FakerHelper'
 import { VersionUpdateType } from '../../dataset/domain/models/VersionUpdateType'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import { DatasetVersionSummarySubset } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetDeaccessionDTO } from '@iqss/dataverse-client-javascript'
 import { DatasetDownloadCount } from '@/dataset/domain/models/DatasetDownloadCount'
 import { DatasetDownloadCountMother } from '@tests/component/dataset/domain/models/DatasetDownloadCountMother'
@@ -98,7 +98,11 @@ export class DatasetMockRepository implements DatasetRepository {
     })
   }
 
-  getDatasetVersionsSummaries(_datasetId: number | string): Promise<DatasetVersionSummaryInfo[]> {
+  getDatasetVersionsSummaries(
+    _datasetId: number | string,
+    _limit?: number,
+    _offset?: number
+  ): Promise<DatasetVersionSummarySubset> {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve(DatasetVersionsSummariesMother.create())

--- a/src/stories/dataset/deaccession-dataset/DeaccessionDatasetModal.stories.tsx
+++ b/src/stories/dataset/deaccession-dataset/DeaccessionDatasetModal.stories.tsx
@@ -37,15 +37,18 @@ export const WithOneVersion: Story = {
     datasetMockRepository.getDatasetVersionsSummaries = () => {
       return new Promise((resolve) => {
         setTimeout(() => {
-          resolve([
-            {
-              id: 1,
-              contributors: 'contributors',
-              versionNumber: '1.0',
-              publishedOn: '2023-01-01',
-              summary: DatasetVersionSummaryStringValues.firstPublished
-            }
-          ])
+          resolve({
+            summaries: [
+              {
+                id: 1,
+                contributors: 'contributors',
+                versionNumber: '1.0',
+                publishedOn: '2023-01-01',
+                summary: DatasetVersionSummaryStringValues.firstPublished
+              }
+            ],
+            totalCount: 1
+          })
         }, 1_000)
       })
     }

--- a/src/stories/file/FileMockRepository.ts
+++ b/src/stories/file/FileMockRepository.ts
@@ -17,7 +17,7 @@ import { UploadedFileDTO } from '@iqss/dataverse-client-javascript'
 import { FixityAlgorithm } from '@/files/domain/models/FixityAlgorithm'
 import { FileMetadataDTO } from '@/files/domain/useCases/DTOs/FileMetadataDTO'
 import { RestrictFileDTO } from '@/files/domain/useCases/restrictFileDTO'
-import { FileVersionSummaryInfo } from '@/files/domain/models/FileVersionSummaryInfo'
+import { FileVersionSummarySubset } from '@/files/domain/models/FileVersionSummaryInfo'
 
 export class FileMockRepository implements FileRepository {
   constructor(public readonly fileMock?: File) {}
@@ -158,10 +158,15 @@ export class FileMockRepository implements FileRepository {
     })
   }
 
-  getFileVersionSummaries(_id: number | string): Promise<FileVersionSummaryInfo[]> {
+  getFileVersionSummaries(
+    _id: number | string,
+    _limit?: number,
+    _offset?: number
+  ): Promise<FileVersionSummarySubset> {
     return new Promise((resolve) => {
       setTimeout(() => {
-        resolve(FileMother.createFileVersionSummary())
+        const summaries = FileMother.createFileVersionSummary()
+        resolve({ summaries, totalCount: summaries.length })
       }, FakerHelper.loadingTimout())
     })
   }

--- a/src/stories/file/FileMockRepository.ts
+++ b/src/stories/file/FileMockRepository.ts
@@ -18,6 +18,7 @@ import { FixityAlgorithm } from '@/files/domain/models/FixityAlgorithm'
 import { FileMetadataDTO } from '@/files/domain/useCases/DTOs/FileMetadataDTO'
 import { RestrictFileDTO } from '@/files/domain/useCases/restrictFileDTO'
 import { FileVersionSummarySubset } from '@/files/domain/models/FileVersionSummaryInfo'
+import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
 
 export class FileMockRepository implements FileRepository {
   constructor(public readonly fileMock?: File) {}
@@ -160,8 +161,7 @@ export class FileMockRepository implements FileRepository {
 
   getFileVersionSummaries(
     _id: number | string,
-    _limit?: number,
-    _offset?: number
+    _paginationInfo?: FileVersionPaginationInfo
   ): Promise<FileVersionSummarySubset> {
     return new Promise((resolve) => {
       setTimeout(() => {

--- a/tests/component/dataset/domain/models/DatasetVersionsSummariesMother.ts
+++ b/tests/component/dataset/domain/models/DatasetVersionsSummariesMother.ts
@@ -1,11 +1,12 @@
 import {
   DatasetVersionSummaryInfo,
   DatasetVersionSummaryStringValues,
+  DatasetVersionSummarySubset,
   Deaccessioned
 } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 
 export class DatasetVersionsSummariesMother {
-  static create(): DatasetVersionSummaryInfo[] {
+  static create(): DatasetVersionSummarySubset {
     const versionSummaryInfo: DatasetVersionSummaryInfo[] = [
       {
         id: 11,
@@ -103,10 +104,13 @@ export class DatasetVersionsSummariesMother {
         publishedOn: '2025-03-11'
       }
     ]
-    return versionSummaryInfo
+    return {
+      summaries: versionSummaryInfo,
+      totalCount: versionSummaryInfo.length
+    }
   }
 
-  static createDeaccessioned(): DatasetVersionSummaryInfo[] {
+  static createDeaccessioned(): DatasetVersionSummarySubset {
     const deaccessioned: Deaccessioned = {
       reason: 'deaccessioned test'
     }
@@ -160,6 +164,9 @@ export class DatasetVersionsSummariesMother {
         publishedOn: '2025-03-11'
       }
     ]
-    return versionSummaryInfo
+    return {
+      summaries: versionSummaryInfo,
+      totalCount: versionSummaryInfo.length
+    }
   }
 }

--- a/tests/component/sections/account/MyDataItemsPanel.spec.tsx
+++ b/tests/component/sections/account/MyDataItemsPanel.spec.tsx
@@ -159,8 +159,7 @@ describe('MyDataItemsPanel', () => {
         Cypress.sinon.match.any,
         Cypress.sinon.match.any,
         Cypress.sinon.match.any,
-        10,
-        1,
+        Cypress.sinon.match.has('pageSize', 10).and(Cypress.sinon.match.has('page', 1)),
         undefined,
         otherUsername
       )
@@ -185,8 +184,7 @@ describe('MyDataItemsPanel', () => {
         Cypress.sinon.match.any,
         Cypress.sinon.match.any,
         Cypress.sinon.match.any,
-        10,
-        1,
+        Cypress.sinon.match.has('pageSize', 10).and(Cypress.sinon.match.has('page', 1)),
         undefined,
         'testUserName'
       )

--- a/tests/component/sections/dataset/Dataset.spec.tsx
+++ b/tests/component/sections/dataset/Dataset.spec.tsx
@@ -648,7 +648,9 @@ describe('Dataset', () => {
   })
 
   it('renders the Dataset Version tab', () => {
-    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
+    datasetRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves({ summaries: versionSummaryInfo, totalCount: versionSummaryInfo.length })
 
     mountWithDataset(
       <Dataset

--- a/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/DeaccessionDatasetButton.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/edit-dataset-menu/DeaccessionDatasetButton.spec.tsx
@@ -30,9 +30,13 @@ describe('DeaccessionDatasetButton', () => {
       summary: {}
     })
   ]
+  const versionSummariesSubset = {
+    summaries: versionSummaries,
+    totalCount: versionSummaries.length
+  }
 
   beforeEach(() => {
-    repository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaries)
+    repository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummariesSubset)
   })
 
   it('renders the DeaccessionDatasetButton if the user has publish dataset permissions and the dataset is released', () => {
@@ -118,7 +122,9 @@ describe('DeaccessionDatasetButton', () => {
         })
       ]
 
-      repository.getDatasetVersionsSummaries = cy.stub().resolves(singleVersionList)
+      repository.getDatasetVersionsSummaries = cy
+        .stub()
+        .resolves({ summaries: singleVersionList, totalCount: singleVersionList.length })
 
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
@@ -156,7 +162,9 @@ describe('DeaccessionDatasetButton', () => {
           summary: {}
         }
       ]
-      repository.getDatasetVersionsSummaries = cy.stub().resolves(singleVersionList)
+      repository.getDatasetVersionsSummaries = cy
+        .stub()
+        .resolves({ summaries: singleVersionList, totalCount: singleVersionList.length })
 
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
@@ -249,9 +257,10 @@ describe('DeaccessionDatasetButton', () => {
         publishedOn: '2021-01-02',
         id: 2
       })
-      repository.getDatasetVersionsSummaries = cy
-        .stub()
-        .resolves([versionSummary1, versionSummary2])
+      repository.getDatasetVersionsSummaries = cy.stub().resolves({
+        summaries: [versionSummary1, versionSummary2],
+        totalCount: 2
+      })
       repository.deaccession = cy.stub().resolves()
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
@@ -300,7 +309,9 @@ describe('DeaccessionDatasetButton', () => {
           summary: {}
         }
       ]
-      repository.getDatasetVersionsSummaries = cy.stub().resolves(versionsSummaries)
+      repository.getDatasetVersionsSummaries = cy
+        .stub()
+        .resolves({ summaries: versionsSummaries, totalCount: versionsSummaries.length })
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),
         version: DatasetVersionMother.createReleased()
@@ -339,7 +350,9 @@ describe('DeaccessionDatasetButton', () => {
         }
       ]
 
-      repository.getDatasetVersionsSummaries = cy.stub().resolves(versionsSummaries)
+      repository.getDatasetVersionsSummaries = cy
+        .stub()
+        .resolves({ summaries: versionsSummaries, totalCount: versionsSummaries.length })
 
       const dataset = DatasetMother.create({
         permissions: DatasetPermissionsMother.createWithPublishingDatasetAllowed(),

--- a/tests/component/sections/dataset/dataset-versions/DatasetVersions.spec.tsx
+++ b/tests/component/sections/dataset/dataset-versions/DatasetVersions.spec.tsx
@@ -1,5 +1,8 @@
 import { DatasetVersions } from '@/sections/dataset/dataset-versions/DatasetVersions'
-import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
+import {
+  DatasetVersionSummaryInfo,
+  DatasetVersionSummarySubset
+} from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
 import { DatasetVersionDiff } from '@/dataset/domain/models/DatasetVersionDiff'
 import { DatasetVersionState } from '@/dataset/domain/models/Dataset'
@@ -8,7 +11,7 @@ import { DatasetVersionDiffMother } from '../../../dataset/domain/models/Dataset
 
 const datasetsRepository: DatasetRepository = {} as DatasetRepository
 
-const versionSummaryInfo: DatasetVersionSummaryInfo[] = DatasetVersionsSummariesMother.create()
+const versionSummariesSubset = DatasetVersionsSummariesMother.create()
 
 const versionSummaryInfoDraft: DatasetVersionSummaryInfo[] = [
   {
@@ -39,7 +42,10 @@ const datasetVersionDiff: DatasetVersionDiff = DatasetVersionDiffMother.create()
 
 describe('DatasetVersions', () => {
   it('should render the dataset versions table without view differences button and checkbox', () => {
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfoDraft)
+    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves({
+      summaries: versionSummaryInfoDraft,
+      totalCount: versionSummaryInfoDraft.length
+    })
     cy.findByTestId('dataset-versions-table').should('exist')
 
     cy.contains('th', 'Dataset Version').should('exist')
@@ -64,7 +70,7 @@ describe('DatasetVersions', () => {
         isInView
       />
     )
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
+    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummariesSubset)
     datasetsRepository.getVersionDiff = cy.stub().resolves(datasetVersionDiff)
   })
 
@@ -81,7 +87,7 @@ describe('DatasetVersions', () => {
 
     cy.findByRole('button', { name: 'View Differences' }).should('exist')
 
-    versionSummaryInfo.forEach((version) => {
+    versionSummariesSubset.summaries.forEach((version) => {
       cy.contains('td', version.versionNumber).should('exist')
       cy.contains('td', version.contributors).should('exist')
       if (version.publishedOn) {
@@ -102,7 +108,7 @@ describe('DatasetVersions', () => {
   })
 
   it('should render the dataset versions table without view differences button if less than 2 versions being selected', () => {
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
+    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummariesSubset)
 
     cy.findByTestId('dataset-versions-table').should('exist')
     cy.contains('th', 'Dataset Version').should('exist')
@@ -121,14 +127,14 @@ describe('DatasetVersions', () => {
   })
 
   it('should not show view detail buttons if there is only one version', () => {
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
+    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummariesSubset)
 
     cy.findByTestId('dataset-versions-table').should('exist')
     cy.get('tr').eq(1).find('td').eq(2).findByText('View Details').should('exist').click()
   })
 
   it('should open dataset versions detail modal', () => {
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
+    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummariesSubset)
 
     cy.findByTestId('dataset-versions-table').should('exist')
     cy.get('tr').eq(1).find('td').eq(2).findByText('View Details').should('exist').click()
@@ -136,7 +142,7 @@ describe('DatasetVersions', () => {
   })
 
   it('should close dataset versions detail modal', () => {
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummaryInfo)
+    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(versionSummariesSubset)
 
     cy.findByTestId('dataset-versions-table').should('exist')
     cy.get('tr').eq(1).find('td').eq(2).findByText('View Details').should('exist').click()
@@ -159,7 +165,9 @@ describe('DatasetVersions', () => {
   })
 
   it('should render loading skeleton if the dataset version is loading', () => {
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().returns(new Promise(() => {}))
+    datasetsRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .returns(new Promise<DatasetVersionSummarySubset>(() => {}))
     cy.customMount(
       <DatasetVersions
         datasetId={'datasetId'}
@@ -256,7 +264,9 @@ describe('DatasetVersions', () => {
       { id: 2, versionNumber: '2.0', contributors: '' },
       { id: 3, versionNumber: '3.0', contributors: '' }
     ]
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(ascendingVersions)
+    datasetsRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves({ summaries: ascendingVersions, totalCount: ascendingVersions.length })
     const diffStub = (datasetsRepository.getVersionDiff = cy
       .stub()
       .callsFake((pid: string, oldV: string, newV: string) =>
@@ -300,7 +310,9 @@ describe('DatasetVersions', () => {
       { id: 4, versionNumber: '4.0', contributors: '' },
       { id: 3, versionNumber: '3.0', contributors: '' }
     ]
-    datasetsRepository.getDatasetVersionsSummaries = cy.stub().resolves(descendingVersions)
+    datasetsRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves({ summaries: descendingVersions, totalCount: descendingVersions.length })
     const diffStub = (datasetsRepository.getVersionDiff = cy
       .stub()
       .callsFake((pid: string, oldV: string, newV: string) =>

--- a/tests/component/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.spec.tsx
+++ b/tests/component/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.spec.tsx
@@ -1,18 +1,19 @@
 import { act, renderHook } from '@testing-library/react'
 import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
-import { DatasetVersionSummary } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { ReadError } from '@iqss/dataverse-client-javascript'
 import { DatasetVersionsSummariesMother } from '@tests/component/dataset/domain/models/DatasetVersionsSummariesMother'
 import { useGetDatasetVersionsSummaries } from '@/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
 
-const datasetVersionsSummariesMock: DatasetVersionSummary[] =
-  DatasetVersionsSummariesMother.create() as unknown as DatasetVersionSummary[]
+const datasetVersionsSummariesSubsetMock = DatasetVersionsSummariesMother.create()
+const datasetVersionsSummariesMock = datasetVersionsSummariesSubsetMock.summaries
 
 describe('useGetDatasetVersionsSummaries', () => {
   it('should return dataset version summaries correctly', async () => {
-    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(datasetVersionsSummariesMock)
+    datasetRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves(datasetVersionsSummariesSubsetMock)
     const { result } = renderHook(() =>
       useGetDatasetVersionsSummaries({
         datasetRepository,
@@ -78,7 +79,9 @@ describe('useGetDatasetVersionsSummaries', () => {
   })
 
   it('should fetch summaries when fetchSummaries is called', () => {
-    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(datasetVersionsSummariesMock)
+    datasetRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves(datasetVersionsSummariesSubsetMock)
 
     const { result } = renderHook(() =>
       useGetDatasetVersionsSummaries({
@@ -108,7 +111,9 @@ describe('useGetDatasetVersionsSummaries', () => {
   })
 
   it('should not fetch summaries if autoFetch is false', async () => {
-    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(datasetVersionsSummariesMock)
+    datasetRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves(datasetVersionsSummariesSubsetMock)
 
     const { result } = renderHook(() =>
       useGetDatasetVersionsSummaries({

--- a/tests/component/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx
+++ b/tests/component/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx
@@ -27,7 +27,9 @@ describe('EditDatasetMetadata', () => {
       .stub()
       .resolves(metadataBlocksInfoOnCreateMode)
     datasetRepository.updateMetadata = cy.stub().resolves(undefined)
-    datasetRepository.getDatasetVersionsSummaries = cy.stub().resolves(undefined)
+    datasetRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves({ summaries: [], totalCount: 0 })
 
     cy.customMount(
       <LoadingProvider>

--- a/tests/component/sections/file/file-version/FileVersions.spec.tsx
+++ b/tests/component/sections/file/file-version/FileVersions.spec.tsx
@@ -5,11 +5,15 @@ import { DatasetVersionState } from '@iqss/dataverse-client-javascript'
 import { QueryParamKey, Route } from '@/sections/Route.enum'
 
 const fileVersionSummaries = FileMother.createFileVersionSummary()
+const fileVersionSummariesSubset = {
+  summaries: fileVersionSummaries,
+  totalCount: fileVersionSummaries.length
+}
 const fileRepository: FileRepository = {} as FileRepository
 
 describe('FileVersions', () => {
   it('renders version rows and metadata correctly', () => {
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummaries)
+    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummariesSubset)
     cy.customMount(
       <FileVersions
         fileId={1}
@@ -48,7 +52,9 @@ describe('FileVersions', () => {
         versionState: DatasetVersionState.DEACCESSIONED
       }
     ]
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(deaccessionedFile)
+    fileRepository.getFileVersionSummaries = cy
+      .stub()
+      .resolves({ summaries: deaccessionedFile, totalCount: deaccessionedFile.length })
     cy.customMount(
       <FileVersions
         fileId={1}
@@ -75,7 +81,9 @@ describe('FileVersions', () => {
         versionState: DatasetVersionState.DEACCESSIONED
       }
     ]
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(deaccessionedFile)
+    fileRepository.getFileVersionSummaries = cy
+      .stub()
+      .resolves({ summaries: deaccessionedFile, totalCount: deaccessionedFile.length })
     cy.customMount(
       <FileVersions
         fileId={1}
@@ -98,7 +106,9 @@ describe('FileVersions', () => {
         versionState: DatasetVersionState.DRAFT
       }
     ]
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(draftFile)
+    fileRepository.getFileVersionSummaries = cy
+      .stub()
+      .resolves({ summaries: draftFile, totalCount: draftFile.length })
     cy.customMount(
       <FileVersions
         fileId={1}
@@ -115,7 +125,9 @@ describe('FileVersions', () => {
   it('the version number should be disable and bold if it is the current version', () => {
     const currentFile = [{ ...fileVersionSummaries[0], datasetVersion: '2.0' }]
 
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(currentFile)
+    fileRepository.getFileVersionSummaries = cy
+      .stub()
+      .resolves({ summaries: currentFile, totalCount: currentFile.length })
     cy.customMount(
       <FileVersions
         fileId={1}

--- a/tests/component/sections/file/file-version/useGetFileVersionsSummaries.spec.tsx
+++ b/tests/component/sections/file/file-version/useGetFileVersionsSummaries.spec.tsx
@@ -5,11 +5,15 @@ import { act, renderHook } from '@testing-library/react'
 import { ReadError } from '@iqss/dataverse-client-javascript'
 
 const fileVersionSummaries = FileMother.createFileVersionSummary()
+const fileVersionSummariesSubset = {
+  summaries: fileVersionSummaries,
+  totalCount: fileVersionSummaries.length
+}
 const fileRepository: FileRepository = {} as FileRepository
 
 describe('useGetFileVersionsSummaries', () => {
   it('should return file version summaries correctly', async () => {
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummaries)
+    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummariesSubset)
     const { result } = renderHook(() =>
       useGetFileVersionsSummaries({
         fileRepository,
@@ -75,7 +79,7 @@ describe('useGetFileVersionsSummaries', () => {
   })
 
   it('should not fetch data if autoFetch is false', async () => {
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummaries)
+    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummariesSubset)
     const { result } = renderHook(() =>
       useGetFileVersionsSummaries({
         fileRepository,
@@ -100,7 +104,7 @@ describe('useGetFileVersionsSummaries', () => {
   })
 
   it('should fetch data when refetch is called', () => {
-    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummaries)
+    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummariesSubset)
     const { result } = renderHook(() =>
       useGetFileVersionsSummaries({
         fileRepository,


### PR DESCRIPTION
## What this PR does / why we need it:
Based on JS-dataverse changes about Adding pagination query parameters to Dataset&File Version Summaries use case https://github.com/IQSS/dataverse-client-javascript/pull/395
This PR adds pagination support to the Dataset and File Version Summaries use cases by introducing optional limit and offset query parameters. This allows clients to retrieve version summaries in paginated chunks rather than loading all versions at once.

Front-end also needs to update these use cases accordingly

## Which issue(s) this PR closes:

- Closes #885 

## Special notes for your reviewer:

## Suggestions on how to test this:
it should be good if all checks pass, no ui change

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
no
## Is there a release notes or changelog update needed for this change?:
yes, breaking change

## Additional documentation:
