### PR TITLE
Open file upload after dataset creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Fixed
 
+- Creating a dataset now opens the Upload Files page for the new draft.
 - After saving on either Edit Template tab (Metadata or Terms), the user is redirected to the templates listing with a success toast instead of staying on the edit page.
 - Edit Template breadcrumb on the Terms page no longer renders the dataset's "Terms and Guestbook" label (templates have no guestbook).
 

--- a/docs/superpowers/plans/2026-07-31-upload-after-create.md
+++ b/docs/superpowers/plans/2026-07-31-upload-after-create.md
@@ -1,0 +1,130 @@
+# Upload Files After Dataset Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Navigate users directly to the Upload Files page after successfully creating a dataset.
+
+**Architecture:** Keep successful submission routing in `useSubmitDataset`. Reuse the existing upload-files route and query parameter contract, while preserving edit-mode and error behavior.
+
+**Tech Stack:** React, TypeScript, React Router, Cypress component tests
+
+---
+
+### Task 1: Prove the create-mode destination
+
+**Files:**
+- Modify: `tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx`
+
+- [ ] **Step 1: Add a location observer and failing assertion**
+
+Import `useLocation`, add a small observer component, mount it alongside the create form in the existing successful-create test, and assert the full in-memory router location:
+
+```tsx
+import { useLocation } from 'react-router-dom'
+
+const LocationObserver = () => {
+  const location = useLocation()
+
+  return <div data-testid="router-location">{`${location.pathname}${location.search}`}</div>
+}
+```
+
+```tsx
+<>
+  <DatasetMetadataForm
+    mode="create"
+    collectionId="root"
+    metadataBlockInfoRepository={metadataBlockInfoRepository}
+  />
+  <LocationObserver />
+</>
+```
+
+```tsx
+cy.findByTestId('router-location').should(
+  'have.text',
+  '/datasets/upload-files?persistentId=persistentId&version=DRAFT'
+)
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+npm run test:unit -- --spec tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
+```
+
+Expected: the successful-create test fails because the location is `/datasets?persistentId=persistentId&version=DRAFT`.
+
+### Task 2: Redirect successful creation to Upload Files
+
+**Files:**
+- Modify: `src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts`
+
+- [ ] **Step 1: Change only the create-mode route**
+
+Replace the current successful-create navigation with the existing upload route while preserving the query parameters:
+
+```ts
+navigate(
+  `${Route.UPLOAD_DATASET_FILES}?${QueryParamKey.PERSISTENT_ID}=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`
+)
+```
+
+- [ ] **Step 2: Run the focused component spec and verify GREEN**
+
+Run:
+
+```bash
+npm run test:unit -- --spec tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
+```
+
+Expected: all tests in the spec pass, including the upload-files destination assertion.
+
+- [ ] **Step 3: Add the changelog entry**
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+Add under the current Unreleased fixes:
+
+```markdown
+- Creating a dataset now opens the Upload Files page for the new draft.
+```
+
+### Task 3: Verify and submit
+
+**Files:**
+- Verify: `CHANGELOG.md`
+- Verify: `src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts`
+- Verify: `tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx`
+
+- [ ] **Step 1: Run lint**
+
+Run `npm run lint`.
+
+Expected: exit code 0, with no new errors.
+
+- [ ] **Step 2: Run the production build**
+
+Run `npm run build`.
+
+Expected: exit code 0.
+
+- [ ] **Step 3: Check the patch**
+
+Run `git diff --check` and `git status --short`.
+
+Expected: no whitespace errors and only the planned files are modified.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
+git commit -m "fix: open file upload after dataset creation"
+```
+
+- [ ] **Step 5: Push and open the pull request**
+
+Push `fix/redirect-after-create-1031` to the fork and open a PR against `IQSS/dataverse-frontend:develop` with `Closes #1031`.

--- a/docs/superpowers/plans/2026-07-31-upload-after-create.md
+++ b/docs/superpowers/plans/2026-07-31-upload-after-create.md
@@ -13,6 +13,7 @@
 ### Task 1: Prove the create-mode destination
 
 **Files:**
+
 - Modify: `tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx`
 
 - [ ] **Step 1: Add a location observer and failing assertion**
@@ -60,6 +61,7 @@ Expected: the successful-create test fails because the location is `/datasets?pe
 ### Task 2: Redirect successful creation to Upload Files
 
 **Files:**
+
 - Modify: `src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts`
 
 - [ ] **Step 1: Change only the create-mode route**
@@ -85,6 +87,7 @@ Expected: all tests in the spec pass, including the upload-files destination ass
 - [ ] **Step 3: Add the changelog entry**
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 
 Add under the current Unreleased fixes:
@@ -96,6 +99,7 @@ Add under the current Unreleased fixes:
 ### Task 3: Verify and submit
 
 **Files:**
+
 - Verify: `CHANGELOG.md`
 - Verify: `src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts`
 - Verify: `tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx`

--- a/docs/superpowers/specs/2026-07-31-upload-after-create-design.md
+++ b/docs/superpowers/specs/2026-07-31-upload-after-create-design.md
@@ -1,0 +1,31 @@
+# Upload Files After Dataset Creation
+
+## Context
+
+After creating a dataset, the frontend currently navigates to the new draft's dataset page. Issue #1031 asks to remove the extra click required to begin adding files by taking the user directly to the existing Upload Files page.
+
+## Design
+
+Keep the behavior in `useSubmitDataset`, where successful create and edit submissions already choose their destinations. On a successful create response, build the existing upload-files URL with the returned persistent ID and the `DRAFT` version search parameter, then navigate to it. Successful metadata edits continue to return to the draft dataset page.
+
+This reuses the route and query contract already used by `DatasetUploadFilesButton`. It avoids adding callback props through `CreateDataset`, `DatasetMetadataForm`, and `MetadataForm`, and avoids loading the dataset page only to perform a second redirect.
+
+## Data Flow
+
+1. The user submits valid create-dataset metadata.
+2. `datasetRepository.create` returns the new dataset's persistent ID.
+3. Existing success state, notification refresh, and toast behavior run unchanged.
+4. The router navigates to `/datasets/upload-files` with `persistentId` and `version=DRAFT` query parameters.
+5. `UploadDatasetFilesFactory` reads those parameters and loads the new draft through `DatasetProvider`.
+
+## Error Handling
+
+Creation failures retain the current validation and fallback error handling. No navigation occurs when creation fails. The upload page retains responsibility for displaying missing or unavailable datasets.
+
+## Testing
+
+Add a component regression test that submits the create-mode metadata form with valid required fields and asserts that the browser location becomes the upload-files URL for the returned persistent ID and draft version. Run the focused component spec, lint, production build, and `git diff --check` before submission.
+
+## Scope
+
+This change does not alter backend APIs, file upload behavior, edit-mode navigation, cancellation, or dataset creation validation.

--- a/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
+++ b/src/sections/shared/form/DatasetMetadataForm/useSubmitDataset.ts
@@ -68,7 +68,7 @@ export function useSubmitDataset(
           needsUpdateStore.setNeedsUpdate(true)
           toast.success(tDataset('alerts.datasetCreated.alertText'))
           navigate(
-            `${Route.DATASETS}?${QueryParamKey.PERSISTENT_ID}=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`
+            `${Route.UPLOAD_DATASET_FILES}?${QueryParamKey.PERSISTENT_ID}=${persistentId}&${QueryParamKey.VERSION}=${DatasetNonNumericVersionSearchParam.DRAFT}`
           )
           return
         })

--- a/tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
+++ b/tests/component/sections/shared/dataset-metadata-form/DatasetMetadataForm.spec.tsx
@@ -11,6 +11,7 @@ import { UserMother } from '../../../users/domain/models/UserMother'
 import { TemplateMother } from '@tests/component/sections/templates/TemplateMother'
 import { needsUpdateStore } from '@/notifications/domain/hooks/needsUpdateStore'
 import { WithRepositories } from '@tests/component/WithRepositories'
+import { useLocation } from 'react-router-dom'
 
 const datasetRepository: DatasetRepository = {} as DatasetRepository
 const metadataBlockInfoRepository: MetadataBlockInfoRepository = {} as MetadataBlockInfoRepository
@@ -160,6 +161,12 @@ const metadataBlocksInfoOnEditMode =
 const wrongCollectionMetadataBlocksInfo =
   MetadataBlockInfoMother.wrongCollectionMetadataBlocksInfo()
 const testUser = UserMother.create()
+
+const LocationObserver = () => {
+  const location = useLocation()
+
+  return <div data-testid="router-location">{`${location.pathname}${location.search}`}</div>
+}
 
 const fillRequiredFieldsOnCreate = () => {
   cy.findByLabelText(/^Title/i).type('Test Dataset Title')
@@ -1288,11 +1295,14 @@ describe('DatasetMetadataForm', () => {
       cy.spy(needsUpdateStore, 'setNeedsUpdate').as('setNeedsUpdate')
       cy.customMount(
         <WithRepositories datasetRepository={datasetRepository}>
-          <DatasetMetadataForm
-            mode="create"
-            collectionId="root"
-            metadataBlockInfoRepository={metadataBlockInfoRepository}
-          />
+          <>
+            <DatasetMetadataForm
+              mode="create"
+              collectionId="root"
+              metadataBlockInfoRepository={metadataBlockInfoRepository}
+            />
+            <LocationObserver />
+          </>
         </WithRepositories>
       )
       fillRequiredFieldsOnCreate()
@@ -1307,6 +1317,10 @@ describe('DatasetMetadataForm', () => {
       cy.findByText('Error').should('not.exist')
       cy.findByText('Success!').should('exist')
       cy.get('@setNeedsUpdate').should('have.been.calledWith', true)
+      cy.findByTestId('router-location').should(
+        'have.text',
+        '/datasets/upload-files?persistentId=persistentId&version=DRAFT'
+      )
     })
 
     it('on edit mode', () => {


### PR DESCRIPTION
## What this PR does / why we need it:

After successful dataset creation, users are taken directly to the existing Upload Files route for the new draft dataset. The redirect preserves the persistent ID and DRAFT version query parameters, and regression coverage observes the exact destination.

## Which issue(s) this PR closes:

- Closes #1031

## Special notes for your reviewer:

The implementation reuses the existing upload route rather than adding a new flow. Chromatic and label-copy checks cannot access fork secrets/permissions; those fork-only failures are expected.

## Suggestions on how to test this:

1. Create a dataset successfully.
2. Confirm the next page is Upload Files for the newly created draft.
3. Run the focused DatasetMetadataForm component spec; all 37 tests pass locally.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

Yes. It changes the post-creation destination to the existing Upload Files page; no mockup is required.

## Is there a release notes or changelog update needed for this change?:

No separate release note is included.

## Additional documentation:

The scoped design and implementation plan are included under docs/superpowers/.

Verification: focused component tests (37 passing), lint (four pre-existing unrelated warnings), production build, and branch diff check.