### PR TITLE
fix for Container dev_solr invalid start port '8983:8983': invalid syntax

### DIFF
--- a/dev-env/docker-compose-dev.yml
+++ b/dev-env/docker-compose-dev.yml
@@ -155,7 +155,7 @@ services:
       dev_solr_initializer:
         condition: service_completed_successfully
     restart: on-failure
-    expose:
+    ports:
       - '8983:8983'
     networks:
       - dataverse


### PR DESCRIPTION
This PR had a defect in it (sorry):

- #928

Now commands like this should work fine, which was the original intent:

```
curl http://localhost:8983/solr/collection1/schema/fields
```

See doc/sphinx-guides/source/container/running/demo.rst under "Additional Metadata Blocks" for related commands. Here: https://guides.dataverse.org/en/6.10.1/container/running/demo.html#additional-metadata-blocks

This change should make the "update Solr" steps in the following PR (where we add the "review" block) actually work:

- #955