### PR TITLE
use new modern url in banner message

### DIFF
--- a/public/config.js
+++ b/public/config.js
@@ -7,7 +7,7 @@ window.__APP_CONFIG__ = {
   backendUrl: 'http://localhost:8000',
   // Optional banner shown at the top of the app when set. Basic HTML markup is supported.
   bannerMessage:
-    "You are using the new Dataverse <strong>Modern version</strong>. This is an early release and some features from the original site are not yet available. Please see the <a href='https://dataverse.harvard.edu/spa/featured-item/harvard/1'>Project Roadmap</a> for details.",
+    "You are using the new Dataverse <strong>Modern version</strong>. This is an early release and some features from the original site are not yet available. Please see the <a href='https://dataverse.harvard.edu/modern/featured-item/harvard/1'>Project Roadmap</a> for details.",
   // OIDC provider settings
   oidc: {
     clientId: 'test',


### PR DESCRIPTION
## What this PR does / why we need it:
The banner message needed to be updated to use the new `modern` url.  Even though this is configurable at runtime, it's easier to create another war file than to update it directly in the Payara environment.