### PR TITLE
Add Edit Collection options and show Not Implemented modal

### DIFF
--- a/public/locales/en/collection.json
+++ b/public/locales/en/collection.json
@@ -52,6 +52,12 @@
   "editCollection": {
     "edit": "Edit",
     "generalInfo": "General Information",
+    "themeAndWidgets": "Theme + Widgets",
+    "permissions": "Permissions",
+    "groups": "Groups",
+    "datasetTemplates": "Dataset Templates",
+    "datasetGuestbooks": "Dataset Guestbooks",
+    "featuredDataverses": "Featured Dataverses",
     "deleteCollection": "Delete Collection"
   },
   "featuredItems": {

--- a/public/locales/es/collection.json
+++ b/public/locales/es/collection.json
@@ -52,6 +52,12 @@
   "editCollection": {
     "edit": "Editar",
     "generalInfo": "Información general",
+    "themeAndWidgets": "Tema + Widgets",
+    "permissions": "Permisos",
+    "groups": "Grupos",
+    "datasetTemplates": "Plantillas de dataset",
+    "datasetGuestbooks": "Libros de visitas de dataset",
+    "featuredDataverses": "Dataverses destacados",
     "deleteCollection": "Eliminar colección"
   },
   "featuredItems": {

--- a/src/sections/collection/edit-collection-dropdown/EditCollectionDropdown.tsx
+++ b/src/sections/collection/edit-collection-dropdown/EditCollectionDropdown.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import {
@@ -14,6 +15,7 @@ import { RouteWithParams } from '@/sections/Route.enum'
 import { CollectionRepository } from '@/collection/domain/repositories/CollectionRepository'
 import { CollectionHelper } from '../CollectionHelper'
 import { DeleteCollectionButton } from './delete-collection-button/DeleteCollectionButton'
+import { NotImplementedModal } from '@/sections/not-implemented/NotImplementedModal'
 import styles from './EditCollectionDropdown.module.scss'
 
 interface EditCollectionDropdownProps {
@@ -28,49 +30,80 @@ export const EditCollectionDropdown = ({
   canUserDeleteCollection
 }: EditCollectionDropdownProps) => {
   const { t } = useTranslation('collection')
+  const [showNotImplementedModal, setShowNotImplementedModal] = useState(false)
 
   const canCollectionBeDeleted =
     canUserDeleteCollection &&
     !CollectionHelper.isRootCollection(collection.hierarchy) &&
     collection.childCount === 0
 
-  return (
-    <DropdownButton
-      id="edit-collection-dropdown"
-      title={t('editCollection.edit')}
-      asButtonGroup
-      variant="secondary"
-      icon={<PencilFill className={styles['dropdown-icon']} />}>
-      <DropdownHeader className={styles['dropdown-header']}>
-        <div className={styles['collection-icon']}>
-          <Icon name={IconName.COLLECTION} />
-        </div>
-        <div>
-          <p className={styles['collection-name']}>
-            {collection.name}{' '}
-            {collection.affiliation ? <span>({collection.affiliation})</span> : null}
-          </p>
-          <p className={styles['collection-alias']}>{collection.id}</p>
-        </div>
-      </DropdownHeader>
-      <DropdownSeparator />
-      <DropdownButtonItem as={Link} to={RouteWithParams.EDIT_COLLECTION(collection.id)}>
-        {t('editCollection.generalInfo')}
-      </DropdownButtonItem>
-      <DropdownButtonItem as={Link} to={RouteWithParams.EDIT_FEATURED_ITEMS(collection.id)}>
-        {t('featuredItems.title')}
-      </DropdownButtonItem>
+  const handleNotImplementedClick = (event: React.MouseEvent<HTMLElement>) => {
+    event.stopPropagation()
+    setShowNotImplementedModal(true)
+  }
 
-      {canCollectionBeDeleted && (
-        <>
-          <DropdownSeparator />
-          <DeleteCollectionButton
-            collectionId={collection.id}
-            parentCollection={CollectionHelper.getParentCollection(collection.hierarchy)}
-            collectionRepository={collectionRepository}
-          />
-        </>
-      )}
-    </DropdownButton>
+  return (
+    <>
+      <DropdownButton
+        id="edit-collection-dropdown"
+        title={t('editCollection.edit')}
+        asButtonGroup
+        variant="secondary"
+        icon={<PencilFill className={styles['dropdown-icon']} />}>
+        <DropdownHeader className={styles['dropdown-header']}>
+          <div className={styles['collection-icon']}>
+            <Icon name={IconName.COLLECTION} />
+          </div>
+          <div>
+            <p className={styles['collection-name']}>
+              {collection.name}{' '}
+              {collection.affiliation ? <span>({collection.affiliation})</span> : null}
+            </p>
+            <p className={styles['collection-alias']}>{collection.id}</p>
+          </div>
+        </DropdownHeader>
+        <DropdownSeparator />
+        <DropdownButtonItem as={Link} to={RouteWithParams.EDIT_COLLECTION(collection.id)}>
+          {t('editCollection.generalInfo')}
+        </DropdownButtonItem>
+        <DropdownButtonItem as={Link} to={RouteWithParams.EDIT_FEATURED_ITEMS(collection.id)}>
+          {t('featuredItems.title')}
+        </DropdownButtonItem>
+        <DropdownButtonItem onClick={handleNotImplementedClick}>
+          {t('editCollection.themeAndWidgets')}
+        </DropdownButtonItem>
+        <DropdownButtonItem onClick={handleNotImplementedClick}>
+          {t('editCollection.permissions')}
+        </DropdownButtonItem>
+        <DropdownButtonItem onClick={handleNotImplementedClick}>
+          {t('editCollection.groups')}
+        </DropdownButtonItem>
+        <DropdownButtonItem onClick={handleNotImplementedClick}>
+          {t('editCollection.datasetTemplates')}
+        </DropdownButtonItem>
+        <DropdownButtonItem onClick={handleNotImplementedClick}>
+          {t('editCollection.datasetGuestbooks')}
+        </DropdownButtonItem>
+        <DropdownButtonItem onClick={handleNotImplementedClick}>
+          {t('editCollection.featuredDataverses')}
+        </DropdownButtonItem>
+
+        {canCollectionBeDeleted && (
+          <>
+            <DropdownSeparator />
+            <DeleteCollectionButton
+              collectionId={collection.id}
+              parentCollection={CollectionHelper.getParentCollection(collection.hierarchy)}
+              collectionRepository={collectionRepository}
+            />
+          </>
+        )}
+      </DropdownButton>
+
+      <NotImplementedModal
+        show={showNotImplementedModal}
+        handleClose={() => setShowNotImplementedModal(false)}
+      />
+    </>
   )
 }

--- a/src/sections/collection/edit-collection-dropdown/EditCollectionDropdown.tsx
+++ b/src/sections/collection/edit-collection-dropdown/EditCollectionDropdown.tsx
@@ -84,9 +84,6 @@ export const EditCollectionDropdown = ({
         <DropdownButtonItem onClick={handleNotImplementedClick}>
           {t('editCollection.datasetGuestbooks')}
         </DropdownButtonItem>
-        <DropdownButtonItem onClick={handleNotImplementedClick}>
-          {t('editCollection.featuredDataverses')}
-        </DropdownButtonItem>
 
         {canCollectionBeDeleted && (
           <>

--- a/tests/component/sections/collection/edit-collection-dropdown/EditCollectionDropdown.spec.tsx
+++ b/tests/component/sections/collection/edit-collection-dropdown/EditCollectionDropdown.spec.tsx
@@ -111,6 +111,42 @@ describe('EditCollectionDropdown', () => {
     )
   })
 
+  it('shows the not implemented collection edit options', () => {
+    cy.mountAuthenticated(
+      <EditCollectionDropdown
+        collection={rootCollection}
+        collectionRepository={collectionRepository}
+        canUserDeleteCollection={false}
+      />
+    )
+
+    openDropdown()
+
+    cy.findByRole('button', { name: 'Theme + Widgets' }).should('exist')
+    cy.findByRole('button', { name: 'Permissions' }).should('exist')
+    cy.findByRole('button', { name: 'Groups' }).should('exist')
+    cy.findByRole('button', { name: 'Dataset Templates' }).should('exist')
+    cy.findByRole('button', { name: 'Dataset Guestbooks' }).should('exist')
+    cy.findByRole('button', { name: 'Featured Dataverses' }).should('exist')
+  })
+
+  it('shows the not implemented modal when a new edit option is clicked', () => {
+    cy.mountAuthenticated(
+      <EditCollectionDropdown
+        collection={rootCollection}
+        collectionRepository={collectionRepository}
+        canUserDeleteCollection={false}
+      />
+    )
+
+    openDropdown()
+
+    cy.findByRole('button', { name: 'Permissions' }).click()
+
+    cy.findByText('Not Implemented').should('exist')
+    cy.findByText('This feature is not implemented yet in SPA.').should('exist')
+  })
+
   describe('delete button', () => {
     it('shows the delete button if user can delete collection, collection is not root and collection has no data', () => {
       cy.mountAuthenticated(

--- a/tests/component/sections/collection/edit-collection-dropdown/EditCollectionDropdown.spec.tsx
+++ b/tests/component/sections/collection/edit-collection-dropdown/EditCollectionDropdown.spec.tsx
@@ -127,7 +127,6 @@ describe('EditCollectionDropdown', () => {
     cy.findByRole('button', { name: 'Groups' }).should('exist')
     cy.findByRole('button', { name: 'Dataset Templates' }).should('exist')
     cy.findByRole('button', { name: 'Dataset Guestbooks' }).should('exist')
-    cy.findByRole('button', { name: 'Featured Dataverses' }).should('exist')
   })
 
   it('shows the not implemented modal when a new edit option is clicked', () => {


### PR DESCRIPTION
## What this PR does / why we need it:
For usability testing, we want users to go through the workflow of trying out a feature in SPA, then switching to do it in JSF

## Which issue(s) this PR closes:

- Closes #935 

## Special notes for your reviewer:

## Suggestions on how to test this:
Try out option and test that modal appears. The Dataverse link should go to the JSF UI

