### PR TITLE
Rename "terms and  guestbook" based on the permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 - Changed the way we were handling DATE type metadata field validation to better match the backend validation and give users better error messages. For example, for an input like “foo AD”, we now show “Production Date is not a valid date. The AD year must be numeric.“. For an input like “99999 AD”, we now show “Production Date is not a valid date. The AD year cant be higher than 9999.“. For an input like “[-9999?], we now show “Production Date is not a valid date. The year in brackets cannot be negative.“, etc.
 - The SPA now fetches the runtime configuration from `config.js` on each load, allowing configurations without rebuilding the app. We don't use `.env` variables at build time anymore.
 - Renamed dataset template fetch/create use cases and DTOs to `getTemplatesByCollectionId` and `CreateTemplateDTO` for API alignment, and added new `getTemplate` and `deleteTemplate` use cases for retrieving a single template by ID and deleting templates.
+- Dataset page Terms tab title now depends on permissions: users with dataset update permission see `Terms and Guestbook`, and read-only users see `Terms`.
 
 ### Fixed
 
@@ -31,6 +32,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 - Show toast notification when API token is copied to clipboard.
 - Dataset versions: (1) file changes should be `Access: Restricted` instead of `isResticted: true/false`; (2) logic of View Detail button. (#879)
 - File versions: (1) logic of linking to a file version; (2)If file not included, show text information "File not included in this version.". (#879)
+- Dataset page publish flow now avoids rendering duplicate tab sets by making tabs skeleton and tabs content mutually exclusive.
 
 ### Removed
 

--- a/public/locales/en/dataset.json
+++ b/public/locales/en/dataset.json
@@ -2,6 +2,7 @@
   "filesTabTitle": "Files",
   "metadataTabTitle": "Metadata",
   "termsTabTitle": "Terms and Guestbook",
+  "termsTabTitleReadOnly": "Terms",
   "anonymizedFieldValue": "withheld",
   "customTerms": {
     "title": "Custom Dataset Terms",

--- a/public/locales/es/dataset.json
+++ b/public/locales/es/dataset.json
@@ -1,7 +1,8 @@
 {
   "filesTabTitle": "Ficheros",
   "metadataTabTitle": "Metadatos",
-  "termsTabTitle": "Términos",
+  "termsTabTitle": "Términos y libros de visitas",
+  "termsTabTitleReadOnly": "Términos",
   "anonymizedFieldValue": "retirado",
   "customTerms": {
     "title": "Términos personalizados del dataset",

--- a/src/sections/dataset/Dataset.tsx
+++ b/src/sections/dataset/Dataset.tsx
@@ -113,6 +113,7 @@ export function Dataset({
 
   const currentVersionNumber = dataset.version.number.toString()
   const canUpdateDataset = dataset.permissions.canUpdateDataset
+  const termsTabTitle = canUpdateDataset ? t('termsTabTitle') : t('termsTabTitleReadOnly')
 
   return (
     <>
@@ -164,87 +165,86 @@ export function Dataset({
             </Col>
           </Row>
 
-          {publishInProgress && <TabsSkeleton />}
-
-          {(!publishInProgress || !isDatasetLoading) &&
-            (isCurrentVersionDeaccessioned && !canUpdateDataset ? (
-              <Tabs defaultActiveKey="versions" onSelect={handleTabSelect}>
-                <Tabs.Tab eventKey="versions" title={t('Versions')}>
-                  <div className={styles['tab-container']}>
-                    <DatasetVersions
-                      datasetRepository={datasetRepository}
-                      datasetId={dataset.persistentId}
-                      currentVersionNumber={currentVersionNumber}
-                      canUpdateDataset={canUpdateDataset}
-                      isInView={activeTab === 'versions'}
-                      key={dataset.internalVersionNumber}
-                      isCurrentVersionDeaccessioned={isCurrentVersionDeaccessioned}
-                    />
-                  </div>
-                </Tabs.Tab>
-              </Tabs>
-            ) : (
-              <Tabs defaultActiveKey={activeTab} onSelect={handleTabSelect}>
-                <Tabs.Tab eventKey="files" title={t('filesTabTitle')}>
-                  <div className={styles['tab-container']}>
-                    {filesTabInfiniteScrollEnabled ? (
-                      <DatasetFilesScrollable
-                        filesRepository={fileRepository}
-                        datasetPersistentId={dataset.persistentId}
-                        datasetVersion={dataset.version}
-                        canUpdateDataset={canUpdateDataset}
-                        key={dataset.version.publishingStatus}
-                        datasetRepository={datasetRepository}
-                      />
-                    ) : (
-                      <DatasetFiles
-                        filesRepository={fileRepository}
-                        datasetPersistentId={dataset.persistentId}
-                        datasetVersion={dataset.version}
-                        datasetRepository={datasetRepository}
-                      />
-                    )}
-                  </div>
-                </Tabs.Tab>
-
-                <Tabs.Tab eventKey="metadata" title={t('metadataTabTitle')}>
-                  <div className={styles['tab-container']}>
-                    <DatasetMetadata
-                      dataset={dataset}
-                      anonymizedView={anonymizedView}
-                      metadataBlockInfoRepository={metadataBlockInfoRepository}
-                      dataverseInfoRepository={dataverseInfoRepository}
-                    />
-                  </div>
-                </Tabs.Tab>
-
-                <Tabs.Tab eventKey="terms" title={t('termsTabTitle')}>
-                  <div ref={termsTabRef} className={styles['tab-container']}>
-                    <DatasetTerms
-                      license={dataset.license}
-                      termsOfUse={dataset.termsOfUse}
+          {publishInProgress || isDatasetLoading ? (
+            <TabsSkeleton />
+          ) : isCurrentVersionDeaccessioned && !canUpdateDataset ? (
+            <Tabs defaultActiveKey="versions" onSelect={handleTabSelect}>
+              <Tabs.Tab eventKey="versions" title={t('Versions')}>
+                <div className={styles['tab-container']}>
+                  <DatasetVersions
+                    datasetRepository={datasetRepository}
+                    datasetId={dataset.persistentId}
+                    currentVersionNumber={currentVersionNumber}
+                    canUpdateDataset={canUpdateDataset}
+                    isInView={activeTab === 'versions'}
+                    key={dataset.internalVersionNumber}
+                    isCurrentVersionDeaccessioned={isCurrentVersionDeaccessioned}
+                  />
+                </div>
+              </Tabs.Tab>
+            </Tabs>
+          ) : (
+            <Tabs defaultActiveKey={activeTab} onSelect={handleTabSelect}>
+              <Tabs.Tab eventKey="files" title={t('filesTabTitle')}>
+                <div className={styles['tab-container']}>
+                  {filesTabInfiniteScrollEnabled ? (
+                    <DatasetFilesScrollable
                       filesRepository={fileRepository}
                       datasetPersistentId={dataset.persistentId}
                       datasetVersion={dataset.version}
                       canUpdateDataset={canUpdateDataset}
-                    />
-                  </div>
-                </Tabs.Tab>
-
-                <Tabs.Tab eventKey="versions" title={t('Versions')}>
-                  <div className={styles['tab-container']}>
-                    <DatasetVersions
+                      key={dataset.version.publishingStatus}
                       datasetRepository={datasetRepository}
-                      datasetId={dataset.persistentId}
-                      currentVersionNumber={currentVersionNumber}
-                      canUpdateDataset={canUpdateDataset}
-                      isInView={activeTab === 'versions'}
-                      key={dataset.internalVersionNumber}
                     />
-                  </div>
-                </Tabs.Tab>
-              </Tabs>
-            ))}
+                  ) : (
+                    <DatasetFiles
+                      filesRepository={fileRepository}
+                      datasetPersistentId={dataset.persistentId}
+                      datasetVersion={dataset.version}
+                      datasetRepository={datasetRepository}
+                    />
+                  )}
+                </div>
+              </Tabs.Tab>
+
+              <Tabs.Tab eventKey="metadata" title={t('metadataTabTitle')}>
+                <div className={styles['tab-container']}>
+                  <DatasetMetadata
+                    dataset={dataset}
+                    anonymizedView={anonymizedView}
+                    metadataBlockInfoRepository={metadataBlockInfoRepository}
+                    dataverseInfoRepository={dataverseInfoRepository}
+                  />
+                </div>
+              </Tabs.Tab>
+
+              <Tabs.Tab eventKey="terms" title={termsTabTitle}>
+                <div ref={termsTabRef} className={styles['tab-container']}>
+                  <DatasetTerms
+                    license={dataset.license}
+                    termsOfUse={dataset.termsOfUse}
+                    filesRepository={fileRepository}
+                    datasetPersistentId={dataset.persistentId}
+                    datasetVersion={dataset.version}
+                    canUpdateDataset={canUpdateDataset}
+                  />
+                </div>
+              </Tabs.Tab>
+
+              <Tabs.Tab eventKey="versions" title={t('Versions')}>
+                <div className={styles['tab-container']}>
+                  <DatasetVersions
+                    datasetRepository={datasetRepository}
+                    datasetId={dataset.persistentId}
+                    currentVersionNumber={currentVersionNumber}
+                    canUpdateDataset={canUpdateDataset}
+                    isInView={activeTab === 'versions'}
+                    key={dataset.internalVersionNumber}
+                  />
+                </div>
+              </Tabs.Tab>
+            </Tabs>
+          )}
 
           <SeparationLine />
         </div>

--- a/tests/component/dataset/domain/models/DatasetMother.ts
+++ b/tests/component/dataset/domain/models/DatasetMother.ts
@@ -227,6 +227,26 @@ export class DatasetPermissionsMother {
       canDeleteDataset: false
     })
   }
+
+  static createWithReadOnlyAllowed(): DatasetPermissions {
+    return this.create({
+      canDownloadFiles: true,
+      canUpdateDataset: false,
+      canPublishDataset: false,
+      canManageDatasetPermissions: false,
+      canManageFilesPermissions: false,
+      canDeleteDataset: false
+    })
+  }
+}
+
+export class DatasetWithoutPermissionsMother {
+  static create(props?: Partial<Dataset>): Dataset {
+    return DatasetMother.create({
+      permissions: DatasetPermissionsMother.createWithNoDatasetPermissions(),
+      ...props
+    })
+  }
 }
 
 export class DatasetLockMother {
@@ -558,14 +578,7 @@ export class DatasetMother {
           }
         }
       ] as DatasetMetadataBlocks,
-      permissions: {
-        canDownloadFiles: true,
-        canUpdateDataset: false,
-        canPublishDataset: false,
-        canManageDatasetPermissions: false,
-        canManageFilesPermissions: false,
-        canDeleteDataset: false
-      },
+      permissions: DatasetPermissionsMother.createWithReadOnlyAllowed(),
       locks: [],
       hasValidTermsOfAccess: true,
       hasOneTabularFileAtLeast: true,
@@ -615,14 +628,7 @@ export class DatasetMother {
   static createDeaccessionedwithNoEditPermission(props?: Partial<Dataset>): Dataset {
     return this.create({
       version: DatasetVersionMother.createDeaccessioned(),
-      permissions: {
-        canDownloadFiles: true,
-        canUpdateDataset: false,
-        canPublishDataset: false,
-        canManageDatasetPermissions: false,
-        canManageFilesPermissions: false,
-        canDeleteDataset: false
-      },
+      permissions: DatasetPermissionsMother.createWithReadOnlyAllowed(),
       ...props
     })
   }

--- a/tests/component/sections/dataset/Dataset.spec.tsx
+++ b/tests/component/sections/dataset/Dataset.spec.tsx
@@ -1,6 +1,6 @@
 import { DatasetRepository } from '../../../../src/dataset/domain/repositories/DatasetRepository'
 import { Dataset } from '../../../../src/sections/dataset/Dataset'
-import { DatasetMother } from '../../dataset/domain/models/DatasetMother'
+import { DatasetMother, DatasetPermissionsMother } from '../../dataset/domain/models/DatasetMother'
 import { LoadingProvider } from '../../../../src/shared/contexts/loading/LoadingProvider'
 import {
   ANONYMIZED_FIELD_VALUE,
@@ -96,7 +96,8 @@ const testDataset = DatasetMother.create({
         ]
       }
     }
-  ]
+  ],
+  permissions: DatasetPermissionsMother.createWithAllAllowed()
 })
 
 const testFilesCountInfo = FilesCountInfoMother.create({
@@ -148,6 +149,7 @@ const versionSummaryInfo: DatasetVersionSummaryInfo[] = [
 ]
 
 const testDatasetMetadataExportFormats = DatasetMetadataExportFormatsMother.create()
+const termsTabLabelRegex = /^Terms(?: and Guestbook)?$/
 
 describe('Dataset', () => {
   const mountWithDataset = (
@@ -368,6 +370,9 @@ describe('Dataset', () => {
     )
 
     cy.findByText('Publish in Progress').should('exist')
+    cy.findAllByRole('tab', { name: 'Files' }).should('have.length', 1)
+    cy.findAllByRole('tab', { name: 'Metadata' }).should('have.length', 1)
+    cy.findAllByRole('tab', { name: 'Versions' }).should('have.length', 1)
   })
 
   it('renders the breadcrumbs', () => {
@@ -445,12 +450,33 @@ describe('Dataset', () => {
 
     cy.findAllByText(testDataset.version.title).should('exist')
 
-    const termsTab = cy.findByRole('tab', { name: 'Terms and Guestbook' })
+    const termsTab = cy.findByRole('tab', { name: termsTabLabelRegex })
     termsTab.should('exist')
 
     termsTab.click()
 
     cy.findByText('Dataset Terms').should('exist')
+  })
+
+  it('renders the read-only terms tab title when user cannot edit dataset', () => {
+    const readOnlyDataset = DatasetMother.create({
+      permissions: DatasetPermissionsMother.createWithUpdateDatasetNotAllowed()
+    })
+
+    mountWithDataset(
+      <Dataset
+        datasetRepository={datasetRepository}
+        fileRepository={fileRepository}
+        metadataBlockInfoRepository={metadataBlockInfoRepository}
+        collectionRepository={collectionRepository}
+        contactRepository={contactRepository}
+        dataverseInfoRepository={dataverseInfoRepository}
+      />,
+      readOnlyDataset
+    )
+
+    cy.findByRole('tab', { name: 'Terms' }).should('exist')
+    cy.findByRole('tab', { name: 'Terms and Guestbook' }).should('not.exist')
   })
 
   it('renders the Dataset Files tab', () => {

--- a/tests/e2e-integration/e2e/sections/edit-dataset-terms/EditDatasetTerms.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/edit-dataset-terms/EditDatasetTerms.spec.tsx
@@ -113,7 +113,7 @@ describe('Edit Dataset Terms', () => {
         cy.findByRole('button', { name: 'Save Changes' }).click()
         cy.findByRole('button', { name: 'Cancel' }).click()
 
-        cy.findByRole('tab', { name: 'Terms and Guestbook' }).click()
+        cy.findByRole('tab', { name: /^Terms(?: and Guestbook)?$/ }).click()
         cy.findByText(/Data can be accessed through the university data center/i).should('exist')
         cy.findByText(/dataowner@university.edu/i).should('exist')
         cy.findByText(/500 MB/i).should('exist')


### PR DESCRIPTION
## What this PR does / why we need it:
It can change the tab name based on the user’s permission level. If a user has permission to edit the dataset, the tab will be labeled “Terms and Guestbook.” Otherwise, it will be labeled “Terms.”
Also, I notice a bug when the dataset is publishing, there is a loading state, two tabs component exist at the same time, and then the "files" components loads again. (the screen recording about this bug: https://github.com/user-attachments/assets/55410881-8f1a-404a-89f7-f3bb79b35c98

## Which issue(s) this PR closes:

- Closes #920 

## Special notes for your reviewer:
- Dataset page Terms tab title now depends on permissions: users with dataset update permission see `Terms and Guestbook`, and read-only users see `Terms`.
- Dataset page publish flow now avoids rendering duplicate tab sets by making tabs skeleton and tabs content mutually exclusive.

## Suggestions on how to test this:
Test the dataset page tab name and edit tab name  based on the permission

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

## Is there a release notes or changelog update needed for this change?:
Yes

## Additional documentation:
