### PR TITLE
Dataset Page reviews sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 ### Added
 
 - Dataset Templates UI integration, including create/edit flows, previews, and skeleton states.
+- Dataset Page: added a sidebar to show dataset reviews
 
 ### Changed
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'cypress'
 import vitePreprocessor from 'cypress-vite'
 import path from 'path'
+import fs from 'node:fs'
+import os from 'node:os'
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const solrCollectionUrl = 'http://localhost:8983/solr/collection1'
+const solrCoreAdminUrl = 'http://localhost:8983/solr/admin/cores'
+const solrSchemaPath = '/var/solr/data/collection1/conf/schema.xml'
+
+type ExecFileError = Error & {
+  stderr?: string
+  stdout?: string
+}
 
 export default defineConfig({
   video: false,
@@ -13,8 +27,47 @@ export default defineConfig({
     viewportWidth: 1920,
     viewportHeight: 1080,
     supportFile: 'tests/support/e2e.ts',
-    setupNodeEvents(on) {
+    setupNodeEvents(on, config) {
       on('file:preprocessor', vitePreprocessor(path.resolve(__dirname, './vite.config.ts')))
+
+      on('task', {
+        async solrSchemaFieldExists(fieldName: string): Promise<boolean> {
+          const statusCode = await runDockerCommand(config, [
+            'exec',
+            getSolrContainerName(config),
+            'curl',
+            '-sS',
+            '-o',
+            '/tmp/solr-schema-field-response.json',
+            '-w',
+            '%{http_code}',
+            `${solrCollectionUrl}/schema/fields/${encodeURIComponent(fieldName)}`
+          ])
+
+          if (statusCode.trim() === '200') {
+            return true
+          }
+
+          if (statusCode.trim() === '404') {
+            return false
+          }
+
+          throw new Error(`Unexpected Solr schema field check status for ${fieldName}: ${statusCode}`)
+        },
+        async replaceSolrSchemaWithDataverseGeneratedSchema(): Promise<null> {
+          const generatedSchemaFragment = await getDataverseGeneratedSolrSchemaFragment(config)
+          const currentSchema = await runDockerCommand(config, [
+            'exec',
+            getSolrContainerName(config),
+            'cat',
+            solrSchemaPath
+          ])
+          const mergedSchema = mergeGeneratedSchemaFragment(currentSchema, generatedSchemaFragment)
+          await copySchemaToSolrContainer(config, mergedSchema)
+          await reloadSolrCore(config)
+          return null
+        }
+      })
     },
     defaultCommandTimeout: 10_000 // https://docs.cypress.io/guides/references/configuration#Timeouts
   },
@@ -62,3 +115,108 @@ export default defineConfig({
     }
   }
 })
+
+function getSolrContainerName(config: Cypress.PluginConfigOptions): string {
+  return (config.env.solrContainerName as string | undefined) ?? 'dev_solr'
+}
+
+async function getDataverseGeneratedSolrSchemaFragment(
+  config: Cypress.PluginConfigOptions
+): Promise<string> {
+  const backendUrl = config.env.backendUrl as string
+  const response = await fetch(`${backendUrl}/api/v1/admin/index/solr/schema`)
+
+  if (!response.ok) {
+    throw new Error(`Error while getting Dataverse-generated Solr schema: ${response.status}`)
+  }
+
+  return response.text()
+}
+
+async function copySchemaToSolrContainer(
+  config: Cypress.PluginConfigOptions,
+  schemaXml: string
+): Promise<void> {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dataverse-solr-schema-'))
+  const tempSchemaPath = path.join(tempDir, 'schema.xml')
+
+  try {
+    fs.writeFileSync(tempSchemaPath, schemaXml)
+    await runDockerCommand(config, [
+      'cp',
+      tempSchemaPath,
+      `${getSolrContainerName(config)}:${solrSchemaPath}`
+    ])
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  }
+}
+
+async function reloadSolrCore(config: Cypress.PluginConfigOptions): Promise<void> {
+  await runDockerCommand(config, [
+    'exec',
+    getSolrContainerName(config),
+    'curl',
+    '-sS',
+    `${solrCoreAdminUrl}?action=RELOAD&core=collection1&wt=json`
+  ])
+}
+
+function mergeGeneratedSchemaFragment(
+  currentSchema: string,
+  generatedSchemaFragment: string
+): string {
+  const generatedSchemaLines = generatedSchemaFragment.split('\n')
+  const fieldLines = generatedSchemaLines.filter((line) => line.includes('<field '))
+  const copyFieldLines = generatedSchemaLines.filter((line) => line.includes('<copyField '))
+
+  return replaceSchemaSection(
+    replaceSchemaSection(
+      currentSchema,
+      '<!-- SCHEMA-FIELDS::BEGIN -->',
+      '<!-- SCHEMA-FIELDS::END -->',
+      fieldLines
+    ),
+    '<!-- SCHEMA-COPY-FIELDS::BEGIN -->',
+    '<!-- SCHEMA-COPY-FIELDS::END -->',
+    copyFieldLines
+  )
+}
+
+function replaceSchemaSection(
+  schema: string,
+  beginMarker: string,
+  endMarker: string,
+  replacementLines: string[]
+): string {
+  const beginIndex = schema.indexOf(beginMarker)
+  const endIndex = schema.indexOf(endMarker)
+
+  if (beginIndex === -1 || endIndex === -1 || beginIndex > endIndex) {
+    throw new Error(`Could not find Solr schema section ${beginMarker}.`)
+  }
+
+  return [
+    schema.slice(0, beginIndex + beginMarker.length),
+    '',
+    replacementLines.join('\n'),
+    schema.slice(endIndex)
+  ].join('\n')
+}
+
+async function runDockerCommand(
+  _config: Cypress.PluginConfigOptions,
+  args: string[]
+): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync('docker', args, { maxBuffer: 10 * 1024 * 1024 })
+    return stdout
+  } catch (error) {
+    const execError = error as ExecFileError
+    throw new Error(
+      `Docker command failed: docker ${args.join(' ')}. Reason was: ${
+        execError.stderr ?? execError.stdout ?? execError.message
+      }`
+    )
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.1.0-alpha.4",
+        "@iqss/dataverse-client-javascript": "2.2.0-pr457.c6b21a4",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3285,9 +3285,9 @@
       }
     },
     "node_modules/@iqss/dataverse-client-javascript": {
-      "version": "2.1.0-alpha.4",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.1.0-alpha.4/0a0dc68d4d99581d7ec017e58dbce3407f99f5d9",
-      "integrity": "sha512-UwHnFSYuvhxpc/JG2cFr5+bwERZXqGfNBTMSUQwtJaj6vfHO7anJAAxAx8g/AB8b4JtR9rljnYjAbsGJXicfBw==",
+      "version": "2.2.0-pr457.c6b21a4",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.2.0-pr457.c6b21a4/c29e777fe839acb125fc0c33bbaf97729a34fbca",
+      "integrity": "sha512-mFcUYGQXemCK3N3BnHnOME7D3LL6qcd547GeH6ThVbxq5/YnE7iVxXUzSv4uHWXXw715T+Y8x3axan8eLygzLA==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@dnd-kit/sortable": "8.0.0",
         "@dnd-kit/utilities": "3.2.2",
         "@faker-js/faker": "7.6.0",
-        "@iqss/dataverse-client-javascript": "2.2.0-pr457.c6b21a4",
+        "@iqss/dataverse-client-javascript": "2.2.0-alpha.10",
         "@iqss/dataverse-design-system": "*",
         "@istanbuljs/nyc-config-typescript": "1.0.2",
         "@tanstack/react-table": "8.9.2",
@@ -3285,9 +3285,9 @@
       }
     },
     "node_modules/@iqss/dataverse-client-javascript": {
-      "version": "2.2.0-pr457.c6b21a4",
-      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.2.0-pr457.c6b21a4/c29e777fe839acb125fc0c33bbaf97729a34fbca",
-      "integrity": "sha512-mFcUYGQXemCK3N3BnHnOME7D3LL6qcd547GeH6ThVbxq5/YnE7iVxXUzSv4uHWXXw715T+Y8x3axan8eLygzLA==",
+      "version": "2.2.0-alpha.10",
+      "resolved": "https://npm.pkg.github.com/download/@IQSS/dataverse-client-javascript/2.2.0-alpha.10/1fcacf53d38b344ea8502ad68aaa69c9eeb66348",
+      "integrity": "sha512-qQx0dLZHEeR4FJh0J4eb7D5sXE+S+PpXB1u8AiySFN4FKXu0wSf50bGEJbmyTqmmvtwfrjuUB2YKl1mCB1rZrg==",
       "license": "MIT",
       "dependencies": {
         "@types/node": "^18.15.11",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.2.0-pr457.c6b21a4",
+    "@iqss/dataverse-client-javascript": "2.2.0-alpha.10",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",
     "@faker-js/faker": "7.6.0",
-    "@iqss/dataverse-client-javascript": "2.1.0-alpha.4",
+    "@iqss/dataverse-client-javascript": "2.2.0-pr457.c6b21a4",
     "@iqss/dataverse-design-system": "*",
     "@istanbuljs/nyc-config-typescript": "1.0.2",
     "@tanstack/react-table": "8.9.2",

--- a/public/locales/en/dataset.json
+++ b/public/locales/en/dataset.json
@@ -330,6 +330,9 @@
     },
     "defaultGetDownloadCountError": "Something went wrong while getting the dataset download count. Try again later."
   },
+  "reviews": {
+    "title": "Dataset Reviews"
+  },
   "persistentId": {
     "name": "Persistent Identifier",
     "description": "The Dataset's unique persistent identifier, either a DOI or Handle"

--- a/public/locales/es/dataset.json
+++ b/public/locales/es/dataset.json
@@ -332,6 +332,9 @@
     },
     "defaultGetDownloadCountError": "Algo salió mal al obtener el conteo de descargas del dataset. Intenta nuevamente más tarde."
   },
+  "reviews": {
+    "title": "Reseñas del dataset"
+  },
   "persistentId": {
     "name": "Identificador persistente",
     "description": "El identificador persistente único del Dataset, ya sea un DOI o Handle"

--- a/src/dataset/domain/models/DatasetReview.ts
+++ b/src/dataset/domain/models/DatasetReview.ts
@@ -1,0 +1,23 @@
+export interface DatasetReview {
+  title: string
+  authors: string[]
+  persistentId: string
+  persistentIdUrl: string
+  id: number
+  citation: string
+  citationHtml: string
+  datePublished: string
+  description: string
+  rubricMetadataBlocks: DatasetReviewRubricMetadataBlock[]
+}
+
+export interface DatasetReviewRubricMetadataBlock {
+  name: string
+  displayName: string
+  fields: DatasetReviewRubricMetadataField[]
+}
+
+export interface DatasetReviewRubricMetadataField {
+  typeName: string
+  value: string
+}

--- a/src/dataset/domain/repositories/DatasetRepository.ts
+++ b/src/dataset/domain/repositories/DatasetRepository.ts
@@ -12,6 +12,7 @@ import { DatasetLicenseUpdateRequest } from '../models/DatasetLicenseUpdateReque
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { DatasetVersionPaginationInfo } from '../models/DatasetVersionPaginationInfo'
 import { DatasetUploadLimits } from '../models/DatasetUploadLimits'
+import { DatasetReview } from '../models/DatasetReview'
 
 export interface DatasetRepository {
   getByPersistentId: (
@@ -70,4 +71,5 @@ export interface DatasetRepository {
   unlink(datasetId: string | number, collectionIdOrAlias: string | number): Promise<void>
   getDatasetLinkedCollections: (datasetId: string | number) => Promise<CollectionSummary[]>
   getDatasetUploadLimits: (datasetId: string | number) => Promise<DatasetUploadLimits>
+  getDatasetReviews: (datasetId: string | number) => Promise<DatasetReview[]>
 }

--- a/src/dataset/domain/useCases/getDatasetReviews.ts
+++ b/src/dataset/domain/useCases/getDatasetReviews.ts
@@ -1,0 +1,9 @@
+import { DatasetReview } from '../models/DatasetReview'
+import { DatasetRepository } from '../repositories/DatasetRepository'
+
+export async function getDatasetReviews(
+  datasetRepository: DatasetRepository,
+  datasetId: string | number
+): Promise<DatasetReview[]> {
+  return datasetRepository.getDatasetReviews(datasetId)
+}

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -44,7 +44,8 @@ import {
   getDatasetLinkedCollections,
   updateTermsOfAccess,
   updateDatasetLicense,
-  getDatasetUploadLimits
+  getDatasetUploadLimits,
+  getDatasetReviews
 } from '@iqss/dataverse-client-javascript'
 import { JSDatasetMapper } from '../mappers/JSDatasetMapper'
 import { DatasetPaginationInfo } from '../../domain/models/DatasetPaginationInfo'
@@ -64,6 +65,7 @@ import { AxiosResponse } from 'axios'
 import { JSDataverseReadErrorHandler } from '@/shared/helpers/JSDataverseReadErrorHandler'
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { DatasetUploadLimits } from '@/dataset/domain/models/DatasetUploadLimits'
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
 
 const includeDeaccessioned = true
 
@@ -473,5 +475,9 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
 
   getDatasetUploadLimits(datasetId: string | number): Promise<DatasetUploadLimits> {
     return getDatasetUploadLimits.execute(datasetId)
+  }
+
+  getDatasetReviews(datasetId: string | number): Promise<DatasetReview[]> {
+    return getDatasetReviews.execute(datasetId)
   }
 }

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -183,7 +183,11 @@ export class FileJSDataverseRepository implements FileRepository {
     )
   }
   private static getAllWithPermissions(files: JSFile[]): Promise<FilePermissions[]> {
-    return Promise.all(files.map((jsFile) => this.getPermissionsById(jsFile.id)))
+    return Promise.all(
+      files.map((jsFile) =>
+        this.getPermissionsByIdOrGuest(jsFile.id, jsFile).then(({ permissions }) => permissions)
+      )
+    )
   }
 
   private static getPermissionsById(id: number): Promise<FilePermissions> {
@@ -320,7 +324,10 @@ export class FileJSDataverseRepository implements FileRepository {
       })
   }
 
-  private static getPermissionsByIdOrGuest(id: number): Promise<{
+  private static getPermissionsByIdOrGuest(
+    id: number,
+    jsFile?: JSFile
+  ): Promise<{
     permissions: FilePermissions
     isGuestFallback: boolean
   }> {
@@ -332,7 +339,10 @@ export class FileJSDataverseRepository implements FileRepository {
 
           if (errorHandler.getStatusCode() === 401) {
             return {
-              permissions: FileJSDataverseRepository.guestFilePermissions,
+              permissions:
+                jsFile !== undefined
+                  ? FileJSDataverseRepository.getGuestPermissionsForFile(jsFile)
+                  : FileJSDataverseRepository.guestFilePermissions,
               isGuestFallback: true
             }
           }

--- a/src/files/infrastructure/FileJSDataverseRepository.ts
+++ b/src/files/infrastructure/FileJSDataverseRepository.ts
@@ -55,6 +55,12 @@ export class FileJSDataverseRepository implements FileRepository {
     return requireAppConfig().backendUrl
   }
 
+  private static readonly guestFilePermissions: FilePermissions = {
+    canDownloadFile: false,
+    canManageFilePermissions: false,
+    canEditOwnerDataset: false
+  }
+
   getAllByDatasetPersistentId(
     datasetPersistentId: string,
     datasetVersion: DatasetVersion,
@@ -260,13 +266,17 @@ export class FileJSDataverseRepository implements FileRepository {
   }
 
   getById(id: number, datasetVersionNumber?: string): Promise<File> {
-    return FileJSDataverseRepository.getPermissionsById(id)
-      .then((permissions) => {
+    return FileJSDataverseRepository.getPermissionsByIdOrGuest(id)
+      .then(({ permissions, isGuestFallback }) => {
         const includeDeaccessioned = permissions?.canEditOwnerDataset
 
         return getFileAndDataset
           .execute(id, datasetVersionNumber, includeDeaccessioned)
           .then(([jsFile, jsDataset]) => {
+            const resolvedPermissions = isGuestFallback
+              ? FileJSDataverseRepository.getGuestPermissionsForFile(jsFile)
+              : permissions
+
             return Promise.all([
               jsFile,
               jsDataset,
@@ -277,7 +287,7 @@ export class FileJSDataverseRepository implements FileRepository {
                 includeDeaccessioned
               ),
               FileJSDataverseRepository.getDownloadCountById(jsFile.id, jsFile.publicationDate),
-              Promise.resolve(permissions),
+              Promise.resolve(resolvedPermissions),
               FileJSDataverseRepository.getThumbnailById(jsFile.id),
               FileJSDataverseRepository.getTabularDataById(jsFile.id, jsFile.tabularData)
             ])
@@ -308,6 +318,35 @@ export class FileJSDataverseRepository implements FileRepository {
       .catch((error: ReadError) => {
         throw new Error(error.message)
       })
+  }
+
+  private static getPermissionsByIdOrGuest(id: number): Promise<{
+    permissions: FilePermissions
+    isGuestFallback: boolean
+  }> {
+    return FileJSDataverseRepository.getPermissionsById(id)
+      .then((permissions) => ({ permissions, isGuestFallback: false }))
+      .catch((error: ReadError) => {
+        if (error instanceof ReadError) {
+          const errorHandler = new JSDataverseReadErrorHandler(error)
+
+          if (errorHandler.getStatusCode() === 401) {
+            return {
+              permissions: FileJSDataverseRepository.guestFilePermissions,
+              isGuestFallback: true
+            }
+          }
+        }
+
+        throw error
+      })
+  }
+
+  private static getGuestPermissionsForFile(jsFile: JSFile): FilePermissions {
+    return {
+      ...FileJSDataverseRepository.guestFilePermissions,
+      canDownloadFile: !jsFile.restricted && jsFile.embargo === undefined
+    }
   }
 
   private static getCitationById(

--- a/src/sections/dataset/Dataset.tsx
+++ b/src/sections/dataset/Dataset.tsx
@@ -32,6 +32,7 @@ import { DatasetPublishingStatus } from '@/dataset/domain/models/Dataset'
 import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
 import { useAnonymized } from './anonymized/AnonymizedContext'
 import { useDatasetRepositories } from '@/shared/contexts/repositories/RepositoriesProvider'
+import { DatasetReviews } from './dataset-reviews/DatasetReviews'
 
 interface DatasetProps {
   fileRepository: FileRepository
@@ -148,6 +149,7 @@ export function Dataset({
               {(!isCurrentVersionDeaccessioned || canUpdateDataset) && (
                 <DatasetMetrics data-testid="dataset-metrics" datasetId={dataset.persistentId} />
               )}
+              <DatasetReviews datasetId={dataset.persistentId} />
             </Col>
           </Row>
 

--- a/src/sections/dataset/dataset-reviews/DatasetReviews.module.scss
+++ b/src/sections/dataset/dataset-reviews/DatasetReviews.module.scss
@@ -17,8 +17,7 @@
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
-    padding: 0.5rem;
-    padding-left: 1rem;
+    padding: 0.625rem 0.75rem 0.75rem 1.75rem;
     margin: 0;
   }
 

--- a/src/sections/dataset/dataset-reviews/DatasetReviews.module.scss
+++ b/src/sections/dataset/dataset-reviews/DatasetReviews.module.scss
@@ -1,0 +1,28 @@
+@use 'sass:color';
+@import 'node_modules/@iqss/dataverse-design-system/src/lib/assets/styles/design-tokens/colors.module';
+
+.dataset-reviews {
+  margin-bottom: 0.5rem;
+  border: solid 1px $dv-border-color;
+  border-radius: 4px;
+
+  .title {
+    padding: 0.25rem 0.5rem;
+    background: color.adjust($dv-secondary-color, $alpha: -0.7);
+    border-bottom: solid 1px $dv-border-color;
+    font-weight: 500;
+  }
+
+  .list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.5rem;
+    padding-left: 1rem;
+    margin: 0;
+  }
+
+  .item {
+    line-height: 1.25;
+  }
+}

--- a/src/sections/dataset/dataset-reviews/DatasetReviews.tsx
+++ b/src/sections/dataset/dataset-reviews/DatasetReviews.tsx
@@ -1,0 +1,47 @@
+import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
+import { QueryParamKey, Route } from '@/sections/Route.enum'
+import { useDatasetRepositories } from '@/shared/contexts/repositories/RepositoriesProvider'
+import styles from './DatasetReviews.module.scss'
+import { useGetDatasetReviews } from './useGetDatasetReviews'
+
+interface DatasetReviewsProps {
+  datasetId: string | number
+}
+
+export const DatasetReviews = ({ datasetId }: DatasetReviewsProps) => {
+  const { datasetRepository } = useDatasetRepositories()
+  const { t } = useTranslation('dataset')
+  const { datasetReviews, isLoading, error } = useGetDatasetReviews({
+    datasetRepository,
+    datasetId
+  })
+
+  if (isLoading || error || datasetReviews.length === 0) {
+    return null
+  }
+
+  return (
+    <section className={styles['dataset-reviews']} aria-labelledby="dataset-reviews-title">
+      <div id="dataset-reviews-title" className={styles.title}>
+        {t('reviews.title')}
+      </div>
+      <ul className={styles.list}>
+        {datasetReviews.map((datasetReview) => (
+          <li key={datasetReview.id} className={styles.item}>
+            <Link to={getDatasetReviewUrl(datasetReview)}>{datasetReview.title}</Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+function getDatasetReviewUrl(datasetReview: DatasetReview): string {
+  const searchParams = new URLSearchParams({
+    [QueryParamKey.PERSISTENT_ID]: datasetReview.persistentId
+  })
+
+  return `${Route.DATASETS}?${searchParams.toString()}`
+}

--- a/src/sections/dataset/dataset-reviews/DatasetReviews.tsx
+++ b/src/sections/dataset/dataset-reviews/DatasetReviews.tsx
@@ -3,8 +3,8 @@ import { useTranslation } from 'react-i18next'
 import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
 import { QueryParamKey, Route } from '@/sections/Route.enum'
 import { useDatasetRepositories } from '@/shared/contexts/repositories/RepositoriesProvider'
-import styles from './DatasetReviews.module.scss'
 import { useGetDatasetReviews } from './useGetDatasetReviews'
+import styles from './DatasetReviews.module.scss'
 
 interface DatasetReviewsProps {
   datasetId: string | number

--- a/src/sections/dataset/dataset-reviews/useGetDatasetReviews.ts
+++ b/src/sections/dataset/dataset-reviews/useGetDatasetReviews.ts
@@ -1,0 +1,53 @@
+import { useEffect, useState } from 'react'
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
+import { DatasetRepository } from '@/dataset/domain/repositories/DatasetRepository'
+import { getDatasetReviews } from '@/dataset/domain/useCases/getDatasetReviews'
+
+interface UseGetDatasetReviewsProps {
+  datasetRepository: DatasetRepository
+  datasetId: string | number
+}
+
+interface UseGetDatasetReviewsReturn {
+  datasetReviews: DatasetReview[]
+  isLoading: boolean
+  error: string | null
+}
+
+export const useGetDatasetReviews = ({
+  datasetRepository,
+  datasetId
+}: UseGetDatasetReviewsProps): UseGetDatasetReviewsReturn => {
+  const [datasetReviews, setDatasetReviews] = useState<DatasetReview[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const handleGetDatasetReviews = async () => {
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const reviews = await getDatasetReviews(datasetRepository, datasetId)
+        setDatasetReviews(reviews)
+      } catch (err: unknown) {
+        const errorMessage =
+          err instanceof Error && err.message
+            ? err.message
+            : 'Something went wrong getting the dataset reviews. Try again later.'
+        setError(errorMessage)
+        setDatasetReviews([])
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    void handleGetDatasetReviews()
+  }, [datasetRepository, datasetId])
+
+  return {
+    datasetReviews,
+    isLoading,
+    error
+  }
+}

--- a/src/stories/dataset/Dataset.stories.tsx
+++ b/src/stories/dataset/Dataset.stories.tsx
@@ -18,6 +18,7 @@ import { WithNotImplementedModal } from '../WithNotImplementedModal'
 import { MetadataBlockInfoMockRepository } from '../shared-mock-repositories/metadata-block-info/MetadataBlockInfoMockRepository'
 import { DatasetMockRepository } from './DatasetMockRepository'
 import { DatasetWithGuestbookMockRepository } from './DatasetWithGuestbookMockRepository'
+import { DatasetWithReviewsMockRepository } from './DatasetWithReviewsMockRepository'
 import { CollectionMockRepository } from '@/stories/collection/CollectionMockRepository'
 import { ContactMockRepository } from '../shared-mock-repositories/contact/ContactMockRepository'
 import { DataverseInfoMockRepository } from '../shared-mock-repositories/info/DataverseInfoMockRepository'
@@ -25,12 +26,20 @@ import { GuestbookMockRepository } from '../shared-mock-repositories/guestbook/G
 import { GuestbookRepositoryProvider } from '@/sections/guestbooks/GuestbookRepositoryProvider'
 import { GuestbookRepository } from '@/guestbooks/domain/repositories/GuestbookRepository'
 import { DatasetProvider } from '@/sections/dataset/DatasetProvider'
-import { RepositoriesStoryProvider } from '@/stories/WithRepositories'
+import { RepositoriesStoryProvider, WithRepositories } from '@/stories/WithRepositories'
 
 const meta: Meta<typeof Dataset> = {
   title: 'Pages/Dataset',
   component: Dataset,
-  decorators: [WithI18next, WithSettings, WithAlerts],
+  decorators: [
+    WithI18next,
+    WithSettings,
+    WithAlerts,
+    WithRepositories({
+      collectionRepository: new CollectionMockRepository(),
+      datasetRepository: new DatasetMockRepository()
+    })
+  ],
   parameters: {
     // Sets the delay for all stories.
     chromatic: { delay: 15000, pauseAnimationAtEnd: true }
@@ -128,6 +137,23 @@ export const LoggedInAsOwner: Story = {
     <RepositoriesStoryProvider
       collectionRepository={new CollectionMockRepository()}
       datasetRepository={new DatasetMockRepository()}>
+      <Dataset
+        fileRepository={new FileMockRepository()}
+        metadataBlockInfoRepository={new MetadataBlockInfoMockRepository()}
+        contactRepository={new ContactMockRepository()}
+        filesTabInfiniteScrollEnabled
+        dataverseInfoRepository={new DataverseInfoMockRepository()}
+      />
+    </RepositoriesStoryProvider>
+  )
+}
+
+export const WithDatasetReviews: Story = {
+  decorators: [WithLayout, WithDataset, WithNotImplementedModal],
+  render: () => (
+    <RepositoriesStoryProvider
+      collectionRepository={new CollectionMockRepository()}
+      datasetRepository={new DatasetWithReviewsMockRepository()}>
       <Dataset
         fileRepository={new FileMockRepository()}
         metadataBlockInfoRepository={new MetadataBlockInfoMockRepository()}

--- a/src/stories/dataset/DatasetErrorMockRepository.ts
+++ b/src/stories/dataset/DatasetErrorMockRepository.ts
@@ -14,6 +14,7 @@ import { DatasetLicenseUpdateRequest } from '@/dataset/domain/models/DatasetLice
 import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 import { DatasetUploadLimits } from '@/dataset/domain/models/DatasetUploadLimits'
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
 
 export class DatasetErrorMockRepository implements DatasetMockRepository {
   getAllWithCount: (
@@ -199,6 +200,14 @@ export class DatasetErrorMockRepository implements DatasetMockRepository {
   }
 
   getDatasetUploadLimits(_datasetId: string | number): Promise<DatasetUploadLimits> {
+    return new Promise((_resolve, reject) => {
+      setTimeout(() => {
+        reject('Error thrown from mock')
+      }, FakerHelper.loadingTimout())
+    })
+  }
+
+  getDatasetReviews(_datasetId: string | number): Promise<DatasetReview[]> {
     return new Promise((_resolve, reject) => {
       setTimeout(() => {
         reject('Error thrown from mock')

--- a/src/stories/dataset/DatasetMockRepository.ts
+++ b/src/stories/dataset/DatasetMockRepository.ts
@@ -20,6 +20,7 @@ import { CollectionSummary } from '@/collection/domain/models/CollectionSummary'
 import { CollectionSummaryMother } from '@tests/component/collection/domain/models/CollectionSummaryMother'
 import { DatasetVersionPaginationInfo } from '@/dataset/domain/models/DatasetVersionPaginationInfo'
 import { DatasetUploadLimits } from '@/dataset/domain/models/DatasetUploadLimits'
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
 
 export class DatasetMockRepository implements DatasetRepository {
   getAllWithCount: (
@@ -231,6 +232,14 @@ export class DatasetMockRepository implements DatasetRepository {
           numberOfFilesRemaining: 10,
           storageQuotaRemaining: 10737418240 // 10 GB in bytes
         })
+      }, FakerHelper.loadingTimout())
+    })
+  }
+
+  getDatasetReviews(_datasetId: string | number): Promise<DatasetReview[]> {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve([])
       }, FakerHelper.loadingTimout())
     })
   }

--- a/src/stories/dataset/DatasetReviewMockData.ts
+++ b/src/stories/dataset/DatasetReviewMockData.ts
@@ -1,0 +1,30 @@
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
+
+export const datasetReviewsMock: DatasetReview[] = [
+  {
+    id: 101,
+    title: 'Computational reproducibility review of global temperature observations',
+    authors: ['Avery Chen', 'Morgan Singh'],
+    persistentId: 'doi:10.5072/FK2/REVIEW01',
+    persistentIdUrl: 'https://doi.org/10.5072/FK2/REVIEW01',
+    citation:
+      'Chen, Avery; Singh, Morgan, 2026, "Computational reproducibility review of global temperature observations"',
+    citationHtml:
+      'Chen, Avery; Singh, Morgan, 2026, "Computational reproducibility review of global temperature observations"',
+    datePublished: '2026-02-03',
+    description: 'A review dataset focused on workflow execution and result reproducibility.',
+    rubricMetadataBlocks: []
+  },
+  {
+    id: 102,
+    title: 'Peer review materials for survey methodology dataset',
+    authors: ['Jordan Rivera'],
+    persistentId: 'doi:10.5072/FK2/REVIEW02',
+    persistentIdUrl: 'https://doi.org/10.5072/FK2/REVIEW02',
+    citation: 'Rivera, Jordan, 2026, "Peer review materials for survey methodology dataset"',
+    citationHtml: 'Rivera, Jordan, 2026, "Peer review materials for survey methodology dataset"',
+    datePublished: '2026-02-10',
+    description: 'Reviewer notes, scoring rubric metadata, and supporting materials.',
+    rubricMetadataBlocks: []
+  }
+]

--- a/src/stories/dataset/DatasetWithReviewsMockRepository.ts
+++ b/src/stories/dataset/DatasetWithReviewsMockRepository.ts
@@ -1,0 +1,9 @@
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
+import { DatasetMockRepository } from './DatasetMockRepository'
+import { datasetReviewsMock } from './DatasetReviewMockData'
+
+export class DatasetWithReviewsMockRepository extends DatasetMockRepository {
+  getDatasetReviews(_datasetId: string | number): Promise<DatasetReview[]> {
+    return Promise.resolve(datasetReviewsMock)
+  }
+}

--- a/src/stories/dataset/dataset-reviews/DatasetReviews.stories.tsx
+++ b/src/stories/dataset/dataset-reviews/DatasetReviews.stories.tsx
@@ -1,0 +1,31 @@
+import { Meta, StoryObj } from '@storybook/react'
+import { DatasetReviews } from '@/sections/dataset/dataset-reviews/DatasetReviews'
+import { RepositoriesStoryProvider } from '@/stories/WithRepositories'
+import { WithI18next } from '@/stories/WithI18next'
+import { DatasetMockRepository } from '../DatasetMockRepository'
+import { DatasetWithReviewsMockRepository } from '../DatasetWithReviewsMockRepository'
+
+const meta: Meta<typeof DatasetReviews> = {
+  title: 'Sections/Dataset Page/DatasetReviews',
+  component: DatasetReviews,
+  decorators: [WithI18next]
+}
+
+export default meta
+type Story = StoryObj<typeof DatasetReviews>
+
+export const WithReviews: Story = {
+  render: () => (
+    <RepositoriesStoryProvider datasetRepository={new DatasetWithReviewsMockRepository()}>
+      <DatasetReviews datasetId="doi:10.5072/FK2/8YOKQI" />
+    </RepositoriesStoryProvider>
+  )
+}
+
+export const WithoutReviews: Story = {
+  render: () => (
+    <RepositoriesStoryProvider datasetRepository={new DatasetMockRepository()}>
+      <DatasetReviews datasetId="doi:10.5072/FK2/8YOKQI" />
+    </RepositoriesStoryProvider>
+  )
+}

--- a/tests/component/metadata-block-info/domain/models/MetadataBlockInfoMother.ts
+++ b/tests/component/metadata-block-info/domain/models/MetadataBlockInfoMother.ts
@@ -50,6 +50,12 @@ export class MetadataBlockInfoMother {
           title: 'Subject',
           description: 'The area of study relevant to the Dataset'
         },
+        keyword: {
+          displayFormat: '#VALUE',
+          type: 'TEXT',
+          title: 'Keyword',
+          description: 'Key terms that describe important aspects of the Dataset'
+        },
         author: {
           displayFormat: '',
           type: 'NONE',
@@ -121,6 +127,18 @@ export class MetadataBlockInfoMother {
           type: 'TEXTBOX',
           title: 'Text',
           description: 'A summary describing the purpose, nature, and scope of the Dataset'
+        },
+        publication: {
+          displayFormat: '#VALUE',
+          type: 'TEXT',
+          title: 'Related Publication',
+          description: 'A publication that uses, cites, or is related to this Dataset'
+        },
+        notesText: {
+          displayFormat: '#VALUE',
+          type: 'TEXTBOX',
+          title: 'Notes',
+          description: 'Additional important information about the Dataset'
         },
         producerURL: {
           displayFormat: '[#VALUE](#VALUE)',

--- a/tests/component/sections/dataset/Dataset.spec.tsx
+++ b/tests/component/sections/dataset/Dataset.spec.tsx
@@ -28,6 +28,7 @@ import { ContactRepository } from '@/contact/domain/repositories/ContactReposito
 import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
 import { DatasetMetadataExportFormatsMother } from '@tests/component/info/domain/models/DatasetMetadataExportFormatsMother'
 import { WithRepositories } from '@tests/component/WithRepositories'
+import { DatasetReview } from '@/dataset/domain/models/DatasetReview'
 
 const setAnonymizedView = () => {}
 const fileRepository: FileRepository = {} as FileRepository
@@ -156,7 +157,8 @@ describe('Dataset', () => {
   const mountWithDataset = (
     component: ReactNode,
     dataset: DatasetModel | undefined,
-    anonymizedView = false
+    anonymizedView = false,
+    datasetReviews: DatasetReview[] = []
   ) => {
     const searchParams = anonymizedView
       ? { privateUrlToken: 'some-private-url-token' }
@@ -164,6 +166,7 @@ describe('Dataset', () => {
     datasetRepository.getByPersistentId = cy.stub().resolves(dataset)
     datasetRepository.getByPrivateUrlToken = cy.stub().resolves(dataset)
     datasetRepository.getLocks = cy.stub().resolves([])
+    datasetRepository.getDatasetReviews = cy.stub().resolves(datasetReviews)
     contactRepository.sendFeedbacktoOwners = cy.stub().resolves([])
     fileRepository.getAllByDatasetPersistentIdWithCount = cy.stub().resolves(testFiles)
     fileRepository.getFilesCountInfoByDatasetPersistentId = cy.stub().resolves(testFilesCountInfo)
@@ -524,6 +527,41 @@ describe('Dataset', () => {
     )
 
     cy.findByTestId('dataset-metrics').should('not.exist')
+  })
+
+  it('renders dataset reviews under the right-side metrics', () => {
+    const datasetReview: DatasetReview = {
+      id: 23,
+      title: 'Review of Some Title',
+      authors: ['Reviewer One'],
+      persistentId: 'doi:10.5072/FK2/REVIEW1',
+      persistentIdUrl: 'https://doi.org/10.5072/FK2/REVIEW1',
+      citation: 'Review citation',
+      citationHtml: 'Review citation',
+      datePublished: '2026-02-03',
+      description: 'A review dataset',
+      rubricMetadataBlocks: []
+    }
+    mountWithDataset(
+      <Dataset
+        fileRepository={fileRepository}
+        metadataBlockInfoRepository={metadataBlockInfoRepository}
+        contactRepository={contactRepository}
+        dataverseInfoRepository={dataverseInfoRepository}
+      />,
+      testDataset,
+      false,
+      [datasetReview]
+    )
+
+    cy.findByText('Dataset Reviews').should('exist')
+    cy.findByRole('link', { name: datasetReview.title })
+      .should('have.attr', 'href')
+      .and('include', '/datasets?persistentId=doi%3A10.5072%2FFK2%2FREVIEW1')
+    cy.wrap(datasetRepository.getDatasetReviews).should(
+      'have.been.calledWith',
+      testDataset.persistentId
+    )
   })
 
   it('should render all tabs if the dataset is in deaccessioned version, and user has edit permission', () => {

--- a/tests/e2e-integration/e2e/sections/auth/Login.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/auth/Login.spec.tsx
@@ -40,7 +40,7 @@ describe('Login', () => {
 
     TestsUtils.finishSignUp()
 
-    cy.url().should((currentUrl) => {
+    cy.url({ timeout: 30_000 }).should((currentUrl) => {
       const baseUrl = Cypress.config().baseUrl as string
       expect([
         `${baseUrl}${FRONTEND_BASE_PATH}`,

--- a/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/dataset/Dataset.spec.tsx
@@ -11,6 +11,10 @@ import { CollectionHelper } from '../../../shared/collection/CollectionHelper'
 import { FILES_TAB_INFINITE_SCROLL_ENABLED } from '../../../../../src/sections/dataset/config'
 import { GuestbookHelper } from '../../../shared/guestbooks/GuestbookHelper'
 import { faker } from '@faker-js/faker'
+import {
+  DatasetReviewHelper,
+  REVIEW_SOLR_SCHEMA_FIELD_NAMES
+} from '../../../shared/datasets/DatasetReviewHelper'
 
 type Dataset = {
   datasetVersion: { metadataBlocks: { citation: { fields: { value: string }[] } } }
@@ -179,6 +183,65 @@ describe('Dataset', () => {
             cy.findByText('Files').should('exist')
           })
         })
+    })
+
+    it('shows dataset reviews for a dataset with a published local review dataset', () => {
+      const timestamp = new Date().valueOf()
+      const collectionAlias = `dataset-reviews-${timestamp}`
+      const targetDatasetTitle = `Dataset with Review ${timestamp}`
+      const reviewDatasetTitle = `Review of Dataset ${timestamp}`
+
+      cy.then(() => DatasetReviewHelper.ensureReviewMetadataBlocksExist())
+      cy.task('replaceSolrSchemaWithDataverseGeneratedSchema')
+      REVIEW_SOLR_SCHEMA_FIELD_NAMES.forEach((fieldName) => {
+        cy.task('solrSchemaFieldExists', fieldName).should('equal', true)
+      })
+
+      cy.then(() =>
+        CollectionHelper.create(collectionAlias).then(async (collection) => {
+          await DatasetReviewHelper.ensureReviewDatasetTypeExists()
+          await DatasetReviewHelper.allowReviewDatasetTypeInCollection(collectionAlias)
+
+          if (!collection.isReleased) {
+            await CollectionHelper.publish(collection.id)
+          }
+        })
+      )
+
+      cy.then(
+        {
+          timeout: 45_000
+        },
+        () =>
+          DatasetHelper.createWithTitle(targetDatasetTitle, collectionAlias).then(
+            async (target) => {
+              await DatasetHelper.publish(target.persistentId)
+              const review = await DatasetReviewHelper.createReviewDataset(
+                collectionAlias,
+                target.persistentId,
+                reviewDatasetTitle
+              )
+              await DatasetHelper.publish(review.persistentId)
+              const indexedReview = await DatasetReviewHelper.waitForDatasetReview(
+                target.persistentId,
+                Number(review.id)
+              )
+
+              return { target, indexedReview }
+            }
+          )
+      ).then(({ target, indexedReview }) => {
+        cy.visit(`${FRONTEND_BASE_PATH}/datasets?persistentId=${target.persistentId}`)
+
+        cy.findByText('Dataset Reviews').should('exist')
+        cy.findByRole('link', { name: reviewDatasetTitle })
+          .should('exist')
+          .and(
+            'have.attr',
+            'href',
+            `/modern/datasets?persistentId=${encodeURIComponent(indexedReview.persistentId)}`
+          )
+      })
     })
 
     it('loads page not found when the user is not authenticated and tries to access a draft', () => {

--- a/tests/e2e-integration/e2e/sections/file/File.spec.tsx
+++ b/tests/e2e-integration/e2e/sections/file/File.spec.tsx
@@ -144,7 +144,6 @@ describe('File', () => {
             GuestbookHelper.createAndGetByName(guestbookName).then(async (guestbook) => {
               await GuestbookHelper.assignToDataset(Number(dataset.id), guestbook.id)
               await DatasetHelper.publish(dataset.persistentId)
-
               return file
             })
           )
@@ -233,6 +232,7 @@ describe('File', () => {
             cy.findByTestId('download-original-file').should('exist').click({ force: true })
 
             cy.findByRole('dialog').should('be.visible')
+            cy.findByRole('dialog').find('.modal-title').should('contain.text', 'Dataset Terms')
             cy.findByText('Custom Dataset Terms').should('exist')
             // Guestbook fields should not be visible since there is no guestbook
             cy.findByLabelText(/name/i).should('not.exist')

--- a/tests/e2e-integration/shared/TestsUtils.ts
+++ b/tests/e2e-integration/shared/TestsUtils.ts
@@ -3,6 +3,7 @@ import { DataverseApiHelper } from './DataverseApiHelper'
 import { DataverseApiAuthMechanism } from '@iqss/dataverse-client-javascript/dist/core/infra/repositories/ApiConfig'
 import { DatasetHelper } from './datasets/DatasetHelper'
 import { requireAppConfig } from '@/config'
+import { FRONTEND_BASE_PATH } from './basePath'
 
 export class TestsUtils {
   static get DATAVERSE_BACKEND_URL(): string {
@@ -74,16 +75,28 @@ export class TestsUtils {
   }
 
   static finishSignUp() {
-    cy.get('body').then(($body) => {
-      const isOnSignUpPage = $body.find('[data-testid="sign-up-page"]').length > 0
-      const hasTermsCheckbox = $body.find('#termsAccepted').length > 0
+    cy.location({ timeout: 30_000 })
+      .should((location) => {
+        const isOnSignUpPage =
+          location.pathname === `${FRONTEND_BASE_PATH}/sign-up` &&
+          location.search.includes('validTokenButNotLinkedAccount=true')
+        const isAlreadySignedIn = [
+          `${FRONTEND_BASE_PATH}`,
+          `${FRONTEND_BASE_PATH}/collections`
+        ].includes(location.pathname)
 
-      if (!isOnSignUpPage || !hasTermsCheckbox) {
-        return
-      }
+        expect(isOnSignUpPage || isAlreadySignedIn, `current location ${location.href}`).to.equal(
+          true
+        )
+      })
+      .then((location) => {
+        if (location.pathname !== `${FRONTEND_BASE_PATH}/sign-up`) {
+          return
+        }
 
-      cy.get('#termsAccepted').check({ force: true })
-      cy.findByRole('button', { name: 'Create Account' }).click()
-    })
+        cy.findByTestId('sign-up-page').should('be.visible')
+        cy.get('#termsAccepted').should('be.visible').check({ force: true })
+        cy.findByRole('button', { name: 'Create Account' }).should('be.enabled').click()
+      })
   }
 }

--- a/tests/e2e-integration/shared/datasets/DatasetHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetHelper.ts
@@ -17,12 +17,22 @@ export interface DatasetFileResponse {
   id: number
 }
 
+function createDatasetPayload(title?: string): typeof newDatasetData {
+  const datasetPayload = structuredClone(newDatasetData)
+
+  if (title !== undefined) {
+    datasetPayload.datasetVersion.metadataBlocks.citation.fields[0].value = title
+  }
+
+  return datasetPayload
+}
+
 export class DatasetHelper extends DataverseApiHelper {
   static async create(collectionId = ROOT_COLLECTION_ALIAS): Promise<DatasetResponse> {
     return this.request<DatasetResponse>(
       `/dataverses/${collectionId}/datasets`,
       'POST',
-      newDatasetData
+      createDatasetPayload()
     )
   }
 
@@ -30,11 +40,10 @@ export class DatasetHelper extends DataverseApiHelper {
     title: string,
     collectionId = ROOT_COLLECTION_ALIAS
   ): Promise<DatasetResponse> {
-    newDatasetData.datasetVersion.metadataBlocks.citation.fields[0].value = title
     return this.request<DatasetResponse>(
       `/dataverses/${collectionId}/datasets`,
       'POST',
-      newDatasetData
+      createDatasetPayload(title)
     )
   }
 

--- a/tests/e2e-integration/shared/datasets/DatasetReviewHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetReviewHelper.ts
@@ -1,0 +1,355 @@
+import { DataverseApiHelper } from '../DataverseApiHelper'
+import { DatasetResponse } from './DatasetHelper'
+
+const REVIEW_DATASET_TYPE_NAME = 'review'
+const DEFAULT_DATASET_TYPE_NAME = 'dataset'
+const RUBRIC_METADATA_BLOCK_NAME = 'rubric_trusteddatadimensionsintensities'
+
+export const REVIEW_SOLR_SCHEMA_FIELD_NAMES = [
+  'itemReviewed',
+  'itemReviewedCitation',
+  'itemReviewedType',
+  'itemReviewedUrl',
+  'authorAndProvenance'
+]
+
+const REVIEW_METADATA_BLOCK_TSV = [
+  '#metadataBlock\tname\tdataverseAlias\tdisplayName',
+  '\treview\t\tReview Metadata',
+  [
+    '#datasetField',
+    'name',
+    'title',
+    'description',
+    'watermark',
+    'fieldType',
+    'displayOrder',
+    'displayFormat',
+    'advancedSearchField',
+    'allowControlledVocabulary',
+    'allowmultiples',
+    'facetable',
+    'displayoncreate',
+    'required',
+    'parent',
+    'metadatablock_id',
+    'termURI'
+  ].join('\t'),
+  '\titemReviewed\tItem Reviewed\tThe item being reviewed\t\tnone\t1\t\tFALSE\tFALSE\tFALSE\tFALSE\tTRUE\tTRUE\t\treview\t',
+  '\titemReviewedUrl\tURL\tThe URL of the item being reviewed\t\turl\t2\t\tFALSE\tFALSE\tFALSE\tFALSE\tTRUE\tTRUE\titemReviewed\treview\t',
+  '\titemReviewedType\tType\tThe type of the item being reviewed\t\ttext\t3\t\tFALSE\tTRUE\tFALSE\tFALSE\tTRUE\tTRUE\titemReviewed\treview\t',
+  '\titemReviewedCitation\tCitation\tThe full bibliographic citation of the item being reviewed\t\ttextbox\t4\t\tFALSE\tFALSE\tFALSE\tFALSE\tTRUE\tTRUE\titemReviewed\treview\t',
+  '#controlledVocabulary\tDatasetField\tValue\tidentifier\tdisplayOrder',
+  '\titemReviewedType\tAudiovisual\t\t0',
+  '\titemReviewedType\tAward\t\t1',
+  '\titemReviewedType\tBook\t\t2',
+  '\titemReviewedType\tBook Chapter\t\t3',
+  '\titemReviewedType\tCollection\t\t4',
+  '\titemReviewedType\tComputational Notebook\t\t5',
+  '\titemReviewedType\tConference Paper\t\t6',
+  '\titemReviewedType\tConference Proceeding\t\t7',
+  '\titemReviewedType\tDataPaper\t\t8',
+  '\titemReviewedType\tDataset\t\t9',
+  '\titemReviewedType\tDissertation\t\t10',
+  '\titemReviewedType\tEvent\t\t11',
+  '\titemReviewedType\tImage\t\t12',
+  '\titemReviewedType\tInteractive Resource\t\t13',
+  '\titemReviewedType\tInstrument\t\t14',
+  '\titemReviewedType\tJournal\t\t15',
+  '\titemReviewedType\tJournal Article\t\t16',
+  '\titemReviewedType\tModel\t\t17',
+  '\titemReviewedType\tOutput Management Plan\t\t18',
+  '\titemReviewedType\tPeer Review\t\t19',
+  '\titemReviewedType\tPhysical Object\t\t20',
+  '\titemReviewedType\tPreprint\t\t21',
+  '\titemReviewedType\tProject\t\t22',
+  '\titemReviewedType\tReport\t\t23',
+  '\titemReviewedType\tService\t\t24',
+  '\titemReviewedType\tSoftware\t\t25',
+  '\titemReviewedType\tSound\t\t26',
+  '\titemReviewedType\tStandard\t\t27',
+  '\titemReviewedType\tStudy Registration\t\t28',
+  '\titemReviewedType\tText\t\t29',
+  '\titemReviewedType\tWorkflow\t\t30',
+  '\titemReviewedType\tOther\t\t31'
+].join('\n')
+
+const RUBRIC_METADATA_BLOCK_TSV = [
+  '#metadataBlock\tname\tdataverseAlias\tdisplayName\tblockURI',
+  `\t${RUBRIC_METADATA_BLOCK_NAME}\t\tTrusted Data Dimensions and Intensities\t`,
+  [
+    '#datasetField',
+    'name',
+    'title',
+    'description',
+    'watermark',
+    'fieldType',
+    'displayOrder',
+    'displayFormat',
+    'advancedSearchField',
+    'allowControlledVocabulary',
+    'allowmultiples',
+    'facetable',
+    'displayoncreate',
+    'required',
+    'parent',
+    'metadatablock_id',
+    'termURI'
+  ].join('\t'),
+  `\tauthorAndProvenance\tAuthor and Provenance\tThe level of trust in the data creators and in other provenance information\t\ttext\t1\t\tTRUE\tTRUE\tFALSE\tTRUE\tFALSE\tFALSE\t\t${RUBRIC_METADATA_BLOCK_NAME}\t`,
+  '#controlledVocabulary\tDatasetField\tValue\tidentifier\tdisplayOrder',
+  '\tauthorAndProvenance\tLow\t\t0',
+  '\tauthorAndProvenance\tMedium\t\t1',
+  '\tauthorAndProvenance\tHigh\t\t2'
+].join('\n')
+
+interface DatasetTypeResponse {
+  id: number
+  name: string
+}
+
+export interface DatasetReviewResponse {
+  id: number
+  title: string
+  persistentId: string
+  persistentIdUrl: string
+}
+
+export class DatasetReviewHelper extends DataverseApiHelper {
+  static async ensureReviewMetadataBlocksExist(): Promise<void> {
+    await this.ensureMetadataBlockExists('review', REVIEW_METADATA_BLOCK_TSV)
+    await this.ensureMetadataBlockExists(RUBRIC_METADATA_BLOCK_NAME, RUBRIC_METADATA_BLOCK_TSV)
+  }
+
+  static async ensureReviewDatasetTypeExists(): Promise<void> {
+    const datasetType = await this.request<DatasetTypeResponse>(
+      `/datasets/datasetTypes/${REVIEW_DATASET_TYPE_NAME}`,
+      'GET'
+    ).catch(() =>
+      this.request<DatasetTypeResponse>('/datasets/datasetTypes', 'POST', {
+        name: REVIEW_DATASET_TYPE_NAME,
+        displayName: 'Review',
+        description: 'A review of a dataset compiled by the expert community.',
+        linkedMetadataBlocks: [],
+        availableLicenses: []
+      })
+    )
+
+    await this.request(`/datasets/datasetTypes/${datasetType.id}`, 'PUT', [
+      'review',
+      RUBRIC_METADATA_BLOCK_NAME
+    ])
+  }
+
+  static async allowReviewDatasetTypeInCollection(collectionAlias: string): Promise<void> {
+    await this.request(
+      `/dataverses/${collectionAlias}/attribute/allowedDatasetTypes?value=${[
+        DEFAULT_DATASET_TYPE_NAME,
+        REVIEW_DATASET_TYPE_NAME
+      ].join(',')}`,
+      'PUT'
+    )
+  }
+
+  static async createReviewDataset(
+    collectionAlias: string,
+    itemReviewedPersistentId: string,
+    reviewTitle: string
+  ): Promise<DatasetResponse> {
+    return this.request<DatasetResponse>(
+      `/dataverses/${collectionAlias}/datasets`,
+      'POST',
+      this.createReviewDatasetPayload(itemReviewedPersistentId, reviewTitle)
+    )
+  }
+
+  static async waitForDatasetReview(
+    datasetId: string | number,
+    reviewDatasetId: number,
+    maxRetries = 20
+  ): Promise<DatasetReviewResponse> {
+    for (let retry = 0; retry < maxRetries; retry++) {
+      const reviews = await this.getDatasetReviews(datasetId)
+      const review = reviews.find((candidate) => candidate.id === reviewDatasetId)
+
+      if (review) {
+        return review
+      }
+
+      await new Promise((resolve) => setTimeout(resolve, 1000))
+    }
+
+    throw new Error(`Expected dataset review ${reviewDatasetId} to be indexed.`)
+  }
+
+  private static async ensureMetadataBlockExists(
+    metadataBlockName: string,
+    metadataBlockTsv: string
+  ): Promise<void> {
+    const exists = await this.request(`/metadatablocks/${metadataBlockName}`, 'GET')
+      .then(() => true)
+      .catch(() => false)
+
+    if (exists) {
+      return
+    }
+
+    await this.request(
+      '/admin/datasetfield/load',
+      'POST',
+      metadataBlockTsv,
+      'text/tab-separated-values'
+    )
+  }
+
+  private static async getDatasetReviews(
+    datasetId: string | number
+  ): Promise<DatasetReviewResponse[]> {
+    const response = await this.request<{ reviews: DatasetReviewResponse[] }>(
+      typeof datasetId === 'number'
+        ? `/datasets/${datasetId}/reviews`
+        : `/datasets/:persistentId/reviews?persistentId=${datasetId}`,
+      'GET'
+    )
+
+    return response.reviews
+  }
+
+  private static createReviewDatasetPayload(itemReviewedPersistentId: string, reviewTitle: string) {
+    const itemReviewedUrl = this.getPersistentIdUrl(itemReviewedPersistentId)
+
+    return {
+      datasetType: REVIEW_DATASET_TYPE_NAME,
+      datasetVersion: {
+        license: {
+          name: 'CC0 1.0',
+          uri: 'http://creativecommons.org/publicdomain/zero/1.0',
+          iconUri: 'https://licensebuttons.net/p/zero/1.0/88x31.png'
+        },
+        metadataBlocks: {
+          citation: {
+            displayName: 'Citation Metadata',
+            fields: [
+              {
+                value: reviewTitle,
+                typeClass: 'primitive',
+                multiple: false,
+                typeName: 'title'
+              },
+              {
+                value: [
+                  {
+                    authorName: {
+                      value: 'Reviewer, Dataverse',
+                      typeClass: 'primitive',
+                      multiple: false,
+                      typeName: 'authorName'
+                    },
+                    authorAffiliation: {
+                      value: 'Dataverse.org',
+                      typeClass: 'primitive',
+                      multiple: false,
+                      typeName: 'authorAffiliation'
+                    }
+                  }
+                ],
+                typeClass: 'compound',
+                multiple: true,
+                typeName: 'author'
+              },
+              {
+                value: [
+                  {
+                    datasetContactEmail: {
+                      value: 'reviewer@mailinator.com',
+                      typeClass: 'primitive',
+                      multiple: false,
+                      typeName: 'datasetContactEmail'
+                    },
+                    datasetContactName: {
+                      value: 'Reviewer, Dataverse',
+                      typeClass: 'primitive',
+                      multiple: false,
+                      typeName: 'datasetContactName'
+                    }
+                  }
+                ],
+                typeClass: 'compound',
+                multiple: true,
+                typeName: 'datasetContact'
+              },
+              {
+                value: [
+                  {
+                    dsDescriptionValue: {
+                      value: 'This is a review of a dataset.',
+                      multiple: false,
+                      typeClass: 'primitive',
+                      typeName: 'dsDescriptionValue'
+                    }
+                  }
+                ],
+                typeClass: 'compound',
+                multiple: true,
+                typeName: 'dsDescription'
+              },
+              {
+                value: ['Medicine, Health and Life Sciences'],
+                typeClass: 'controlledVocabulary',
+                multiple: true,
+                typeName: 'subject'
+              }
+            ]
+          },
+          review: {
+            displayName: 'Review Metadata',
+            fields: [
+              {
+                value: {
+                  itemReviewedUrl: {
+                    value: itemReviewedUrl,
+                    typeClass: 'primitive',
+                    multiple: false,
+                    typeName: 'itemReviewedUrl'
+                  },
+                  itemReviewedType: {
+                    value: 'Dataset',
+                    typeClass: 'controlledVocabulary',
+                    multiple: false,
+                    typeName: 'itemReviewedType'
+                  },
+                  itemReviewedCitation: {
+                    value: 'Dataset with a review, Dataverse, 2026',
+                    typeClass: 'primitive',
+                    multiple: false,
+                    typeName: 'itemReviewedCitation'
+                  }
+                },
+                typeClass: 'compound',
+                multiple: false,
+                typeName: 'itemReviewed'
+              }
+            ]
+          },
+          [RUBRIC_METADATA_BLOCK_NAME]: {
+            displayName: 'Trusted Data Dimensions and Intensities',
+            fields: [
+              {
+                value: 'High',
+                typeClass: 'controlledVocabulary',
+                multiple: false,
+                typeName: 'authorAndProvenance'
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+
+  private static getPersistentIdUrl(persistentId: string): string {
+    return persistentId.startsWith('doi:')
+      ? `https://doi.org/${persistentId.replace(/^doi:/, '')}`
+      : persistentId
+  }
+}

--- a/tests/e2e-integration/shared/datasets/DatasetReviewHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetReviewHelper.ts
@@ -125,15 +125,21 @@ export class DatasetReviewHelper extends DataverseApiHelper {
     const datasetType = await this.request<DatasetTypeResponse>(
       `/datasets/datasetTypes/${REVIEW_DATASET_TYPE_NAME}`,
       'GET'
-    ).catch(() =>
-      this.request<DatasetTypeResponse>('/datasets/datasetTypes', 'POST', {
+    ).catch((error: unknown) => {
+      const status = (error as { response?: { status?: number } }).response?.status
+
+      if (status !== 404) {
+        throw error
+      }
+
+      return this.request<DatasetTypeResponse>('/datasets/datasetTypes', 'POST', {
         name: REVIEW_DATASET_TYPE_NAME,
         displayName: 'Review',
         description: 'A review of a dataset compiled by the expert community.',
         linkedMetadataBlocks: [],
         availableLicenses: []
       })
-    )
+    })
 
     await this.request(`/datasets/datasetTypes/${datasetType.id}`, 'PUT', [
       'review',

--- a/tests/e2e-integration/shared/datasets/DatasetReviewHelper.ts
+++ b/tests/e2e-integration/shared/datasets/DatasetReviewHelper.ts
@@ -194,7 +194,15 @@ export class DatasetReviewHelper extends DataverseApiHelper {
   ): Promise<void> {
     const exists = await this.request(`/metadatablocks/${metadataBlockName}`, 'GET')
       .then(() => true)
-      .catch(() => false)
+      .catch((error: unknown) => {
+        const status = (error as { response?: { status?: number } }).response?.status
+
+        if (status === 404) {
+          return false
+        }
+
+        throw error
+      })
 
     if (exists) {
       return


### PR DESCRIPTION
## What this PR does / why we need it:
Adds a sidebar to the Dataset Page, for Dataset Reviews. This component only is displayed if there are available reviews.

## Which issue(s) this PR closes:

- Closes #985 

## Special notes for your reviewer:
I also made changes in some e2e tests that were failing, because of a change to /api/access/datafile/{id}/userPermissions, and because of a timing issue in the Login test.

## Suggestions on how to test this:
Until the PR to create a Review is merged, it's hard to test the whole workflow in the browser. The Dataset e2e test adds a Dataset and Related Review in the test setup, so you can review that, as well as the component test.


## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
<img width="1207" height="593" alt="Screenshot 2026-06-17 at 5 09 12 PM" src="https://github.com/user-attachments/assets/92108d2f-122c-489f-9208-1fd611e065e7" />

## Is there a release notes or changelog update needed for this change?:
Yes
## Additional documentation:
