### PR TITLE
Collection Page: Prevent infinite scrolling into blank space

### DIFF
--- a/src/sections/collection/collection-items-panel/items-list/ItemsList.module.scss
+++ b/src/sections/collection/collection-items-panel/items-list/ItemsList.module.scss
@@ -10,6 +10,7 @@
 .items-list {
   --inline-padding: 1rem;
 
+  position: relative;
   height: 650px;
   max-height: 650px;
   padding-inline: var(--inline-padding);

--- a/tests/component/sections/collection/collection-items-panel/CollectionItemsPanel.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/CollectionItemsPanel.spec.tsx
@@ -366,6 +366,122 @@ describe('CollectionItemsPanel', () => {
     cy.findByTestId('collection-items-list-infinite-scroll-skeleton').should('exist')
   })
 
+  it('keeps repeated infinite scrolling within the items list page boundary', () => {
+    cy.customMount(
+      <>
+        <CollectionItemsPanel
+          collectionId={ROOT_COLLECTION_ALIAS}
+          collectionRepository={collectionRepository}
+          collectionQueryParams={{
+            pageQuery: 1,
+            searchQuery: undefined,
+            typesQuery: undefined,
+            filtersQuery: undefined
+          }}
+          addDataSlot={null}
+        />
+        <footer data-testid="collection-page-footer" style={{ height: 160 }}>
+          Footer
+        </footer>
+      </>
+    )
+
+    let initialPageScrollHeight = 0
+    let initialListScrollHeight = 0
+
+    cy.findByTestId('items-list').should('exist').children().should('have.length', 10)
+
+    cy.document().then((document) => {
+      initialPageScrollHeight = document.documentElement.scrollHeight
+      expect(initialPageScrollHeight).to.equal(document.body.scrollHeight)
+    })
+
+    cy.findByTestId('items-list-scrollable-container').then(($itemsList) => {
+      initialListScrollHeight = $itemsList[0].scrollHeight
+    })
+
+    for (const expectedItemCount of [20, 30, 40, 50, 60]) {
+      cy.findByTestId('items-list-scrollable-container').scrollTo('bottom')
+      cy.findByTestId('items-list').children().should('have.length', expectedItemCount)
+    }
+
+    cy.findByTestId('items-list-scrollable-container').then(($itemsList) => {
+      const itemsList = $itemsList[0]
+      const stickyHeader = itemsList.querySelector(':scope > header')
+
+      expect(itemsList.scrollHeight).to.be.greaterThan(initialListScrollHeight)
+      expect(stickyHeader).not.to.equal(null)
+      expect(getComputedStyle(stickyHeader as HTMLElement).position).to.equal('sticky')
+      expect((stickyHeader as HTMLElement).getBoundingClientRect().top).to.be.closeTo(
+        itemsList.getBoundingClientRect().top,
+        1
+      )
+    })
+
+    cy.findByRole('button', { name: /Sort/ }).should('be.visible')
+
+    cy.findByTestId('collection-page-footer').then(($footer) => {
+      const pageWindow = $footer[0].ownerDocument.defaultView
+      const footerBottom = Math.ceil(
+        $footer[0].getBoundingClientRect().bottom + (pageWindow?.scrollY ?? 0)
+      )
+
+      cy.document().then((document) => {
+        expect(document.documentElement.scrollHeight).to.equal(initialPageScrollHeight)
+        expect(document.documentElement.scrollHeight).to.equal(document.body.scrollHeight)
+        expect(document.documentElement.scrollHeight).to.be.closeTo(footerBottom, 1)
+      })
+    })
+  })
+
+  it('resets the items list scroll position after search, sort and filter changes', () => {
+    cy.customMount(
+      <CollectionItemsPanel
+        collectionId={ROOT_COLLECTION_ALIAS}
+        collectionRepository={collectionRepository}
+        collectionQueryParams={{
+          pageQuery: 1,
+          searchQuery: undefined,
+          typesQuery: undefined,
+          filtersQuery: undefined
+        }}
+        addDataSlot={null}
+      />
+    )
+
+    const moveItemsListAwayFromTop = () => {
+      cy.findByTestId('items-list-scrollable-container').then(($itemsList) => {
+        const itemsList = $itemsList[0]
+        const scrollTop = Math.min(100, itemsList.scrollHeight - itemsList.clientHeight)
+
+        expect(scrollTop).to.be.greaterThan(0)
+        itemsList.scrollTop = scrollTop
+        expect(itemsList.scrollTop).to.equal(scrollTop)
+      })
+    }
+
+    const expectItemsListAtTop = () => {
+      cy.findByTestId('items-list-scrollable-container').should(($itemsList) => {
+        expect($itemsList[0].scrollTop).to.equal(0)
+      })
+    }
+
+    cy.findByTestId('items-list').should('exist').children().should('have.length', 10)
+
+    moveItemsListAwayFromTop()
+    cy.findByPlaceholderText('Search this collection...').type('test search{enter}')
+    expectItemsListAtTop()
+
+    moveItemsListAwayFromTop()
+    cy.findByRole('button', { name: /Sort/ }).click()
+    cy.findByRole('button', { name: /Name \(A-Z\)/ }).click()
+    expectItemsListAtTop()
+
+    moveItemsListAwayFromTop()
+    cy.findByRole('checkbox', { name: /Files/ }).click()
+    expectItemsListAtTop()
+  })
+
   it('renders 4 items with no more to load, correct results in header, and no bottom skeleton loader', () => {
     const first4Elements = items.slice(0, 4)
     const first4ElementsWithCount: CollectionItemSubset = {


### PR DESCRIPTION
## What this PR does / why we need it:

Prevents the Collection Page from scrolling into blank space after repeatedly loading results through infinite scrolling.

In the affected layout, the page-level scroll range can grow as more results are added to the internal results list, even though the rendered page content and footer remain in the same bounds.

This PR:

- Adds a local positioning context to the collection items scroll container.
- Keeps the page-level scroll range aligned with the rendered page and footer.
- Adds regression coverage for repeated infinite-scroll loading.
- Verifies that the sticky results header and Sort control continue to work.
- Verifies that search, sort, and filter changes continue resetting the results list scroll position.
- Covers empty, small-result, and large-result states.

The change is intentionally limited to the collection items scroll container. It does not redesign the scrolling architecture or introduce broader CSS containment changes.

## Which issue(s) this PR closes:

- Closes #1030

## Suggestions on how to test this:

1. Open a Collection Page containing enough results for multiple infinite-scroll loads.
2. Repeatedly scroll the results list to the bottom.
3. Confirm that additional results load inside the list.
4. Confirm that the results header and Sort control remain sticky.
5. Use the page-level scrollbar and scroll to the bottom.
6. Confirm that the page ends at the footer and cannot scroll into blank space.
7. Perform a search, change sorting, and change a filter.
8. Confirm that each action resets the results list to the top.

## Does this PR introduce a user interface change?

No intended visual change. It corrects the page scroll boundary.

## Is there a release notes or changelog update needed for this change?

No.

## Testing performed:

- Collection items component tests: 94 passed
- Targeted Cypress E2E verification using the locally served branch with the Harvard Dataverse backend
- Typecheck
- ESLint, Stylelint, and Prettier checks
- Production build
