### PR TITLE
Allow Github Action Checks Running for Forks

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -3,7 +3,7 @@ name: accessibility
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   interaction-and-accessibility:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 jobs:
   lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: test
 on:
   push:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
 
 env:
   E2E_DATAVERSE_IMAGE_TAG: unstable


### PR DESCRIPTION
## What this PR does / why we need it:
When the contributors submit a new commit, the github action checks wouldn't trigger since the fork is seemed as a "synchronize" PR types. This change could allow forks run github action checks successfully. 

`Copy_labels`runs only if the contributor has writing permission for the repo, so it cannot run for forks. Storybook's workflows are also related chromatics so they're skipped

This should work, since I accidently push a commit with this fix into Sy's PR https://github.com/IQSS/dataverse-frontend/pull/1048 , but if this PR is approved, I won't need to retrieve anything from that PR.
