### PR TITLE
skip Chromatic checks for forks

### DIFF
--- a/.github/workflows/chromatic-design-system.yml
+++ b/.github/workflows/chromatic-design-system.yml
@@ -10,6 +10,8 @@ on:
 # List of jobs
 jobs:
   chromatic-deployment:
+    # Avoid being triggered by forks. See https://github.com/IQSS/dataverse-frontend/issues/1042
+    if: '! github.event.pull_request.head.repo.fork'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -10,6 +10,8 @@ on:
 # List of jobs
 jobs:
   chromatic-deployment:
+    # Avoid being triggered by forks
+    if: '! github.event.pull_request.head.repo.fork'
     # Operating System
     runs-on: ubuntu-latest
     # Job steps


### PR DESCRIPTION
## What this PR does / why we need it:

To avoid confusion for people make PRs who don't have write access to the upstream IQSS repo (who have forked).

## Which issue(s) this PR closes:

- Closes #1042

## Special notes for your reviewer:

There's a surprising variety of solutions out there. In the end I went with a slightly simplified version of the one we use here: https://github.com/IQSS/dataverse/blob/v6.11/.github/workflows/copy_labels.yml#L10

Codex and Claude both came up with this:

`if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`

Googling yields a variety of methods as well.

## Suggestions on how to test this:

- Merge this PR.
- Make a PR from IQSS and check to make sure the Chromatic checks DO run. (No regression.)
- Make a PR from a fork and check to make sure the Chromatic checks DON'T run. (A good fix.)

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:

No.

## Is there a release notes or changelog update needed for this change?:

No.

## Additional documentation:

None.