### PR TITLE
use config.js from code base when deploying

### DIFF
--- a/.github/workflows/deploy-beta-testing.yml
+++ b/.github/workflows/deploy-beta-testing.yml
@@ -44,25 +44,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.BETA_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.BETA_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.BETA_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' }
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
         shell: bash
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,25 +53,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.BETA_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.BETA_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.BETA_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' },
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
 
       - name: Override runtime config.js for QA
         if: ${{ github.event.inputs.environment == 'qa' }}
@@ -82,25 +64,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.QA_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.QA_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.QA_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' },
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
 
       - name: Override runtime config.js for DEMO
         if: ${{ github.event.inputs.environment == 'demo' }}
@@ -111,25 +75,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.DEMO_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.DEMO_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.DEMO_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' },
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/generate-war.yml
+++ b/.github/workflows/generate-war.yml
@@ -53,25 +53,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.BETA_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.BETA_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.BETA_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' },
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
 
       - name: Override runtime config.js for QA
         if: ${{ github.event.inputs.environment == 'qa' }}
@@ -82,25 +64,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.QA_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.QA_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.QA_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' },
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
 
       - name: Override runtime config.js for DEMO
         if: ${{ github.event.inputs.environment == 'demo' }}
@@ -111,25 +75,7 @@ jobs:
           OIDC_TOKEN_ENDPOINT: ${{ secrets.DEMO_OIDC_TOKEN_ENDPOINT }}
           OIDC_LOGOUT_ENDPOINT: ${{ secrets.DEMO_OIDC_LOGOUT_ENDPOINT }}
           OIDC_STORAGE_KEY_PREFIX: ${{ secrets.DEMO_OIDC_STORAGE_KEY_PREFIX }}
-        run: |
-          mkdir -p ./dist
-          cat > ./dist/config.js <<EOF
-          window.__APP_CONFIG__ = {
-            backendUrl: "${DATAVERSE_BACKEND_URL}",
-            oidc: {
-              clientId: "${OIDC_CLIENT_ID}",
-              authorizationEndpoint: "${OIDC_AUTHORIZATION_ENDPOINT}",
-              tokenEndpoint: "${OIDC_TOKEN_ENDPOINT}",
-              logoutEndpoint: "${OIDC_LOGOUT_ENDPOINT}",
-              localStorageKeyPrefix: "${OIDC_STORAGE_KEY_PREFIX}"
-            },
-            languages: [
-              { code: 'en', name: 'English' },
-              { code: 'es', name: 'Español' },
-            ],
-            defaultLanguage: 'en'
-          }
-          EOF
+        run: node ./scripts/write-runtime-config.mjs
 
       - uses: actions/upload-artifact@v4
         with:

--- a/public/config.js
+++ b/public/config.js
@@ -7,7 +7,7 @@ window.__APP_CONFIG__ = {
   backendUrl: 'http://localhost:8000',
   // Optional banner shown at the top of the app when set. Basic HTML markup is supported.
   bannerMessage:
-    'You are using the new Dataverse <strong>Modern version</strong>. This is an early release and some features from the original site are not yet available.',
+    "You are using the new Dataverse <strong>Modern version</strong>. This is an early release and some features from the original site are not yet available. Please see the <a href='https://dataverse.harvard.edu/spa/featured-item/harvard/1'>Project Roadmap</a> for details.",
   // OIDC provider settings
   oidc: {
     clientId: 'test',

--- a/scripts/write-runtime-config.mjs
+++ b/scripts/write-runtime-config.mjs
@@ -1,0 +1,36 @@
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import vm from 'node:vm'
+
+const sourcePath = path.resolve('public/config.js')
+const outputPath = path.resolve('dist/config.js')
+
+const source = await readFile(sourcePath, 'utf8')
+
+const sandbox = { window: {} }
+vm.createContext(sandbox)
+new vm.Script(source, { filename: sourcePath }).runInContext(sandbox)
+
+const baseConfig = sandbox.window.__APP_CONFIG__
+
+if (!baseConfig || typeof baseConfig !== 'object') {
+  throw new Error(`Expected window.__APP_CONFIG__ to be defined in ${sourcePath}`)
+}
+
+const withOverride = (key, value) => (value ? { [key]: value } : {})
+
+const runtimeConfig = {
+  ...baseConfig,
+  ...withOverride('backendUrl', process.env.DATAVERSE_BACKEND_URL),
+  oidc: {
+    ...baseConfig.oidc,
+    ...withOverride('clientId', process.env.OIDC_CLIENT_ID),
+    ...withOverride('authorizationEndpoint', process.env.OIDC_AUTHORIZATION_ENDPOINT),
+    ...withOverride('tokenEndpoint', process.env.OIDC_TOKEN_ENDPOINT),
+    ...withOverride('logoutEndpoint', process.env.OIDC_LOGOUT_ENDPOINT),
+    ...withOverride('localStorageKeyPrefix', process.env.OIDC_STORAGE_KEY_PREFIX)
+  }
+}
+
+await mkdir(path.dirname(outputPath), { recursive: true })
+await writeFile(outputPath, `window.__APP_CONFIG__ = ${JSON.stringify(runtimeConfig, null, 2)}\n`)

--- a/src/sections/layout/Layout.module.scss
+++ b/src/sections/layout/Layout.module.scss
@@ -3,3 +3,14 @@
 .body-container {
   min-height: $main-container-available-height;
 }
+
+.banner-message {
+  a {
+    color: #286090;
+  }
+
+  a:hover,
+  a:focus {
+    color: #23527c;
+  }
+}

--- a/src/sections/layout/Layout.tsx
+++ b/src/sections/layout/Layout.tsx
@@ -19,7 +19,7 @@ export function Layout() {
       <TopBarProgressIndicator />
       {HeaderFactory.create()}
       {sanitizedBannerMessage ? (
-        <div className="alert alert-warning rounded-0" role="alert">
+        <div className={`alert alert-warning rounded-0 ${styles['banner-message']}`} role="alert">
           <div className="container" dangerouslySetInnerHTML={{ __html: sanitizedBannerMessage }} />
         </div>
       ) : null}


### PR DESCRIPTION
## What this PR does / why we need it:
## Which issue(s) this PR closes:
Update the build scripts so they use the bannerMessage defined in config.js, rather than creating a separate config object.

This is needed so we can deploy the correct banner message in the github deploy actions.

