### PR TITLE
Expose Solr port for dev

### DIFF
--- a/dev-env/docker-compose-dev.yml
+++ b/dev-env/docker-compose-dev.yml
@@ -156,7 +156,7 @@ services:
         condition: service_completed_successfully
     restart: on-failure
     expose:
-      - '8983'
+      - '8983:8983'
     networks:
       - dataverse
     command:


### PR DESCRIPTION
## What this PR does / why we need it:

This useful when trying to reload Solr after adding a metadata block and running update-fields.sh.

See https://guides.dataverse.org/en/6.9/container/running/demo.html#additional-metadata-blocks

My workaround is to exec into the Solr container first:

```
pdurbin@beamish dataverse % docker exec -it dev_solr bash
solr@solr:/opt/solr-9.8.0$ curl "http://localhost:8983/solr/admin/cores?action=RELOAD&core=collection1"
{
  "responseHeader":{
    "status":0,
    "QTime":479
  }
}solr@solr:/opt/solr-9.8.0$ 
```