### PR TITLE
added pagination to Versions tab on Dataset and File page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Changed
 
+- Added pagination to the Versions tabs on Dataset and File pages so version summaries are loaded and displayed one page at a time.
+
 ### Fixed
 
 ### Removed

--- a/dev-env/docker-compose-dev.yml
+++ b/dev-env/docker-compose-dev.yml
@@ -155,7 +155,7 @@ services:
       dev_solr_initializer:
         condition: service_completed_successfully
     restart: on-failure
-    expose:
+    ports:
       - '8983:8983'
     networks:
       - dataverse

--- a/src/dataset/domain/models/DatasetVersionPaginationInfo.ts
+++ b/src/dataset/domain/models/DatasetVersionPaginationInfo.ts
@@ -1,7 +1,17 @@
 import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
 
 export class DatasetVersionPaginationInfo extends PaginationInfo<DatasetVersionPaginationInfo> {
-  constructor(page = 1, pageSize = 10, totalItems = 0, itemName = 'Version') {
+  constructor(
+    page = 1,
+    pageSize = 10,
+    totalItems = 0,
+    itemName = 'Version',
+    private readonly offsetOverride?: number
+  ) {
     super(page, pageSize, totalItems, itemName)
+  }
+
+  get offset(): number {
+    return this.offsetOverride ?? super.offset
   }
 }

--- a/src/sections/dataset/Dataset.tsx
+++ b/src/sections/dataset/Dataset.tsx
@@ -172,9 +172,8 @@ export function Dataset({
                     datasetId={dataset.persistentId}
                     currentVersionNumber={currentVersionNumber}
                     canUpdateDataset={canUpdateDataset}
-                    isInView={activeTab === 'versions'}
+                    isInView
                     key={dataset.internalVersionNumber}
-                    isCurrentVersionDeaccessioned={isCurrentVersionDeaccessioned}
                   />
                 </div>
               </Tabs.Tab>

--- a/src/sections/dataset/dataset-versions/DatasetVersions.module.scss
+++ b/src/sections/dataset/dataset-versions/DatasetVersions.module.scss
@@ -34,6 +34,13 @@
   }
 }
 
+.dataset-versions-table-loading {
+  tbody {
+    opacity: 0.55;
+    transition: opacity 120ms ease-in-out;
+  }
+}
+
 .visually-hidden {
   position: absolute;
   clip: rect(1px, 1px, 1px, 1px);

--- a/src/sections/dataset/dataset-versions/DatasetVersions.tsx
+++ b/src/sections/dataset/dataset-versions/DatasetVersions.tsx
@@ -89,7 +89,7 @@ export function DatasetVersions({
 
       void fetchSummaries(paginationInfoToFetch).then((totalCount) => {
         if (typeof totalCount === 'number') {
-          setPaginationInfo(paginationInfoToDisplay.withTotal(totalCount))
+          setPaginationInfo((currentPaginationInfo) => currentPaginationInfo.withTotal(totalCount))
         }
       })
     }
@@ -99,12 +99,12 @@ export function DatasetVersions({
     setSelectedVersions([])
   }, [paginationInfo.page, paginationInfo.pageSize])
 
-  if (!datasetVersionSummaries) {
-    return <DatasetVersionsLoadingSkeleton />
-  }
-
   if (error) {
     return <Alert variant="danger">Error loading dataset versions</Alert>
+  }
+
+  if (!datasetVersionSummaries) {
+    return <DatasetVersionsLoadingSkeleton />
   }
 
   return (
@@ -217,15 +217,7 @@ export function DatasetVersions({
       </div>
       <PaginationControls
         initialPaginationInfo={paginationInfo}
-        onPaginationInfoChange={(newPaginationInfo) =>
-          setPaginationInfo(
-            new DatasetVersionPaginationInfo(
-              newPaginationInfo.page,
-              newPaginationInfo.pageSize,
-              newPaginationInfo.totalItems
-            )
-          )
-        }
+        onPaginationInfoChange={setPaginationInfo}
       />
     </>
   )

--- a/src/sections/dataset/dataset-versions/DatasetVersions.tsx
+++ b/src/sections/dataset/dataset-versions/DatasetVersions.tsx
@@ -16,6 +16,8 @@ import { useDatasetVersionSummaryDescription } from './useDatasetVersionSummaryD
 import { DatasetViewDetailButton } from './DatasetViewDetailButton'
 import { DatasetVersionState } from '@/dataset/domain/models/Dataset'
 import styles from './DatasetVersions.module.scss'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
+import { PaginationControls } from '@/sections/shared/pagination/PaginationControls'
 
 interface DatasetVersionsProps {
   datasetRepository: DatasetRepository
@@ -23,7 +25,6 @@ interface DatasetVersionsProps {
   currentVersionNumber: string
   canUpdateDataset: boolean
   isInView: boolean
-  isCurrentVersionDeaccessioned?: boolean
 }
 
 const isVersionDeaccessioned = (version: DatasetVersionSummaryInfo) =>
@@ -36,11 +37,13 @@ export function DatasetVersions({
   datasetId,
   currentVersionNumber,
   canUpdateDataset,
-  isInView,
-  isCurrentVersionDeaccessioned
+  isInView
 }: DatasetVersionsProps) {
   const { t } = useTranslation('dataset')
   const [selectedVersions, setSelectedVersions] = useState<DatasetVersionSummaryInfo[]>([])
+  const [paginationInfo, setPaginationInfo] = useState<DatasetVersionPaginationInfo>(
+    new DatasetVersionPaginationInfo()
+  )
   const {
     datasetVersionSummaries,
     error,
@@ -49,7 +52,7 @@ export function DatasetVersions({
   } = useGetDatasetVersionsSummaries({
     datasetRepository,
     persistentId: datasetId,
-    autoFetch: isCurrentVersionDeaccessioned ? true : false
+    autoFetch: false
   })
 
   const handleCheckboxChange = (datasetSummary: DatasetVersionSummaryInfo) => {
@@ -64,18 +67,39 @@ export function DatasetVersions({
     })
   }
 
+  const visibleDatasetVersionSummaries = datasetVersionSummaries?.slice(0, paginationInfo.pageSize)
   const selectableVersions =
-    datasetVersionSummaries &&
-    datasetVersionSummaries.filter((version) => !isVersionDeaccessioned(version))
+    visibleDatasetVersionSummaries &&
+    visibleDatasetVersionSummaries.filter((version) => !isVersionDeaccessioned(version))
   const isCheckBoxValid = (selectableVersions?.length ?? 0) > 2
 
   useEffect(() => {
-    if (isInView && !datasetVersionSummaries) {
-      void fetchSummaries()
-    }
-  }, [isInView, fetchSummaries, datasetVersionSummaries])
+    if (isInView) {
+      const paginationInfoToDisplay = new DatasetVersionPaginationInfo(
+        paginationInfo.page,
+        paginationInfo.pageSize
+      )
+      const paginationInfoToFetch = new DatasetVersionPaginationInfo(
+        paginationInfo.page,
+        paginationInfo.pageSize + 1,
+        0,
+        'Version',
+        paginationInfoToDisplay.offset
+      )
 
-  if (isLoadingDatasetVersionSummaries || !datasetVersionSummaries) {
+      void fetchSummaries(paginationInfoToFetch).then((totalCount) => {
+        if (typeof totalCount === 'number') {
+          setPaginationInfo(paginationInfoToDisplay.withTotal(totalCount))
+        }
+      })
+    }
+  }, [isInView, fetchSummaries, paginationInfo.page, paginationInfo.pageSize])
+
+  useEffect(() => {
+    setSelectedVersions([])
+  }, [paginationInfo.page, paginationInfo.pageSize])
+
+  if (!datasetVersionSummaries) {
     return <DatasetVersionsLoadingSkeleton />
   }
 
@@ -93,7 +117,12 @@ export function DatasetVersions({
         />
       )}
 
-      <div className={styles['dataset-versions-table']} data-testid="dataset-versions-table">
+      <div
+        className={`${styles['dataset-versions-table']} ${
+          isLoadingDatasetVersionSummaries ? styles['dataset-versions-table-loading'] : ''
+        }`}
+        data-testid="dataset-versions-table"
+        aria-busy={isLoadingDatasetVersionSummaries}>
         <Table>
           <thead>
             <tr>
@@ -110,7 +139,7 @@ export function DatasetVersions({
             </tr>
           </thead>
           <tbody>
-            {datasetVersionSummaries?.map((dataset, index) => {
+            {visibleDatasetVersionSummaries?.map((dataset, index) => {
               const findLastNonDeaccessionedPreviousVersion = () => {
                 for (let i = index + 1; i < datasetVersionSummaries.length; i++) {
                   const version = datasetVersionSummaries[i]
@@ -186,6 +215,18 @@ export function DatasetVersions({
           </tbody>
         </Table>
       </div>
+      <PaginationControls
+        initialPaginationInfo={paginationInfo}
+        onPaginationInfoChange={(newPaginationInfo) =>
+          setPaginationInfo(
+            new DatasetVersionPaginationInfo(
+              newPaginationInfo.page,
+              newPaginationInfo.pageSize,
+              newPaginationInfo.totalItems
+            )
+          )
+        }
+      />
     </>
   )
 }

--- a/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
+++ b/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { DatasetVersionSummaryInfo } from '@/dataset/domain/models/DatasetVersionSummaryInfo'
 import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
 import { getDatasetVersionsSummaries } from '@/dataset/domain/useCases/getDatasetVersionsSummaries'
@@ -25,9 +25,12 @@ export const useGetDatasetVersionsSummaries = ({
   const [summaries, setSummaries] = useState<DatasetVersionSummaryInfo[]>()
   const [isLoading, setIsLoading] = useState<boolean>(autoFetch)
   const [error, setError] = useState<string | null>(null)
+  const latestRequestId = useRef(0)
 
   const fetchSummaries = useCallback(
     async (paginationInfo?: DatasetVersionPaginationInfo) => {
+      const requestId = latestRequestId.current + 1
+      latestRequestId.current = requestId
       setIsLoading(true)
       setError(null)
 
@@ -37,9 +40,15 @@ export const useGetDatasetVersionsSummaries = ({
           persistentId,
           paginationInfo
         )
+        if (requestId !== latestRequestId.current) {
+          return undefined
+        }
         setSummaries(versionSummaries.summaries)
         return versionSummaries.totalCount
       } catch (err) {
+        if (requestId !== latestRequestId.current) {
+          return undefined
+        }
         const errorMessage =
           err instanceof Error && err.message
             ? err.message
@@ -47,7 +56,9 @@ export const useGetDatasetVersionsSummaries = ({
         setError(errorMessage)
         return undefined
       } finally {
-        setIsLoading(false)
+        if (requestId === latestRequestId.current) {
+          setIsLoading(false)
+        }
       }
     },
     [datasetRepository, persistentId]

--- a/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
+++ b/src/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.ts
@@ -8,7 +8,7 @@ interface UseGetDatasetVersionsSummaries {
   datasetVersionSummaries: DatasetVersionSummaryInfo[] | undefined
   error: string | null
   isLoading: boolean
-  fetchSummaries: (paginationInfo?: DatasetVersionPaginationInfo) => Promise<void>
+  fetchSummaries: (paginationInfo?: DatasetVersionPaginationInfo) => Promise<number | undefined>
 }
 
 interface Props {
@@ -38,12 +38,14 @@ export const useGetDatasetVersionsSummaries = ({
           paginationInfo
         )
         setSummaries(versionSummaries.summaries)
+        return versionSummaries.totalCount
       } catch (err) {
         const errorMessage =
           err instanceof Error && err.message
             ? err.message
             : 'Something went wrong getting the information from the dataset versions summaries. Try again later.'
         setError(errorMessage)
+        return undefined
       } finally {
         setIsLoading(false)
       }

--- a/src/sections/file/file-version/FileVersion.module.scss
+++ b/src/sections/file/file-version/FileVersion.module.scss
@@ -19,6 +19,13 @@
   }
 }
 
+.file-versions-table-loading {
+  tbody {
+    opacity: 0.55;
+    transition: opacity 120ms ease-in-out;
+  }
+}
+
 .no-summary-text {
   font-style: italic;
   color: $dv-subtext-color;

--- a/src/sections/file/file-version/FileVersions.tsx
+++ b/src/sections/file/file-version/FileVersions.tsx
@@ -13,8 +13,10 @@ import {
 import { useGetFileVersionsSummaries } from './useGetFileVersionsSummaries'
 import { DateHelper } from '@/shared/helpers/DateHelper'
 import { FileRepository } from '@/files/domain/repositories/FileRepository'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import styles from './FileVersion.module.scss'
+import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
+import { PaginationControls } from '@/sections/shared/pagination/PaginationControls'
 
 interface FileVersionProps {
   fileId: number
@@ -32,6 +34,9 @@ export function FileVersions({
   isInView
 }: FileVersionProps) {
   const { t } = useTranslation('file')
+  const [paginationInfo, setPaginationInfo] = useState<FileVersionPaginationInfo>(
+    new FileVersionPaginationInfo()
+  )
 
   const { fileVersionSummaries, isLoading, fetchSummaries, error } = useGetFileVersionsSummaries({
     fileRepository,
@@ -40,12 +45,21 @@ export function FileVersions({
   })
 
   useEffect(() => {
-    if (isInView && !fileVersionSummaries) {
-      void fetchSummaries()
-    }
-  }, [isInView, fileVersionSummaries, fetchSummaries])
+    if (isInView) {
+      const paginationInfoToFetch = new FileVersionPaginationInfo(
+        paginationInfo.page,
+        paginationInfo.pageSize
+      )
 
-  if (isLoading || !fileVersionSummaries) {
+      void fetchSummaries(paginationInfoToFetch).then((totalCount) => {
+        if (typeof totalCount === 'number') {
+          setPaginationInfo(paginationInfoToFetch.withTotal(totalCount))
+        }
+      })
+    }
+  }, [isInView, fetchSummaries, paginationInfo.page, paginationInfo.pageSize])
+
+  if (!fileVersionSummaries) {
     return <FileVersionsLoadingSkeleton />
   }
 
@@ -62,65 +76,85 @@ export function FileVersions({
       : datasetVersionNumber
 
   return (
-    <div data-testid={`file-file`} className={styles['file-versions-table']}>
-      <Table>
-        <thead>
-          <tr>
-            <th>{t('fileVersion.version')}</th>
-            <th>{t('fileVersion.summary')}</th>
-            <th>{t('fileVersion.contributors')}</th>
-            <th>{t('fileVersion.publishedOn')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {fileVersionSummaries?.map((fileVersion) => {
-            const isCurrentVersion = fileVersion.datasetVersion === displayVersion
-            // Helper functions for readability
-            const hasDataFile = fileVersion.datafileId
-            const isReleased = fileVersion.versionState === DatasetVersionState.RELEASED
-            const isDeaccessionedWithAccess =
-              fileVersion.versionState === DatasetVersionState.DEACCESSIONED && canEditOwnerDataset
-            const isDraftWithAccess =
-              fileVersion.versionState === DatasetVersionState.DRAFT && canEditOwnerDataset
+    <>
+      <div
+        data-testid={`file-file`}
+        className={`${styles['file-versions-table']} ${
+          isLoading ? styles['file-versions-table-loading'] : ''
+        }`}
+        aria-busy={isLoading}>
+        <Table>
+          <thead>
+            <tr>
+              <th>{t('fileVersion.version')}</th>
+              <th>{t('fileVersion.summary')}</th>
+              <th>{t('fileVersion.contributors')}</th>
+              <th>{t('fileVersion.publishedOn')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {fileVersionSummaries?.map((fileVersion) => {
+              const isCurrentVersion = fileVersion.datasetVersion === displayVersion
+              // Helper functions for readability
+              const hasDataFile = fileVersion.datafileId
+              const isReleased = fileVersion.versionState === DatasetVersionState.RELEASED
+              const isDeaccessionedWithAccess =
+                fileVersion.versionState === DatasetVersionState.DEACCESSIONED &&
+                canEditOwnerDataset
+              const isDraftWithAccess =
+                fileVersion.versionState === DatasetVersionState.DRAFT && canEditOwnerDataset
 
-            const isLinkable =
-              hasDataFile && (isReleased || isDeaccessionedWithAccess || isDraftWithAccess)
+              const isLinkable =
+                hasDataFile && (isReleased || isDeaccessionedWithAccess || isDraftWithAccess)
 
-            return (
-              <tr key={fileVersion.datasetVersion}>
-                <td style={{ verticalAlign: 'middle' }}>
-                  {isCurrentVersion ? (
-                    <strong>{fileVersion.datasetVersion}</strong>
-                  ) : isLinkable ? (
-                    <Link
-                      to={`${Route.FILES}?${QueryParamKey.FILE_ID}=${fileId}&${QueryParamKey.DATASET_VERSION}=${fileVersion.datasetVersion}`}
-                      data-testid={`file-version-link-${fileVersion.datasetVersion}`}>
-                      {fileVersion.datasetVersion}
-                    </Link>
+              return (
+                <tr key={fileVersion.datasetVersion}>
+                  <td style={{ verticalAlign: 'middle' }}>
+                    {isCurrentVersion ? (
+                      <strong>{fileVersion.datasetVersion}</strong>
+                    ) : isLinkable ? (
+                      <Link
+                        to={`${Route.FILES}?${QueryParamKey.FILE_ID}=${fileId}&${QueryParamKey.DATASET_VERSION}=${fileVersion.datasetVersion}`}
+                        data-testid={`file-version-link-${fileVersion.datasetVersion}`}>
+                        {fileVersion.datasetVersion}
+                      </Link>
+                    ) : (
+                      <span>{fileVersion.datasetVersion}</span>
+                    )}
+                  </td>
+
+                  <td style={{ textAlign: 'left' }}>
+                    <SummaryDescription
+                      summary={fileVersion.fileDifferenceSummary}
+                      isNoVersions={fileVersion.datafileId === undefined}
+                    />
+                  </td>
+                  <td>{fileVersion.contributors}</td>
+                  {fileVersion.publishedDate &&
+                  fileVersion.datasetVersion !== DatasetVersionState.DRAFT ? (
+                    <td>{DateHelper.toISO8601Format(new Date(fileVersion.publishedDate))}</td>
                   ) : (
-                    <span>{fileVersion.datasetVersion}</span>
+                    <td></td>
                   )}
-                </td>
-
-                <td style={{ textAlign: 'left' }}>
-                  <SummaryDescription
-                    summary={fileVersion.fileDifferenceSummary}
-                    isNoVersions={fileVersion.datafileId === undefined}
-                  />
-                </td>
-                <td>{fileVersion.contributors}</td>
-                {fileVersion.publishedDate &&
-                fileVersion.datasetVersion !== DatasetVersionState.DRAFT ? (
-                  <td>{DateHelper.toISO8601Format(new Date(fileVersion.publishedDate))}</td>
-                ) : (
-                  <td></td>
-                )}
-              </tr>
+                </tr>
+              )
+            })}
+          </tbody>
+        </Table>
+      </div>
+      <PaginationControls
+        initialPaginationInfo={paginationInfo}
+        onPaginationInfoChange={(newPaginationInfo) =>
+          setPaginationInfo(
+            new FileVersionPaginationInfo(
+              newPaginationInfo.page,
+              newPaginationInfo.pageSize,
+              newPaginationInfo.totalItems
             )
-          })}
-        </tbody>
-      </Table>
-    </div>
+          )
+        }
+      />
+    </>
   )
 }
 

--- a/src/sections/file/file-version/FileVersions.tsx
+++ b/src/sections/file/file-version/FileVersions.tsx
@@ -53,18 +53,18 @@ export function FileVersions({
 
       void fetchSummaries(paginationInfoToFetch).then((totalCount) => {
         if (typeof totalCount === 'number') {
-          setPaginationInfo(paginationInfoToFetch.withTotal(totalCount))
+          setPaginationInfo((currentPaginationInfo) => currentPaginationInfo.withTotal(totalCount))
         }
       })
     }
   }, [isInView, fetchSummaries, paginationInfo.page, paginationInfo.pageSize])
 
-  if (!fileVersionSummaries) {
-    return <FileVersionsLoadingSkeleton />
-  }
-
   if (error) {
     return <Alert variant="danger">{t('fileVersion.error')}</Alert>
+  }
+
+  if (!fileVersionSummaries) {
+    return <FileVersionsLoadingSkeleton />
   }
 
   const datasetVersionDisplayMap: Record<string, string> = {
@@ -144,15 +144,7 @@ export function FileVersions({
       </div>
       <PaginationControls
         initialPaginationInfo={paginationInfo}
-        onPaginationInfoChange={(newPaginationInfo) =>
-          setPaginationInfo(
-            new FileVersionPaginationInfo(
-              newPaginationInfo.page,
-              newPaginationInfo.pageSize,
-              newPaginationInfo.totalItems
-            )
-          )
-        }
+        onPaginationInfoChange={setPaginationInfo}
       />
     </>
   )

--- a/src/sections/file/file-version/useGetFileVersionsSummaries.ts
+++ b/src/sections/file/file-version/useGetFileVersionsSummaries.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { FileVersionSummaryInfo } from '@/files/domain/models/FileVersionSummaryInfo'
 import { FileRepository } from '@/files/domain/repositories/FileRepository'
 import { getFileVersionSummaries } from '@/files/domain/useCases/getFileVersionSummaries'
@@ -25,9 +25,12 @@ export const useGetFileVersionsSummaries = ({
   const [summaries, setSummaries] = useState<FileVersionSummaryInfo[]>()
   const [isLoading, setIsLoading] = useState<boolean>(autoFetch)
   const [error, setError] = useState<string | null>(null)
+  const latestRequestId = useRef(0)
 
   const fetchSummaries = useCallback(
     async (paginationInfo?: FileVersionPaginationInfo) => {
+      const requestId = latestRequestId.current + 1
+      latestRequestId.current = requestId
       setIsLoading(true)
       setError(null)
       try {
@@ -36,9 +39,15 @@ export const useGetFileVersionsSummaries = ({
           fileId,
           paginationInfo
         )
+        if (requestId !== latestRequestId.current) {
+          return undefined
+        }
         setSummaries(versionSummaries.summaries)
         return versionSummaries.totalCount
       } catch (err) {
+        if (requestId !== latestRequestId.current) {
+          return undefined
+        }
         const errorMessage =
           err instanceof Error && err.message
             ? err.message
@@ -46,7 +55,9 @@ export const useGetFileVersionsSummaries = ({
         setError(errorMessage)
         return undefined
       } finally {
-        setIsLoading(false)
+        if (requestId === latestRequestId.current) {
+          setIsLoading(false)
+        }
       }
     },
     [fileRepository, fileId]

--- a/src/sections/file/file-version/useGetFileVersionsSummaries.ts
+++ b/src/sections/file/file-version/useGetFileVersionsSummaries.ts
@@ -8,7 +8,7 @@ interface UseGetFileVersionsSummaries {
   fileVersionSummaries: FileVersionSummaryInfo[] | undefined
   error: string | null
   isLoading: boolean
-  fetchSummaries: (paginationInfo?: FileVersionPaginationInfo) => Promise<void>
+  fetchSummaries: (paginationInfo?: FileVersionPaginationInfo) => Promise<number | undefined>
 }
 
 interface Props {
@@ -37,12 +37,14 @@ export const useGetFileVersionsSummaries = ({
           paginationInfo
         )
         setSummaries(versionSummaries.summaries)
+        return versionSummaries.totalCount
       } catch (err) {
         const errorMessage =
           err instanceof Error && err.message
             ? err.message
             : 'Something went wrong getting the information from the file versions summaries. Try again later.'
         setError(errorMessage)
+        return undefined
       } finally {
         setIsLoading(false)
       }

--- a/src/sections/shared/pagination/PaginationControls.tsx
+++ b/src/sections/shared/pagination/PaginationControls.tsx
@@ -4,32 +4,19 @@ import { PageSizeSelector } from './PageSizeSelector'
 import styles from './Pagination.module.scss'
 import { PaginationInfo } from '../../../shared/pagination/domain/models/PaginationInfo'
 import { useEffect, useState } from 'react'
-import { FilePaginationInfo } from '../../../files/domain/models/FilePaginationInfo'
-import { DatasetPaginationInfo } from '../../../dataset/domain/models/DatasetPaginationInfo'
-import { NotificationsPaginationInfo } from '@/notifications/domain/models/NotificationsPaginationInfo'
-import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
-import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
 
-type SupportedPaginationInfo =
-  | DatasetPaginationInfo
-  | FilePaginationInfo
-  | NotificationsPaginationInfo
-  | DatasetVersionPaginationInfo
-  | FileVersionPaginationInfo
-
-interface PaginationProps {
-  onPaginationInfoChange: (paginationInfo: PaginationInfo<SupportedPaginationInfo>) => void
-  initialPaginationInfo: PaginationInfo<SupportedPaginationInfo>
+interface PaginationProps<T extends PaginationInfo<T>> {
+  onPaginationInfoChange: (paginationInfo: T) => void
+  initialPaginationInfo: T
   showPageSizeSelector?: boolean
 }
 const MINIMUM_NUMBER_OF_PAGES_TO_DISPLAY_PAGINATION = 2
-export function PaginationControls({
+export function PaginationControls<T extends PaginationInfo<T>>({
   onPaginationInfoChange,
   initialPaginationInfo,
   showPageSizeSelector = true
-}: PaginationProps) {
-  const [paginationInfo, setPaginationInfo] =
-    useState<SupportedPaginationInfo>(initialPaginationInfo)
+}: PaginationProps<T>) {
+  const [paginationInfo, setPaginationInfo] = useState<T>(initialPaginationInfo)
   const goToPage = (newPage: number) => {
     setPaginationInfo(paginationInfo.goToPage(newPage))
   }

--- a/src/sections/shared/pagination/PaginationControls.tsx
+++ b/src/sections/shared/pagination/PaginationControls.tsx
@@ -7,16 +7,19 @@ import { useEffect, useState } from 'react'
 import { FilePaginationInfo } from '../../../files/domain/models/FilePaginationInfo'
 import { DatasetPaginationInfo } from '../../../dataset/domain/models/DatasetPaginationInfo'
 import { NotificationsPaginationInfo } from '@/notifications/domain/models/NotificationsPaginationInfo'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
+import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
+
+type SupportedPaginationInfo =
+  | DatasetPaginationInfo
+  | FilePaginationInfo
+  | NotificationsPaginationInfo
+  | DatasetVersionPaginationInfo
+  | FileVersionPaginationInfo
 
 interface PaginationProps {
-  onPaginationInfoChange: (
-    paginationInfo: PaginationInfo<
-      DatasetPaginationInfo | FilePaginationInfo | NotificationsPaginationInfo
-    >
-  ) => void
-  initialPaginationInfo: PaginationInfo<
-    DatasetPaginationInfo | FilePaginationInfo | NotificationsPaginationInfo
-  >
+  onPaginationInfoChange: (paginationInfo: PaginationInfo<SupportedPaginationInfo>) => void
+  initialPaginationInfo: PaginationInfo<SupportedPaginationInfo>
   showPageSizeSelector?: boolean
 }
 const MINIMUM_NUMBER_OF_PAGES_TO_DISPLAY_PAGINATION = 2
@@ -25,9 +28,8 @@ export function PaginationControls({
   initialPaginationInfo,
   showPageSizeSelector = true
 }: PaginationProps) {
-  const [paginationInfo, setPaginationInfo] = useState<
-    DatasetPaginationInfo | FilePaginationInfo | NotificationsPaginationInfo
-  >(initialPaginationInfo)
+  const [paginationInfo, setPaginationInfo] =
+    useState<SupportedPaginationInfo>(initialPaginationInfo)
   const goToPage = (newPage: number) => {
     setPaginationInfo(paginationInfo.goToPage(newPage))
   }

--- a/tests/component/sections/dataset/dataset-versions/DatasetVersions.spec.tsx
+++ b/tests/component/sections/dataset/dataset-versions/DatasetVersions.spec.tsx
@@ -8,6 +8,7 @@ import { DatasetVersionDiff } from '@/dataset/domain/models/DatasetVersionDiff'
 import { DatasetVersionState } from '@/dataset/domain/models/Dataset'
 import { DatasetVersionsSummariesMother } from '../../../dataset/domain/models/DatasetVersionsSummariesMother'
 import { DatasetVersionDiffMother } from '../../../dataset/domain/models/DatasetVersionDiffMother'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 
 const datasetsRepository: DatasetRepository = {} as DatasetRepository
 
@@ -397,5 +398,58 @@ describe('DatasetVersions', () => {
 
     // Assert ordering: oldVersion '4.0', newVersion '5.0'
     cy.wrap(diffStub).should('have.been.calledWith', 'pid', '4.0', '5.0', true)
+  })
+
+  it('fetches dataset versions with pagination when changing pages', () => {
+    const paginatedVersions: DatasetVersionSummaryInfo[] = Array.from(
+      { length: 11 },
+      (_, index) => ({
+        id: index + 1,
+        versionNumber: `${11 - index}.0`,
+        summary: {},
+        contributors: 'Test ',
+        publishedOn: ''
+      })
+    )
+    const getDatasetVersionsSummariesStub = cy
+      .stub()
+      .callsFake((_datasetId: string, paginationInfo: DatasetVersionPaginationInfo) => {
+        const start = paginationInfo.offset
+        return Promise.resolve({
+          summaries: paginatedVersions.slice(start, start + paginationInfo.pageSize),
+          totalCount: paginatedVersions.length
+        })
+      })
+    datasetsRepository.getDatasetVersionsSummaries = getDatasetVersionsSummariesStub
+
+    cy.customMount(
+      <DatasetVersions
+        datasetId={'datasetId'}
+        datasetRepository={datasetsRepository}
+        currentVersionNumber={'11.0'}
+        canUpdateDataset={true}
+        isInView
+      />
+    )
+
+    cy.wrap(getDatasetVersionsSummariesStub).should(() => {
+      const firstCallPaginationInfo = getDatasetVersionsSummariesStub.getCall(0)
+        .args[1] as DatasetVersionPaginationInfo
+      expect(firstCallPaginationInfo.page).to.equal(1)
+      expect(firstCallPaginationInfo.pageSize).to.equal(11)
+      expect(firstCallPaginationInfo.offset).to.equal(0)
+    })
+
+    cy.findByRole('button', { name: 'Next' }).click()
+
+    cy.wrap(getDatasetVersionsSummariesStub).should(() => {
+      const secondCallPaginationInfo = getDatasetVersionsSummariesStub.getCall(1)
+        .args[1] as DatasetVersionPaginationInfo
+      expect(secondCallPaginationInfo.page).to.equal(2)
+      expect(secondCallPaginationInfo.pageSize).to.equal(11)
+      expect(secondCallPaginationInfo.offset).to.equal(10)
+    })
+    cy.findByText('1.0').should('exist')
+    cy.findByText('11.0').should('not.exist')
   })
 })

--- a/tests/component/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.spec.tsx
+++ b/tests/component/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries.spec.tsx
@@ -3,6 +3,7 @@ import { DatasetRepository } from '@/dataset/domain/repositories/DatasetReposito
 import { ReadError } from '@iqss/dataverse-client-javascript'
 import { DatasetVersionsSummariesMother } from '@tests/component/dataset/domain/models/DatasetVersionsSummariesMother'
 import { useGetDatasetVersionsSummaries } from '@/sections/dataset/dataset-versions/useGetDatasetVersionsSummaries'
+import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
 
@@ -107,6 +108,38 @@ describe('useGetDatasetVersionsSummaries', () => {
       expect(result.current.isLoading).to.equal(false)
       expect(result.current.datasetVersionSummaries).to.deep.equal(datasetVersionsSummariesMock)
       expect(datasetRepository.getDatasetVersionsSummaries).to.have.been.calledOnce
+    })
+  })
+
+  it('should fetch summaries with pagination info and return the total count', () => {
+    const paginationInfo = new DatasetVersionPaginationInfo(2, 10, 11)
+    datasetRepository.getDatasetVersionsSummaries = cy
+      .stub()
+      .resolves(datasetVersionsSummariesSubsetMock)
+
+    const { result } = renderHook(() =>
+      useGetDatasetVersionsSummaries({
+        datasetRepository,
+        persistentId: 'doi:10.5072/FK2/ABC123',
+        autoFetch: false
+      })
+    )
+
+    let totalCount: number | undefined
+
+    act(() => {
+      void result.current.fetchSummaries(paginationInfo).then((count) => {
+        totalCount = count
+      })
+    })
+
+    cy.wrap(null).should(() => {
+      expect(result.current.isLoading).to.equal(false)
+      expect(datasetRepository.getDatasetVersionsSummaries).to.have.been.calledWith(
+        'doi:10.5072/FK2/ABC123',
+        paginationInfo
+      )
+      expect(totalCount).to.equal(datasetVersionsSummariesSubsetMock.totalCount)
     })
   })
 

--- a/tests/component/sections/file/File.spec.tsx
+++ b/tests/component/sections/file/File.spec.tsx
@@ -101,7 +101,11 @@ describe('File', () => {
 
   it('renders the FileVersions component', () => {
     const testFile = FileMother.createRealistic()
+    const summaries = FileMother.createFileVersionSummary()
     fileRepository.getById = cy.stub().resolves(testFile)
+    fileRepository.getFileVersionSummaries = cy
+      .stub()
+      .resolves({ summaries, totalCount: summaries.length })
 
     cy.customMount(
       <File

--- a/tests/component/sections/file/file-version/FileVersions.spec.tsx
+++ b/tests/component/sections/file/file-version/FileVersions.spec.tsx
@@ -3,6 +3,8 @@ import { FileVersions } from '../../../../../src/sections/file/file-version/File
 import { FileMother } from '../../../files/domain/models/FileMother'
 import { DatasetVersionState } from '@iqss/dataverse-client-javascript'
 import { QueryParamKey, Route } from '@/sections/Route.enum'
+import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
+import { FileVersionSummarySubset } from '@/files/domain/models/FileVersionSummaryInfo'
 
 const fileVersionSummaries = FileMother.createFileVersionSummary()
 const fileVersionSummariesSubset = {
@@ -212,5 +214,58 @@ describe('FileVersions', () => {
       />
     )
     cy.contains('File not included in this version.').should('exist')
+  })
+
+  it('fetches file versions with pagination when changing pages', () => {
+    const paginatedVersions = Array.from({ length: 11 }, (_, index) => ({
+      ...fileVersionSummaries[0],
+      datafileId: index + 1,
+      datasetVersion: `${11 - index}.0`
+    }))
+    const getFileVersionSummariesStub = cy
+      .stub()
+      .callsFake(
+        (
+          _fileId: number,
+          paginationInfo: FileVersionPaginationInfo
+        ): Promise<FileVersionSummarySubset> => {
+          const start = paginationInfo.offset
+          return Promise.resolve({
+            summaries: paginatedVersions.slice(start, start + paginationInfo.pageSize),
+            totalCount: paginatedVersions.length
+          })
+        }
+      )
+    fileRepository.getFileVersionSummaries = getFileVersionSummariesStub
+
+    cy.customMount(
+      <FileVersions
+        fileId={1}
+        datasetVersionNumber={'11.0'}
+        fileRepository={fileRepository}
+        canEditOwnerDataset={true}
+        isInView
+      />
+    )
+
+    cy.wrap(getFileVersionSummariesStub).should(() => {
+      const firstCallPaginationInfo = getFileVersionSummariesStub.getCall(0)
+        .args[1] as FileVersionPaginationInfo
+      expect(firstCallPaginationInfo.page).to.equal(1)
+      expect(firstCallPaginationInfo.pageSize).to.equal(10)
+      expect(firstCallPaginationInfo.offset).to.equal(0)
+    })
+
+    cy.findByRole('button', { name: 'Next' }).click()
+
+    cy.wrap(getFileVersionSummariesStub).should(() => {
+      const secondCallPaginationInfo = getFileVersionSummariesStub.getCall(1)
+        .args[1] as FileVersionPaginationInfo
+      expect(secondCallPaginationInfo.page).to.equal(2)
+      expect(secondCallPaginationInfo.pageSize).to.equal(10)
+      expect(secondCallPaginationInfo.offset).to.equal(10)
+    })
+    cy.findByText('1.0').should('exist')
+    cy.findByText('11.0').should('not.exist')
   })
 })

--- a/tests/component/sections/file/file-version/useGetFileVersionsSummaries.spec.tsx
+++ b/tests/component/sections/file/file-version/useGetFileVersionsSummaries.spec.tsx
@@ -3,6 +3,7 @@ import { FileMother } from '../../../files/domain/models/FileMother'
 import { useGetFileVersionsSummaries } from '@/sections/file/file-version/useGetFileVersionsSummaries'
 import { act, renderHook } from '@testing-library/react'
 import { ReadError } from '@iqss/dataverse-client-javascript'
+import { FileVersionPaginationInfo } from '@/files/domain/models/FileVersionPaginationInfo'
 
 const fileVersionSummaries = FileMother.createFileVersionSummary()
 const fileVersionSummariesSubset = {
@@ -129,6 +130,32 @@ describe('useGetFileVersionsSummaries', () => {
       expect(result.current.isLoading).to.deep.equal(false)
       expect(result.current.fileVersionSummaries).to.deep.equal(fileVersionSummaries)
       expect(fileRepository.getFileVersionSummaries).to.have.been.calledWith(1)
+    })
+  })
+
+  it('should fetch data with pagination info and return the total count', () => {
+    const paginationInfo = new FileVersionPaginationInfo(2, 10, 11)
+    fileRepository.getFileVersionSummaries = cy.stub().resolves(fileVersionSummariesSubset)
+    const { result } = renderHook(() =>
+      useGetFileVersionsSummaries({
+        fileRepository,
+        fileId: 1,
+        autoFetch: false
+      })
+    )
+
+    let totalCount: number | undefined
+
+    act(() => {
+      void result.current.fetchSummaries(paginationInfo).then((count) => {
+        totalCount = count
+      })
+    })
+
+    cy.wrap(null).should(() => {
+      expect(result.current.isLoading).to.deep.equal(false)
+      expect(fileRepository.getFileVersionSummaries).to.have.been.calledWith(1, paginationInfo)
+      expect(totalCount).to.deep.equal(fileVersionSummariesSubset.totalCount)
     })
   })
 })


### PR DESCRIPTION
## What this PR does / why we need it:
To improve performance, we need to add pagination to the versions tab, and load only one page of results at a time.

## Which issue(s) this PR closes:

- Closes #974 

## Special notes for your reviewer:

## Suggestions on how to test this:

The PR was deployed on qa.dataverse.org.  To see an example of a dataset with many versions, try https://qa.dataverse.org/modern/datasets?persistentId=doi:10.7910/DVN/2USIUM

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
add pagination controls to Dataset Page Version tab and File Page Version tab

## Is there a release notes or changelog update needed for this change?:
yes

