### PR TITLE
Fix Featured Item Style

### DIFF
--- a/src/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard.module.scss
+++ b/src/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard.module.scss
@@ -34,8 +34,17 @@
   }
 
   .content {
+    box-sizing: border-box;
+    padding-bottom: 0.25rem;
+
+    --line-height: 1.25rem;
+
+    --lines: 8;
+
+    max-height: calc(var(--line-height) * var(--lines));
     width: 100%;
     overflow: hidden;
+    position: relative;
     pointer-events: none;
 
     & * {
@@ -44,13 +53,12 @@
 
     min-height: 0;
     min-width: 0;
-
-    /* Height-based clamp */
     line-height: 1.25rem;
-    max-height: calc(1.25rem * 8);
 
     &.with_image {
-      max-height: calc(1.25rem * 4);
+      --lines: 4;
+
+      max-height: calc(var(--line-height) * var(--lines));
     }
 
     h1 {
@@ -74,7 +82,6 @@
       word-break: break-all;
     }
 
-    // Both of these are only beacuse block codes make card overflow
     :global .rte-code-block {
       white-space: pre-wrap;
       word-break: break-word;
@@ -83,6 +90,20 @@
     :global .rte-code-block code {
       white-space: pre-wrap;
       word-break: break-word;
+    }
+
+    mask-image: linear-gradient(top, rgb(0 0 0 / 100%) 60%, rgb(0 0 0 / 0%) 100%);
+    mask-image: linear-gradient(180deg, rgb(0 0 0 / 100%) 60%, rgb(0 0 0 / 0%) 100%);
+
+    &::after {
+      content: '';
+      position: absolute;
+      right: 0.5rem;
+      bottom: 0;
+      pointer-events: none;
+      color: inherit;
+      background: linear-gradient(to right, rgb(255 255 255 / 0%), var(--card-bg, #fff));
+      padding-left: 0.25rem;
     }
   }
 }

--- a/src/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard.module.scss
+++ b/src/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard.module.scss
@@ -34,10 +34,6 @@
   }
 
   .content {
-    display: -webkit-box;
-    -webkit-line-clamp: 8;
-    line-clamp: 8;
-    -webkit-box-orient: vertical;
     width: 100%;
     overflow: hidden;
     pointer-events: none;
@@ -46,9 +42,15 @@
       pointer-events: none;
     }
 
+    min-height: 0;
+    min-width: 0;
+
+    /* Height-based clamp */
+    line-height: 1.25rem;
+    max-height: calc(1.25rem * 8);
+
     &.with_image {
-      -webkit-line-clamp: 4;
-      line-clamp: 4;
+      max-height: calc(1.25rem * 4);
     }
 
     h1 {

--- a/src/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard.module.scss
+++ b/src/sections/collection/featured-items/custom-featured-item-card/CustomFeaturedItemCard.module.scss
@@ -38,7 +38,6 @@
     padding-bottom: 0.25rem;
 
     --line-height: 1.25rem;
-
     --lines: 8;
 
     max-height: calc(var(--line-height) * var(--lines));
@@ -92,8 +91,7 @@
       word-break: break-word;
     }
 
-    mask-image: linear-gradient(top, rgb(0 0 0 / 100%) 60%, rgb(0 0 0 / 0%) 100%);
-    mask-image: linear-gradient(180deg, rgb(0 0 0 / 100%) 60%, rgb(0 0 0 / 0%) 100%);
+    mask-image: linear-gradient(to bottom, rgb(0 0 0 / 100%) 60%, rgb(0 0 0 / 0%) 100%);
 
     &::after {
       content: '';


### PR DESCRIPTION


## What this PR does / why we need it:
Fixes the style for Custom Featured Items, so they display corrrectly in Safari

## Which issue(s) this PR closes:

- Closes #890

## Special notes for your reviewer:

## Suggestions on how to test this:
To test, create a custom featured Item that contains a header image, some text and bullet points, so that the content has to be trimmed in the Featured Item card.  View the Card in Safari and Chrome. It should crop the content correctly, in both browsers.  See the [issue](https://github.com/IQSS/dataverse-frontend/issues/890#issue-3597713168) for screenshot example of the problem.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No
