### PR TITLE
Fix Edit Metadata to always pre-populate latest metadata

### DIFF
--- a/docs/issues/1024-edit-metadata-latest-version-verification.html
+++ b/docs/issues/1024-edit-metadata-latest-version-verification.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Issue #1024 — Edit Metadata Latest Version: Fix Verification Report</title>
+  <style>
+    :root {
+      --bg: #f6f4ef;
+      --ink: #1c1b19;
+      --muted: #5c574e;
+      --card: #fffdf8;
+      --line: #d9d2c4;
+      --bad: #8b1e1e;
+      --bad-bg: #f8e8e6;
+      --good: #1f5c3a;
+      --good-bg: #e6f3eb;
+      --accent: #0b3d5c;
+      --code: #f0ebe1;
+      --warn: #7a5a00;
+      --warn-bg: #fff6d9;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "Iowan Old Style", "Palatino Linotype", Palatino, Georgia, serif;
+      color: var(--ink);
+      background:
+        radial-gradient(1200px 500px at 10% -10%, #e8efe8 0%, transparent 55%),
+        radial-gradient(900px 400px at 100% 0%, #e7eef5 0%, transparent 50%),
+        var(--bg);
+      line-height: 1.55;
+    }
+    .wrap { max-width: 980px; margin: 0 auto; padding: 40px 22px 80px; }
+    header {
+      border-bottom: 2px solid var(--ink);
+      padding-bottom: 20px;
+      margin-bottom: 28px;
+    }
+    .eyebrow {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+      margin: 0 0 8px;
+    }
+    h1 {
+      font-size: clamp(1.6rem, 3vw, 2.2rem);
+      line-height: 1.2;
+      margin: 0 0 12px;
+      letter-spacing: -0.02em;
+    }
+    h2 {
+      font-size: 1.25rem;
+      margin: 36px 0 12px;
+      border-left: 4px solid var(--accent);
+      padding-left: 12px;
+    }
+    h3 { font-size: 1.05rem; margin: 22px 0 8px; }
+    p, li { color: var(--ink); }
+    .meta {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 10px;
+      margin-top: 16px;
+    }
+    .meta div {
+      background: var(--card);
+      border: 1px solid var(--line);
+      padding: 10px 12px;
+      border-radius: 8px;
+    }
+    .meta dt {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 11px;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+    }
+    .meta dd { margin: 4px 0 0; font-weight: 600; }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 18px 18px 14px;
+      margin: 14px 0;
+      box-shadow: 0 1px 0 rgba(0,0,0,0.03);
+    }
+    .row {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 14px;
+    }
+    @media (max-width: 780px) { .row { grid-template-columns: 1fr; } }
+    .badge {
+      display: inline-block;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 11px;
+      font-weight: 700;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      padding: 3px 8px;
+      border-radius: 999px;
+      margin-bottom: 8px;
+    }
+    .badge.bad { background: var(--bad-bg); color: var(--bad); }
+    .badge.good { background: var(--good-bg); color: var(--good); }
+    .badge.warn { background: var(--warn-bg); color: var(--warn); }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.95rem;
+      background: var(--card);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      overflow: hidden;
+    }
+    th, td {
+      border-bottom: 1px solid var(--line);
+      padding: 10px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th { background: #efe9dc; font-size: 0.85rem; }
+    tr:last-child td { border-bottom: 0; }
+    code, .mono {
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.86em;
+    }
+    pre {
+      background: var(--code);
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 14px;
+      overflow-x: auto;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 12.5px;
+      line-height: 1.45;
+    }
+    .form-mock {
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      padding: 14px;
+      background: #fff;
+    }
+    .field { margin-bottom: 12px; }
+    .field label {
+      display: block;
+      font-size: 12px;
+      color: var(--muted);
+      margin-bottom: 4px;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+    }
+    .field .input {
+      border: 1px solid #bbb;
+      border-radius: 6px;
+      padding: 8px 10px;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      background: #fafafa;
+    }
+    .field .input.empty { color: #999; font-style: italic; }
+    .field .input.filled { background: #eef8f1; border-color: #7aa88c; font-weight: 600; }
+    .arrow {
+      text-align: center;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      color: var(--muted);
+      margin: 8px 0;
+      font-size: 13px;
+    }
+    .checklist li { margin: 8px 0; }
+    .pass { color: var(--good); font-weight: 700; }
+    .fail { color: var(--bad); font-weight: 700; }
+    .pending { color: var(--warn); font-weight: 700; }
+    footer {
+      margin-top: 40px;
+      padding-top: 16px;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+    a { color: var(--accent); }
+    .flow {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      font-family: ui-sans-serif, system-ui, sans-serif;
+      font-size: 13px;
+    }
+    .flow span {
+      background: #fff;
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 8px 10px;
+    }
+    .flow .x { border: 0; background: transparent; color: var(--muted); padding: 0; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <p class="eyebrow">IQSS/dataverse-frontend · Issue #1024 · Verification Report</p>
+      <h1>Edit Metadata must always pre-populate the <em>latest</em> metadata</h1>
+      <p>
+        This report shows the original bug (wrong version used to initialize the edit form),
+        the exact code fix, the expected outputs before vs after, and how to verify the fix
+        is complete against the issue statement.
+      </p>
+      <div class="meta">
+        <div><dt>Issue</dt><dd><a href="https://github.com/IQSS/dataverse-frontend/issues/1024">#1024</a></dd></div>
+        <div><dt>Branch</dt><dd class="mono">fix/1024-edit-metadata-latest-version</dd></div>
+        <div><dt>Commit</dt><dd class="mono">f108609</dd></div>
+        <div><dt>Primary file</dt><dd class="mono">EditDatasetMetadataFactory.tsx</dd></div>
+      </div>
+    </header>
+
+    <h2>1. Original issue (exact requirement)</h2>
+    <div class="card">
+      <p><strong>Product rule (JSF parity):</strong> No matter which historical dataset version the user is viewing, clicking <strong>Edit Metadata</strong> must pre-fill the form with the <strong>latest</strong> metadata (<code>:latest</code> = draft if present, else latest published).</p>
+      <p><strong>SPA bug:</strong> The form was pre-filled from the <em>browsed</em> version in the URL (<code>?version=1.0</code>), so older fields appeared and newer values could be overwritten on save.</p>
+    </div>
+
+    <h3>Scenario dataset (from the issue)</h3>
+    <table>
+      <thead>
+        <tr><th>Version</th><th>Title</th><th>Subtitle</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>1.0</code></td><td>Test Dataset</td><td><em>(empty)</em></td></tr>
+        <tr><td><code>2.0</code> (latest published)</td><td>Test Dataset</td><td><strong>My Subtitle</strong></td></tr>
+      </tbody>
+    </table>
+    <p>User action: open Version <code>1.0</code> → <strong>Edit Dataset → Metadata</strong>.</p>
+
+    <h2>2. What was parsed / loaded wrongly (BEFORE)</h2>
+    <div class="card">
+      <span class="badge bad">Bug path</span>
+      <div class="flow">
+        <span>Browse <code>?version=1.0</code></span>
+        <span class="x">→</span>
+        <span>Menu writes URL <code>version=1.0</code></span>
+        <span class="x">→</span>
+        <span>Factory reads URL version</span>
+        <span class="x">→</span>
+        <span>Fetch API <code>versions/1.0</code></span>
+        <span class="x">→</span>
+        <span>Form defaults = v1 blocks</span>
+      </div>
+    </div>
+
+    <h3>Wrong Factory logic (before)</h3>
+<pre><code>// EditDatasetMetadataFactory.tsx — BEFORE (bug)
+const searchParamVersion = searchParams.get('version') ?? undefined
+const version = searchParamVersionToDomainVersion(searchParamVersion)
+// If URL is ...&amp;version=1.0  →  version === "1.0"
+// DatasetProvider fetches that historical version</code></pre>
+
+    <div class="row">
+      <div class="card">
+        <span class="badge bad">Before · fetch argument</span>
+        <pre><code>getByPersistentId(
+  "doi:…",
+  "1.0",          // ← browsed / wrong
+  undefined,
+  true
+)</code></pre>
+        <p class="mono">API equivalent: <code>.../versions/1.0</code></p>
+      </div>
+      <div class="card">
+        <span class="badge bad">Before · form output (wrong)</span>
+        <div class="form-mock">
+          <div class="field">
+            <label>Title</label>
+            <div class="input filled">Test Dataset</div>
+          </div>
+          <div class="field">
+            <label>Subtitle</label>
+            <div class="input empty">(empty — Version 1 metadata)</div>
+          </div>
+        </div>
+        <p class="fail">FAIL vs issue expectation</p>
+        <p>JSF would show Subtitle = <strong>My Subtitle</strong>. SPA showed empty.</p>
+      </div>
+    </div>
+
+    <h2>3. What was fixed (AFTER)</h2>
+    <div class="card">
+      <span class="badge good">Fixed path</span>
+      <div class="flow">
+        <span>Browse <code>?version=1.0</code></span>
+        <span class="x">→</span>
+        <span>Menu may still pass <code>version=1.0</code> in URL</span>
+        <span class="x">→</span>
+        <span>Factory <strong>ignores</strong> URL version</span>
+        <span class="x">→</span>
+        <span>Fetch <code>:latest</code></span>
+        <span class="x">→</span>
+        <span>Form defaults = latest blocks</span>
+      </div>
+      <p>Same pattern as <code>EditDatasetTermsFactory</code> (already correct in this repo).</p>
+    </div>
+
+    <h3>Fixed Factory logic</h3>
+<pre><code>// EditDatasetMetadataFactory.tsx — AFTER (fix)
+const persistentId = searchParams.get('persistentId') ?? undefined
+// Always load the latest version (draft if exists, otherwise latest published).
+// Ignore the browsed `version` query param (IQSS/dataverse-frontend#1024).
+const version = DatasetNonNumericVersion.LATEST  // ":latest"
+
+return (
+  &lt;DatasetProvider
+    repository={datasetRepository}
+    searchParams={{ persistentId, version }}&gt;
+    &lt;EditDatasetMetadata ... /&gt;
+  &lt;/DatasetProvider&gt;
+)</code></pre>
+
+    <div class="row">
+      <div class="card">
+        <span class="badge good">After · fetch argument</span>
+        <pre><code>getByPersistentId(
+  "doi:…",
+  ":latest",     // ← DatasetNonNumericVersion.LATEST
+  undefined,
+  true
+)</code></pre>
+        <p class="mono">API equivalent: <code>.../versions/:latest</code></p>
+        <p><code>:latest</code> = draft if one exists, else latest published (here Version 2.0).</p>
+      </div>
+      <div class="card">
+        <span class="badge good">After · form output (correct)</span>
+        <div class="form-mock">
+          <div class="field">
+            <label>Title</label>
+            <div class="input filled">Test Dataset</div>
+          </div>
+          <div class="field">
+            <label>Subtitle</label>
+            <div class="input filled">My Subtitle</div>
+          </div>
+        </div>
+        <p class="pass">PASS vs issue expectation</p>
+        <p>Matches JSF: latest metadata pre-populated.</p>
+      </div>
+    </div>
+
+    <h2>4. Side-by-side comparison</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Checkpoint</th>
+          <th>Before (bug)</th>
+          <th>After (fix)</th>
+          <th>Issue requirement</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>User viewing</td>
+          <td colspan="3"><code>/datasets?persistentId=…&amp;version=1.0</code></td>
+        </tr>
+        <tr>
+          <td>Edit Metadata URL may contain</td>
+          <td><code>version=1.0</code></td>
+          <td><code>version=1.0</code> (ignored)</td>
+          <td>N/A — output must be latest</td>
+        </tr>
+        <tr>
+          <td>Factory version variable</td>
+          <td><code>"1.0"</code> from URL</td>
+          <td><code>":latest"</code> constant</td>
+          <td>Always latest</td>
+        </tr>
+        <tr>
+          <td>Repository call</td>
+          <td><code>getByPersistentId(pid, "1.0", …)</code></td>
+          <td><code>getByPersistentId(pid, ":latest", …)</code></td>
+          <td>Latest metadata source</td>
+        </tr>
+        <tr>
+          <td>Subtitle in form</td>
+          <td class="fail">empty</td>
+          <td class="pass">My Subtitle</td>
+          <td>My Subtitle</td>
+        </tr>
+        <tr>
+          <td>Browse page v1 still historical?</td>
+          <td>yes</td>
+          <td class="pass">yes (unchanged)</td>
+          <td>Must remain historical</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>5. How to verify the fix is completed</h2>
+    <div class="card">
+      <span class="badge warn">Definition of done</span>
+      <p>The fix is <strong>complete for #1024</strong> only when <strong>all</strong> of the following pass. Code presence alone is not enough without the automated and/or manual checks.</p>
+    </div>
+
+    <h3>A. Static code verification (already on this branch)</h3>
+    <ul class="checklist">
+      <li><span class="pass">DONE</span> — <code>EditDatasetMetadataFactory.tsx</code> sets <code>version = DatasetNonNumericVersion.LATEST</code></li>
+      <li><span class="pass">DONE</span> — URL <code>version</code> query param is no longer passed into <code>DatasetProvider</code></li>
+      <li><span class="pass">DONE</span> — Regression spec asserts call with <code>:latest</code> and <strong>not</strong> <code>"1.0"</code></li>
+      <li><span class="pass">DONE</span> — Matches Edit Terms factory pattern</li>
+    </ul>
+
+    <h3>B. Automated verification (required)</h3>
+    <p>From repo root (needs working <code>npm</code> auth for <code>@IQSS/dataverse-client-javascript</code>):</p>
+<pre><code>npx cypress run --component --spec \
+  tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx
+
+npx cypress run --component --spec \
+  tests/component/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx</code></pre>
+    <table>
+      <thead><tr><th>Test</th><th>Verified result if green</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><code>always fetches :latest when the URL carries an older published version</code></td>
+          <td>Even with URL <code>version=1.0</code>, <code>getByPersistentId</code> is called with <code>DatasetNonNumericVersion.LATEST</code> (<code>:latest</code>), never <code>"1.0"</code>.</td>
+        </tr>
+        <tr>
+          <td><code>still fetches :latest when the URL has no version param</code></td>
+          <td>Missing version param still loads latest (no accidental <code>undefined</code> / published-only default).</td>
+        </tr>
+        <tr>
+          <td>Existing <code>EditDatasetMetadata.spec.tsx</code></td>
+          <td>No regression on breadcrumbs / host collection / not-found.</td>
+        </tr>
+      </tbody>
+    </table>
+    <p><span class="pending">NOTE:</span> On this machine, <code>npm install</code> failed with GitHub Packages <code>401</code> for <code>@IQSS/dataverse-client-javascript</code>, so Cypress was not executed here. Run the commands above in an authenticated environment and record green results before merging.</p>
+
+    <h3>C. Manual product verification (original issue scenario)</h3>
+    <ol class="checklist">
+      <li>Create/publish Version 1.0 without subtitle.</li>
+      <li>Add subtitle <code>My Subtitle</code>, publish Version 2.0.</li>
+      <li>Open SPA: <code>/datasets?persistentId=…&amp;version=1.0</code> — browse still shows empty subtitle.</li>
+      <li>Click <strong>Edit Dataset → Metadata</strong>.</li>
+      <li><span class="pass">PASS</span> if Subtitle input = <code>My Subtitle</code>.</li>
+      <li><span class="fail">FAIL</span> if Subtitle is empty.</li>
+      <li>Optional DevTools check: dataset fetch uses version <code>:latest</code>, not <code>1.0</code>.</li>
+    </ol>
+
+    <h3>D. Negative control (must not break browse)</h3>
+    <p>On <code>?version=1.0</code> <em>without</em> opening Edit Metadata, the dataset page must still show Version 1 content (empty subtitle). If browse also shows latest, the fix was applied too broadly.</p>
+
+    <h2>6. Expected verified result summary</h2>
+    <table>
+      <thead>
+        <tr><th>Layer</th><th>Expected verified result after fix</th><th>Status on branch f108609</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Code</td>
+          <td>Factory hard-codes <code>:latest</code></td>
+          <td class="pass">Verified by source review</td>
+        </tr>
+        <tr>
+          <td>Unit/component</td>
+          <td>Stub shows call args <code>(pid, ":latest", undefined, true)</code></td>
+          <td class="pending">Spec written; run Cypress locally to confirm green</td>
+        </tr>
+        <tr>
+          <td>UI / issue scenario</td>
+          <td>From v1 browse → Edit Metadata → Subtitle = My Subtitle</td>
+          <td class="pending">Manual / e2e after env install</td>
+        </tr>
+        <tr>
+          <td>Parity</td>
+          <td>Same behavior as JSF + Edit Terms</td>
+          <td class="pass">Design parity verified in code</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>7. Files touched</h2>
+    <table>
+      <thead><tr><th>File</th><th>Role</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="mono">src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx</td>
+          <td>Production fix</td>
+        </tr>
+        <tr>
+          <td class="mono">tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx</td>
+          <td>Automated regression</td>
+        </tr>
+        <tr>
+          <td class="mono">docs/issues/1024-edit-metadata-latest-version.md</td>
+          <td>Full engineering playbook</td>
+        </tr>
+        <tr>
+          <td class="mono">docs/issues/1024-edit-metadata-latest-version-verification.html</td>
+          <td>This visual verification report</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <footer>
+      Generated for IQSS/dataverse-frontend issue
+      <a href="https://github.com/IQSS/dataverse-frontend/issues/1024">#1024</a>
+      on branch <span class="mono">fix/1024-edit-metadata-latest-version</span>
+      (<span class="mono">f108609</span>).
+      Open this file in a browser to review before/after outputs.
+    </footer>
+  </div>
+</body>
+</html>

--- a/docs/issues/1024-edit-metadata-latest-version.md
+++ b/docs/issues/1024-edit-metadata-latest-version.md
@@ -1,0 +1,598 @@
+# Issue #1024 — Edit Metadata: should always pre-populate the latest metadata
+
+| Field | Value |
+| --- | --- |
+| Status | **Implemented on branch `fix/1024-edit-metadata-latest-version`** — awaiting PR / upstream review |
+| Labels | `bug`, `SPA`, `GREI Re-arch`, `Original size: 3` |
+| Reporter | `ChengShi-1` (description from `@pdurbin`) |
+| Issue URL | https://github.com/IQSS/dataverse-frontend/issues/1024 |
+| Diagnosis baseline commit | `922dcfc` (`develop` tip when diagnosis was written) |
+| Fix branch | `fix/1024-edit-metadata-latest-version` |
+| Local package path | `/Users/shihuayu/Documents/GitHub/dataverse-frontend` |
+| How to implement | Follow §8 Steps 0–7; every fix must pass §10 acceptance criteria |
+| How to verify | Follow §18 (commands + expected outputs). Do not merge without green AC1–AC6 |
+
+---
+
+## 1. Executive summary
+
+When a dataset has multiple published versions, the **legacy JSF** “Edit Metadata” flow always pre-fills the form from the **latest** metadata (draft if one exists, otherwise latest published), regardless of which version the user is currently viewing.
+
+The **SPA** incorrectly pre-fills from the **version currently being browsed**. That version is written into the edit-page URL as `?version=…` and then used as the fetch target in `EditDatasetMetadataFactory`.
+
+### Concrete failure (from the issue + Phil’s screenshot narrative)
+
+| Version | Title | Subtitle |
+| --- | --- | --- |
+| 1.0 | Test Dataset | *(empty)* |
+| 2.0 | Test Dataset | My Subtitle |
+
+1. User opens the dataset page for **Version 1.0**.
+2. User clicks **Edit Dataset → Metadata**.
+3. **JSF (correct):** form shows Subtitle = `My Subtitle` (latest).
+4. **SPA (bug):** form shows Subtitle empty (version 1.0).
+
+### Risk
+
+If the user saves from a form that was initialized with older metadata, they can **overwrite newer field values** on the draft that editing creates/updates — silent data loss relative to the latest published content.
+
+### Root cause (one sentence)
+
+`EditDatasetMetadataFactory` passes the URL `version` query param into `DatasetProvider` / `getDatasetByPersistentId`, instead of forcing `DatasetNonNumericVersion.LATEST` (`:latest`) the way `EditDatasetTermsFactory` already does.
+
+### Recommended fix (one sentence)
+
+In `EditDatasetMetadataFactory.tsx`, ignore the browsed `version` search param and always load `DatasetNonNumericVersion.LATEST`, matching Edit Terms; add regression tests for “enter Edit Metadata while viewing an older published version.”
+
+---
+
+## 2. Expected vs actual behavior
+
+### 2.1 Product expectation (JSF parity)
+
+| User context | Click “Edit Metadata” | Form must show |
+| --- | --- | --- |
+| Viewing published `1.0` while `2.0` exists | Edit Metadata | Metadata of **latest** (`:latest` → draft if present, else latest published) |
+| Viewing published `2.0` (already latest published) | Edit Metadata | Same latest metadata (no regression) |
+| Viewing / working on `DRAFT` | Edit Metadata | Draft metadata (`:latest` resolves to draft when present) |
+
+**Important semantic of `:latest` in Dataverse:** draft if a draft exists; otherwise the latest published version. This is exactly what the Edit Terms factory comment documents and what JSF edit-metadata behavior matches.
+
+### 2.2 SPA actual behavior today
+
+| User context | URL after menu click | Dataset fetch version | Form |
+| --- | --- | --- | --- |
+| Viewing `1.0` | `.../edit-metadata?persistentId=…&version=1.0` | `1.0` | Old metadata |
+| Viewing `2.0` | `...&version=2.0` | `2.0` | Happens to look correct if 2.0 is latest published and no draft |
+| Viewing draft | `...&version=DRAFT` → domain `:draft` | `:draft` | Draft (often OK, but still “browsed version” coupling) |
+
+---
+
+## 3. Architecture context (where this lives)
+
+```text
+Dataset page (browse any version)
+  └─ DatasetActionButtons
+       └─ EditDatasetMenu  ──navigate──►  /datasets/edit-metadata?persistentId&version
+                                              │
+                                              ▼
+                                    EditDatasetMetadataFactory
+                                              │
+                                              ▼
+                                    DatasetProvider(getDatasetByPersistentId)
+                                              │
+                                              ▼
+                                    DatasetJSDataverseRepository.getByPersistentId
+                                              │
+                                              ▼
+                                    @iqss/dataverse-client-javascript getDataset.execute
+                                              │
+                                              ▼
+                                    Native API: GET .../versions/{versionId}
+                                              │
+                                              ▼
+                                    EditDatasetMetadata
+                                              │
+                                              ▼
+                                    DatasetMetadataForm(mode="edit")
+                                         defaults ← dataset.metadataBlocks
+```
+
+The form component is **not** the bug. It faithfully displays whatever `dataset.metadataBlocks` it receives. The bug is **which version is fetched** before the form mounts.
+
+---
+
+## 4. Verified call chain (with file:line evidence)
+
+All line numbers refer to local tree at commit `922dcfc` unless noted.
+
+### 4.1 Route
+
+| Item | Location |
+| --- | --- |
+| Path enum | `src/sections/Route.enum.ts` — `EDIT_DATASET_METADATA = '/datasets/edit-metadata'` (line 12) |
+| Query keys | `QueryParamKey.VERSION = 'version'`, `PERSISTENT_ID = 'persistentId'` (lines 96–98 area) |
+| Route registration | `src/router/routes.tsx` — lazy `EditDatasetMetadataFactory.create()` on `Route.EDIT_DATASET_METADATA` |
+
+### 4.2 Navigation (contributes browsed version into the URL)
+
+File: `src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx`
+
+```39:55:src/sections/dataset/dataset-action-buttons/edit-dataset-menu/EditDatasetMenu.tsx
+  const handleOnSelect = (eventKey: EditDatasetMenuItems | string | null) => {
+    const searchParams = new URLSearchParams()
+    searchParams.set(QueryParamKey.PERSISTENT_ID, dataset.persistentId)
+
+    if (dataset.version.publishingStatus === DatasetPublishingStatus.DRAFT) {
+      searchParams.set(QueryParamKey.VERSION, DatasetNonNumericVersionSearchParam.DRAFT)
+    } else {
+      searchParams.set(QueryParamKey.VERSION, dataset.version.number.toString())
+    }
+    // ...
+    if (eventKey === EditDatasetMenuItems.METADATA) {
+      navigate(`${Route.EDIT_DATASET_METADATA}?${searchParams.toString()}`)
+      return
+    }
+```
+
+When the user is viewing published version `1.0`, this navigates to:
+
+```text
+/datasets/edit-metadata?persistentId=<doi>&version=1.0
+```
+
+**Note:** The same menu also sets `version` for Terms and Upload Files. Edit **Terms** already ignores URL version in its factory (see §5). Upload Files may still need a version-aware URL — do **not** globally remove version from the menu without checking upload behavior.
+
+### 4.3 Factory (bug site — consumes URL version)
+
+File: `src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx`
+
+```18:30:src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx
+function EditDatasetMetadataWithParams() {
+  const [searchParams] = useSearchParams()
+  const persistentId = searchParams.get('persistentId') ?? undefined
+  const searchParamVersion = searchParams.get('version') ?? undefined
+  const version = searchParamVersionToDomainVersion(searchParamVersion)
+
+  return (
+    <DatasetProvider
+      repository={datasetRepository}
+      searchParams={{ persistentId: persistentId, version: version }}>
+      <EditDatasetMetadata metadataBlockInfoRepository={metadataBlockInfoRepository} />
+    </DatasetProvider>
+  )
+}
+```
+
+`searchParamVersionToDomainVersion` (`src/router/index.tsx` lines 11–17) only special-cases `DRAFT` → `:draft`; numeric versions like `1.0` pass through unchanged.
+
+### 4.4 Provider → use case → repository
+
+| Step | File | Behavior |
+| --- | --- | --- |
+| Provider | `src/sections/dataset/DatasetProvider.tsx` ~28–36 | Calls `getDatasetByPersistentId(repository, persistentId, searchParams.version, undefined, true)` |
+| Use case | `src/dataset/domain/useCases/getDatasetByPersistentId.ts` | Delegates to repository |
+| Repository | `src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts` ~213–220 | `getDataset.execute(persistentId, version, …)` via JS client |
+
+Default for `getByPersistentId` when version omitted is `DatasetNonNumericVersion.LATEST_PUBLISHED` (`:latest-published`) — but the factory **does not omit** version; it passes the browsed one explicitly.
+
+### 4.5 Form initialization (downstream, correct given inputs)
+
+File: `src/sections/edit-dataset-metadata/EditDatasetMetadata.tsx` ~61–68
+
+```61:68:src/sections/edit-dataset-metadata/EditDatasetMetadata.tsx
+            <DatasetMetadataForm
+              mode="edit"
+              collectionId={datasetParentCollection?.id}
+              metadataBlockInfoRepository={metadataBlockInfoRepository}
+              datasetPersistentID={dataset.persistentId}
+              datasetMetadaBlocksCurrentValues={dataset.metadataBlocks}
+              datasetLastUpdateTime={dataset.version.lastUpdateTime}
+            />
+```
+
+`DatasetMetadataForm` builds defaults via `MetadataFieldsHelper.getFormDefaultValues(...)` from those blocks (`src/sections/shared/form/DatasetMetadataForm/index.tsx`).
+
+### 4.6 Version domain constants
+
+File: `src/dataset/domain/models/Dataset.ts` ~210–217
+
+```210:217:src/dataset/domain/models/Dataset.ts
+export enum DatasetNonNumericVersion {
+  LATEST = ':latest',
+  DRAFT = ':draft',
+  LATEST_PUBLISHED = ':latest-published'
+}
+export enum DatasetNonNumericVersionSearchParam {
+  DRAFT = 'DRAFT'
+}
+```
+
+| Constant | API `versionId` | Meaning |
+| --- | --- | --- |
+| `LATEST` | `:latest` | Draft if exists, else latest published — **use this for Edit Metadata** |
+| `DRAFT` | `:draft` | Draft only |
+| `LATEST_PUBLISHED` | `:latest-published` | Latest published only (skips draft) |
+
+**Do not** use `:latest-published` for Edit Metadata: if a draft already exists with newer edits, editors must see the draft.
+
+---
+
+## 5. Proven correct pattern already in this repo (Edit Terms)
+
+File: `src/sections/edit-dataset-terms/EditDatasetTermsFactory.tsx`
+
+```19:29:src/sections/edit-dataset-terms/EditDatasetTermsFactory.tsx
+function EditDatasetTermsWithSearchParams() {
+  const [searchParams] = useSearchParams()
+  const defaultActiveTabKey = EditDatasetTermsHelper.defineSelectedTabKey(searchParams)
+  const persistentId = searchParams.get('persistentId') ?? undefined
+  // Always load the latest version (draft if exists, otherwise latest published)
+  const version = DatasetNonNumericVersion.LATEST
+
+  return (
+    <DatasetProvider
+      repository={datasetRepository}
+      searchParams={{ persistentId: persistentId, version: version }}>
+```
+
+Edit Terms receives the same menu URL shape (including `version=1.0`) but **ignores** it. Edit Metadata should do the same. This is the strongest in-repo proof that the intended SPA product behavior is “always `:latest` for edit screens.”
+
+---
+
+## 6. End-to-end bug flowchart
+
+```mermaid
+flowchart TD
+  A["User browses /datasets?persistentId=…&version=1.0"] --> B["EditDatasetMenu.handleOnSelect METADATA"]
+  B --> C["navigate /datasets/edit-metadata?persistentId=…&version=1.0"]
+  C --> D["EditDatasetMetadataFactory reads version from URL"]
+  D --> E["DatasetProvider → getDatasetByPersistentId … '1.0'"]
+  E --> F["JS client getDataset.execute → API versions/1.0"]
+  F --> G["Form defaults = v1 metadataBlocks"]
+  G --> H["Bug: Subtitle empty even though v2 has My Subtitle"]
+
+  C2["Desired"] --> D2["Factory forces DatasetNonNumericVersion.LATEST"]
+  D2 --> E2["getDatasetByPersistentId … ':latest'"]
+  E2 --> F2["API versions/:latest"]
+  F2 --> G2["Form defaults = latest metadataBlocks"]
+```
+
+---
+
+## 7. Specific solution (what to change)
+
+### 7.1 Primary fix (required) — Factory always uses `:latest`
+
+**File:** `src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx`  
+**Function:** `EditDatasetMetadataWithParams`
+
+**Replace** the version extraction:
+
+```tsx
+const searchParamVersion = searchParams.get('version') ?? undefined
+const version = searchParamVersionToDomainVersion(searchParamVersion)
+```
+
+**With** (mirror Edit Terms):
+
+```tsx
+import { DatasetNonNumericVersion } from '@/dataset/domain/models/Dataset'
+// or relative import consistent with this file's style
+
+// Always load the latest version (draft if exists, otherwise latest published)
+const version = DatasetNonNumericVersion.LATEST
+```
+
+**Remove** unused imports after the change (`searchParamVersionToDomainVersion` if no longer referenced).
+
+**Why this is the right primary fix**
+
+1. Matches JSF expectation stated in #1024.
+2. Matches existing SPA Edit Terms pattern.
+3. Fixes **deep links** to `/edit-metadata?...&version=1.0`, not only menu clicks.
+4. Does not break the dataset **browse** page (which must still load the selected version).
+5. Does not change `DatasetProvider` or repository defaults globally (avoids collateral damage).
+
+### 7.2 Optional cleanup — Menu URL for METADATA
+
+Optionally stop attaching a numeric `version` when navigating to Edit Metadata (Terms already ignores it). **Optional only** after Factory fix is in place; not required for correctness once Factory forces `:latest`.
+
+If you change the menu, keep Upload Files behavior reviewed separately — it still sets version for a reason.
+
+### 7.3 Explicitly out of scope / do not change
+
+| Do not | Why |
+| --- | --- |
+| Change browse-page version loading | Users must still view historical versions |
+| Change `DatasetProvider` to always latest | Shared by browse + edit |
+| Change form defaulting helpers | They are correct given inputs |
+| Use `:latest-published` instead of `:latest` | Misses existing draft content |
+| Redesign Edit Metadata UI | Issue is data-fetching only |
+
+### 7.4 Save / update path (sanity)
+
+After submit, navigation already targets draft (see `useSubmitDataset.ts` navigating with `VERSION=DRAFT`). Prefill must therefore also be latest/draft-aware so the user edits the same lineage they will save into. No change required there for #1024 if Factory uses `:latest`.
+
+---
+
+## 8. Implementation playbook (Steps 0–7)
+
+### Step 0 — Baseline (broken)
+
+1. Use a dataset with ≥2 published versions where a field differs (e.g. subtitle added in v2).
+2. Open SPA dataset page with `version=1.0`.
+3. Edit Dataset → Metadata.
+4. **Observe:** form shows v1 values (subtitle empty).
+5. Optionally compare same click path on JSF: subtitle present.
+
+Record URL query string and network call version id (`1.0` vs `:latest`).
+
+### Step 1 — Apply Factory fix
+
+Edit `EditDatasetMetadataFactory.tsx` as in §7.1.
+
+### Step 2 — Manual verify (happy paths)
+
+| Case | Steps | Expected |
+| --- | --- | --- |
+| A | Browse v1 → Edit Metadata | Latest fields (e.g. subtitle from v2 or draft) |
+| B | Browse latest published → Edit Metadata | Same latest fields (no regression) |
+| C | With an existing draft that changed a field → Edit Metadata from any published version | Draft values appear (`:latest`) |
+| D | Direct URL `/edit-metadata?persistentId=…&version=1.0` | Still loads `:latest`, not `1.0` |
+
+### Step 3 — Automated tests
+
+Existing coverage gaps (verified):
+
+| File | Current focus | Gap |
+| --- | --- | --- |
+| `tests/component/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx` | Breadcrumbs / skeleton / not-found; `searchParams = { persistentId }` only | No assertion that fetch uses `:latest` when URL has old version |
+| `tests/e2e-integration/e2e/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx` | Visits with `version=DRAFT` only | No multi-version “from old published version” case |
+| `tests/component/.../EditDatasetMenu.spec.tsx` | Menu click | Does not assert fetch version |
+
+**Add at least one of:**
+
+1. **Component / unit (preferred minimal):** Mount or exercise `EditDatasetMetadataFactory` (or route) with  
+   `?persistentId=…&version=1.0`  
+   and assert the repository `getByPersistentId` was called with `DatasetNonNumericVersion.LATEST` (`:latest`), **not** `"1.0"`.
+
+2. **E2E (strongest product proof):**  
+   - Create dataset, publish v1 without subtitle.  
+   - Add subtitle, publish v2.  
+   - Visit dataset with `version=1.0`.  
+   - Open Edit Metadata.  
+   - Assert subtitle input shows v2 value.
+
+3. **Regression:** From latest version / draft, Edit Metadata still works (existing e2e paths should remain green).
+
+### Step 4 — Lint / typecheck / affected tests
+
+Run the project’s standard checks for touched files (per `CONTRIBUTING.md` / CI). At minimum run the edit-metadata component and e2e specs you touched.
+
+### Step 5 — PR description checklist
+
+- Link #1024  
+- State: “Always load `:latest` in `EditDatasetMetadataFactory`, matching `EditDatasetTermsFactory` and JSF.”  
+- Note: browse page version selection unchanged  
+- List test cases added  
+
+### Step 6 — Definition of done
+
+See §10.
+
+### Step 7 — Evidence to attach
+
+- Before/after screenshots (v1 browse → Edit Metadata subtitle)  
+- Network panel showing `versions/:latest` (or equivalent JS client version arg)  
+- Test output  
+
+---
+
+## 9. Suggested patch sketch (illustrative)
+
+```tsx
+// EditDatasetMetadataFactory.tsx — after fix
+import { ReactElement } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { EditDatasetMetadata } from './EditDatasetMetadata'
+import { DatasetProvider } from '../dataset/DatasetProvider'
+import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
+import { MetadataBlockInfoJSDataverseRepository } from '../../metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
+import { DatasetNonNumericVersion } from '../../dataset/domain/models/Dataset'
+
+const datasetRepository = new DatasetJSDataverseRepository()
+const metadataBlockInfoRepository = new MetadataBlockInfoJSDataverseRepository()
+
+export class EditDatasetMetadataFactory {
+  static create(): ReactElement {
+    return <EditDatasetMetadataWithParams />
+  }
+}
+
+function EditDatasetMetadataWithParams() {
+  const [searchParams] = useSearchParams()
+  const persistentId = searchParams.get('persistentId') ?? undefined
+  // Always load the latest version (draft if exists, otherwise latest published)
+  // See EditDatasetTermsFactory and IQSS/dataverse-frontend#1024
+  const version = DatasetNonNumericVersion.LATEST
+
+  return (
+    <DatasetProvider
+      repository={datasetRepository}
+      searchParams={{ persistentId: persistentId, version: version }}>
+      <EditDatasetMetadata metadataBlockInfoRepository={metadataBlockInfoRepository} />
+    </DatasetProvider>
+  )
+}
+```
+
+Import path style should match surrounding files (`@/` vs relative) — keep consistency with this module / Edit Terms.
+
+---
+
+## 10. Acceptance criteria (verifiable)
+
+| # | Criterion | How to verify |
+| --- | --- | --- |
+| AC1 | From an older published version, Edit Metadata shows **latest** field values | Manual case A + e2e |
+| AC2 | Deep link with `version=<old>` still loads latest | Manual case D + unit spy on repository |
+| AC3 | From latest published / draft, Edit Metadata unchanged / correct | Manual B/C + existing e2e |
+| AC4 | Dataset **browse** of historical versions still shows that version’s metadata | Browse v1 page still empty subtitle |
+| AC5 | Implementation aligns with Edit Terms (`DatasetNonNumericVersion.LATEST`) | Code review |
+| AC6 | Automated regression exists for AC1 or AC2 | CI green on new test |
+
+---
+
+## 11. API mapping (for debugging)
+
+The SPA uses `@iqss/dataverse-client-javascript` `getDataset.execute(persistentId, version, …)`, which maps to Dataverse Native API:
+
+```text
+GET /api/datasets/:persistentId/versions/:versionId?persistentId=...
+```
+
+| Scenario | `versionId` today (bug) | `versionId` after fix |
+| --- | --- | --- |
+| Browsing v1, click Edit Metadata | `1.0` | `:latest` |
+| Draft exists | often `:draft` via menu | `:latest` (→ draft) |
+| Latest published, no draft | `N.M` | `:latest` (→ that published) |
+
+When debugging in DevTools, confirm the version segment or client argument — not only the form UI.
+
+---
+
+## 12. Test plan matrix
+
+| ID | Type | Setup | Action | Expect |
+| --- | --- | --- | --- | --- |
+| T1 | Manual | v1 no subtitle, v2 has subtitle | Browse v1 → Edit Metadata | Subtitle = v2 value |
+| T2 | Manual | Same | Browse v2 → Edit Metadata | Subtitle = v2 value |
+| T3 | Manual | Draft edits subtitle further | Browse v1 → Edit Metadata | Subtitle = draft value |
+| T4 | Manual | Open `/edit-metadata?persistentId&version=1.0` | Load page | Same as latest, not v1 |
+| T5 | Unit/component | Mock repository | Mount factory with `version=1.0` | `getByPersistentId(..., ':latest')` |
+| T6 | E2E | Publish two versions | Automate T1 | Pass |
+| T7 | Regression | Existing draft edit e2e | Run suite | Still pass |
+
+---
+
+## 13. Risks and edge cases
+
+| Risk | Mitigation |
+| --- | --- |
+| Confusing `:latest` vs `:latest-published` | Use `LATEST` only; document draft preference |
+| Menu still puts old version in URL | Harmless after Factory fix; optional cleanup |
+| Permissions / deaccessioned versions | Existing menu disable / permission checks unchanged; retest if deaccessioned latest |
+| Private URL datasets | Factory path uses `persistentId`; private-URL browse uses different provider entry — confirm Edit Metadata entry points still go through this factory |
+| Concurrent draft from another user | Pre-existing conflict handling via `datasetLastUpdateTime` / API; out of scope for #1024 |
+
+---
+
+## 14. Relationship to JSF (issue text)
+
+Quoted expectation from #1024 / `@pdurbin`:
+
+> In JSF, when you click "Edit Metadata", the latest metadata is pre-populated, no matter which version you're on. In the SPA, if I click "Edit Metadata" on version 1, the metadata from that version is pre-populated.
+
+There is **no** separate SPA design doc required: JSF behavior + Edit Terms factory are the specifications.
+
+---
+
+## 15. Work estimate note
+
+Label **Original size: 3** fits: one focused factory change (and optional menu cleanup) plus tests. Risk is low if scope stays at Factory + tests and avoids global provider changes.
+
+---
+
+## 16. Checklist for the implementer
+
+- [ ] Reproduce on SPA with multi-version dataset (Step 0)
+- [ ] Change `EditDatasetMetadataFactory` to `DatasetNonNumericVersion.LATEST`
+- [ ] Remove unused imports
+- [ ] Manual cases A–D
+- [ ] Add unit/component and/or e2e regression
+- [ ] Confirm browse historical version still shows historical metadata
+- [ ] Open PR linking #1024 with before/after evidence
+
+---
+
+## 17. Implementation record (this branch)
+
+| Change | Path | What changed |
+| --- | --- | --- |
+| Factory fix | `src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx` | Ignore URL `version`; always pass `DatasetNonNumericVersion.LATEST` (`:latest`) into `DatasetProvider` |
+| Regression tests | `tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx` | Assert `getByPersistentId` is called with `:latest` when URL has `version=1.0`, and when URL omits `version` |
+| This doc | `docs/issues/1024-edit-metadata-latest-version.md` | Diagnosis + playbook + verification |
+
+**Not changed (intentionally):**
+
+- Dataset browse page version loading
+- `EditDatasetMenu` URL construction (harmless after Factory fix; Terms already ignored URL version)
+- `DatasetProvider` / repository defaults
+- Form defaulting helpers
+
+---
+
+## 18. Verification instructions (must pass before PR)
+
+Every claim below is falsifiable. Record pass/fail.
+
+### 18.1 Automated (required)
+
+From repo root, with dependencies installed (`npm ci` if needed):
+
+```bash
+# Focused regression for #1024
+npx cypress run --component --spec \
+  tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx
+
+# Existing edit-metadata component suite (no regressions)
+npx cypress run --component --spec \
+  tests/component/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx
+```
+
+**Pass criteria:**
+
+| Spec | Expect |
+| --- | --- |
+| `EditDatasetMetadataFactory.spec.tsx` | Both tests green: call uses `:latest` / `DatasetNonNumericVersion.LATEST`, **not** `"1.0"` |
+| `EditDatasetMetadata.spec.tsx` | All existing tests still green |
+
+**Fail if:** `getByPersistentId` is invoked with `"1.0"` for the old-version URL case.
+
+### 18.2 Manual product check (required for AC1)
+
+Prerequisite: dataset with ≥2 published versions where a field differs (e.g. title or subtitle added in v2).
+
+| Step | Action | Expected (pass) | Fail if |
+| --- | --- | --- | --- |
+| M1 | Open SPA dataset with `?version=1.0` | Browse page shows v1 content | — |
+| M2 | Edit Dataset → Metadata | Network/API version is `:latest` (or draft via `:latest`) | Request is for `1.0` |
+| M3 | Inspect form field that differs in v2 | Shows **latest** value | Shows empty / v1 value |
+| M4 | Open Edit Metadata from latest published | Same latest values | Regression / blank form |
+| M5 | If a draft exists with further edits, open Edit Metadata from v1 | Form shows **draft** values (`:latest`) | Shows published-only / v1 |
+
+### 18.3 Negative control (browse must stay historical)
+
+| Step | Action | Expected |
+| --- | --- | --- |
+| N1 | Stay on browse `?version=1.0` (do not edit) | Historical metadata still shown (e.g. missing subtitle) |
+
+If N1 fails, the fix was applied too broadly (e.g. Provider always latest) — revert and keep the change only in `EditDatasetMetadataFactory`.
+
+### 18.4 Code review checklist
+
+- [ ] Factory uses `DatasetNonNumericVersion.LATEST` only
+- [ ] No use of `:latest-published` for this page
+- [ ] Comment references #1024 / Edit Terms parity
+- [ ] Unused `searchParamVersionToDomainVersion` import removed from Factory
+- [ ] New component spec committed
+
+---
+
+## 19. Document history
+
+| Date | Commit / branch | Notes |
+| --- | --- | --- |
+| 2026-07-31 | `922dcfc` on `develop` | Diagnosis + solution written from source |
+| 2026-07-31 | `fix/1024-edit-metadata-latest-version` | Factory fix + component regression tests + verification §18 |

--- a/src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx
+++ b/src/sections/edit-dataset-metadata/EditDatasetMetadataFactory.tsx
@@ -4,7 +4,7 @@ import { EditDatasetMetadata } from './EditDatasetMetadata'
 import { DatasetProvider } from '../dataset/DatasetProvider'
 import { DatasetJSDataverseRepository } from '../../dataset/infrastructure/repositories/DatasetJSDataverseRepository'
 import { MetadataBlockInfoJSDataverseRepository } from '../../metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
-import { searchParamVersionToDomainVersion } from '../../router'
+import { DatasetNonNumericVersion } from '../../dataset/domain/models/Dataset'
 
 const datasetRepository = new DatasetJSDataverseRepository()
 const metadataBlockInfoRepository = new MetadataBlockInfoJSDataverseRepository()
@@ -18,8 +18,10 @@ export class EditDatasetMetadataFactory {
 function EditDatasetMetadataWithParams() {
   const [searchParams] = useSearchParams()
   const persistentId = searchParams.get('persistentId') ?? undefined
-  const searchParamVersion = searchParams.get('version') ?? undefined
-  const version = searchParamVersionToDomainVersion(searchParamVersion)
+  // Always load the latest version (draft if exists, otherwise latest published).
+  // Ignore the browsed `version` query param so Edit Metadata matches JSF / Edit Terms
+  // (IQSS/dataverse-frontend#1024).
+  const version = DatasetNonNumericVersion.LATEST
 
   return (
     <DatasetProvider

--- a/tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx
+++ b/tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx
@@ -1,0 +1,80 @@
+import { DatasetJSDataverseRepository } from '../../../../src/dataset/infrastructure/repositories/DatasetJSDataverseRepository'
+import { MetadataBlockInfoJSDataverseRepository } from '../../../../src/metadata-block-info/infrastructure/repositories/MetadataBlockInfoJSDataverseRepository'
+import { DatasetNonNumericVersion } from '../../../../src/dataset/domain/models/Dataset'
+import { EditDatasetMetadataFactory } from '../../../../src/sections/edit-dataset-metadata/EditDatasetMetadataFactory'
+import { LoadingProvider } from '../../../../src/shared/contexts/loading/LoadingProvider'
+import { DatasetMother } from '../../dataset/domain/models/DatasetMother'
+import { MetadataBlockInfoMother } from '../../metadata-block-info/domain/models/MetadataBlockInfoMother'
+import { QueryParamKey, Route } from '../../../../src/sections/Route.enum'
+
+const dataset = DatasetMother.createRealistic()
+const metadataBlocksInfoOnEditMode =
+  MetadataBlockInfoMother.getByCollectionIdDisplayedOnCreateFalse()
+const metadataBlocksInfoOnCreateMode =
+  MetadataBlockInfoMother.getByCollectionIdDisplayedOnCreateTrue()
+
+describe('EditDatasetMetadataFactory', () => {
+  const persistentId = 'doi:10.5072/FK2/EDITMETA'
+
+  beforeEach(() => {
+    cy.stub(DatasetJSDataverseRepository.prototype, 'getByPersistentId').resolves(dataset)
+    cy.stub(DatasetJSDataverseRepository.prototype, 'updateMetadata').resolves(undefined)
+    cy.stub(DatasetJSDataverseRepository.prototype, 'getDatasetVersionsSummaries').resolves({
+      summaries: [],
+      totalCount: 0
+    })
+    cy.stub(MetadataBlockInfoJSDataverseRepository.prototype, 'getByCollectionId').resolves(
+      metadataBlocksInfoOnEditMode
+    )
+    cy.stub(
+      MetadataBlockInfoJSDataverseRepository.prototype,
+      'getDisplayedOnCreateByCollectionId'
+    ).resolves(metadataBlocksInfoOnCreateMode)
+  })
+
+  it('always fetches :latest when the URL carries an older published version (issue #1024)', () => {
+    const initialEntry = `${Route.EDIT_DATASET_METADATA}?${QueryParamKey.PERSISTENT_ID}=${encodeURIComponent(
+      persistentId
+    )}&${QueryParamKey.VERSION}=1.0`
+
+    cy.customMount(<LoadingProvider>{EditDatasetMetadataFactory.create()}</LoadingProvider>, [
+      initialEntry
+    ])
+
+    cy.wrap(DatasetJSDataverseRepository.prototype.getByPersistentId).should(
+      'have.been.calledWith',
+      persistentId,
+      DatasetNonNumericVersion.LATEST,
+      undefined,
+      true
+    )
+    cy.wrap(DatasetJSDataverseRepository.prototype.getByPersistentId).should(
+      'not.have.been.calledWith',
+      persistentId,
+      '1.0',
+      undefined,
+      true
+    )
+
+    cy.findByTestId('edit-dataset-metadata-skeleton').should('not.exist')
+    cy.findByText(/^Host Collection/i).should('exist')
+  })
+
+  it('still fetches :latest when the URL has no version param', () => {
+    const initialEntry = `${Route.EDIT_DATASET_METADATA}?${QueryParamKey.PERSISTENT_ID}=${encodeURIComponent(
+      persistentId
+    )}`
+
+    cy.customMount(<LoadingProvider>{EditDatasetMetadataFactory.create()}</LoadingProvider>, [
+      initialEntry
+    ])
+
+    cy.wrap(DatasetJSDataverseRepository.prototype.getByPersistentId).should(
+      'have.been.calledWith',
+      persistentId,
+      DatasetNonNumericVersion.LATEST,
+      undefined,
+      true
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- Fixes #1024: Edit Metadata in the SPA always loads `:latest` metadata (draft if present, else latest published), matching JSF and `EditDatasetTermsFactory`.
- Ignores the browsed `version` query param in `EditDatasetMetadataFactory` so opening Edit Metadata from an older version (e.g. `1.0`) no longer pre-fills stale fields (e.g. missing subtitle from version 2).
- Adds component regression tests and issue documentation / verification HTML.

## Test plan
- [ ] `npx cypress run --component --spec tests/component/sections/edit-dataset-metadata/EditDatasetMetadataFactory.spec.tsx`
- [ ] `npx cypress run --component --spec tests/component/sections/edit-dataset-metadata/EditDatasetMetadata.spec.tsx`
- [ ] Manual: publish v1 without subtitle, publish v2 with subtitle, browse `?version=1.0`, Edit Metadata → subtitle shows v2 value
- [ ] Manual: browsing `?version=1.0` (without edit) still shows historical v1 metadata


Made with [Cursor](https://cursor.com)