### PR TITLE
Fix bootstrap CSS leaks when reusing Dataverse Design System

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Preview } from '@storybook/react'
+import '@iqss/dataverse-design-system/bootstrap-global.css'
 import { ThemeProvider } from '@iqss/dataverse-design-system'
 import { createBrowserRouter, RouteObject, RouterProvider } from 'react-router-dom'
 import { FakerHelper } from '../tests/component/shared/FakerHelper'

--- a/packages/design-system/.storybook/preview.tsx
+++ b/packages/design-system/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { Preview } from '@storybook/react'
+import '../src/lib/assets/styles/bootstrap-global.scss'
 import { ThemeProvider } from '../src/lib/components/theme/ThemeProvider'
 import DocumentationTemplate from '../src/lib/stories/DocumentationTemplate.mdx'
 

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -56,6 +56,12 @@ function App() {
 export default App
 ```
 
+The Dataverse Design System's default stylesheet does not include Bootstrap's global Reboot or typography rules, so that importing components does not restyle the surrounding document. Applications that do want these page-level baselines can choose to import them at their application entry point:
+
+```jsx
+import '@iqss/dataverse-design-system/bootstrap-global.css'
+```
+
 For detailed usage instructions and available customization options, refer to the [Storybook](https://646fbe232a8d3b501a1943f3-mdvdyoulio.chromatic.com) provided with the package.
 
 [//]: # 'COMMING SOON'

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -21,7 +21,8 @@
   ],
   "scripts": {
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && npm run build:global-css",
+    "build:global-css": "sass --load-path=../../node_modules src/lib/assets/styles/bootstrap-global.scss dist/bootstrap-global.css --style=compressed --no-source-map",
     "prepublishOnly": "npm run build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
@@ -82,7 +83,8 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.umd.js"
       }
-    }
+    },
+    "./bootstrap-global.css": "./dist/bootstrap-global.css"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -22,7 +22,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build && npm run build:global-css",
-    "build:global-css": "sass --load-path=../../node_modules src/lib/assets/styles/bootstrap-global.scss dist/bootstrap-global.css --style=compressed --no-source-map",
+    "build:global-css": "node scripts/build-global-css.mjs",
     "prepublishOnly": "npm run build",
     "lint": "eslint src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",

--- a/packages/design-system/scripts/build-global-css.mjs
+++ b/packages/design-system/scripts/build-global-css.mjs
@@ -1,0 +1,20 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import sass from 'sass'
+
+const require = createRequire(import.meta.url)
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
+const bootstrapPackageRoot = path.dirname(require.resolve('bootstrap/package.json'))
+const nodeModulesRoot = path.dirname(bootstrapPackageRoot)
+const inputFile = path.join(packageRoot, 'src/lib/assets/styles/bootstrap-global.scss')
+const outputFile = path.join(packageRoot, 'dist/bootstrap-global.css')
+
+const result = sass.compile(inputFile, {
+  loadPaths: [nodeModulesRoot],
+  style: 'compressed'
+})
+
+mkdirSync(path.dirname(outputFile), { recursive: true })
+writeFileSync(outputFile, `${result.css}\n`)

--- a/packages/design-system/src/lib/assets/styles/_bootstrap-configuration.scss
+++ b/packages/design-system/src/lib/assets/styles/_bootstrap-configuration.scss
@@ -1,0 +1,52 @@
+@import 'design-tokens/typography.module';
+@import 'design-tokens/colors.module';
+
+@import 'bootstrap/scss/functions';
+
+// Theme
+$prefix: dv-bs-;
+
+$primary: $dv-primary-color;
+$secondary: $dv-secondary-color;
+$success: $dv-success-color;
+$info: $dv-info-color;
+$warning: $dv-warning-color;
+$danger: $dv-danger-color;
+
+// Body
+$body-color: $dv-text-color;
+$headings-color: $dv-headings-color;
+$code-color: $dv-text-color;
+
+// Typography
+$font-family-base: $dv-font-family;
+$line-height-base: $dv-line-height;
+$font-weight-normal: $dv-font-weight;
+$font-weight-light: $dv-font-weight-light;
+$font-weight-bold: $dv-font-weight-bold;
+
+// Links
+$link-color: $dv-link-color;
+$link-hover-color: $dv-link-hover-color;
+
+// Forms
+$form-label-font-weight: $dv-font-weight-bold;
+
+// Breadcrumb
+$breadcrumb-divider: '>';
+
+// QuestionMarkTooltip
+$tooltip-max-width: 500px;
+
+@import 'bootstrap/scss/variables';
+@import 'bootstrap/scss/maps';
+@import 'bootstrap/scss/mixins';
+
+// Bootstrap calculates some dimensions in rem while loading its variables, so
+// apply the Dataverse px-based font sizes after those calculations are complete.
+$font-size-base: $dv-font-size;
+$font-size-sm: $dv-font-size-sm;
+
+// Navbar
+$navbar-light-brand-color: $dv-brand-color;
+$navbar-brand-font-size: $dv-brand-font-size;

--- a/packages/design-system/src/lib/assets/styles/bootstrap-customized.scss
+++ b/packages/design-system/src/lib/assets/styles/bootstrap-customized.scss
@@ -1,45 +1,6 @@
-@import 'design-tokens/typography.module';
-@import 'design-tokens/colors.module';
+@import 'bootstrap-configuration';
 
-// Theme
-
-$primary: $dv-primary-color;
-$secondary: $dv-secondary-color;
-$success: $dv-success-color;
-$info: $dv-info-color;
-$warning: $dv-warning-color;
-$danger: $dv-danger-color;
-
-@import 'bootstrap/scss/functions';
-@import 'bootstrap/scss/variables';
-@import 'bootstrap/scss/mixins';
-
-// Body
-$body-color: $dv-text-color;
-$headings-color: $dv-headings-color;
-$code-color: $dv-text-color;
-
-// Typography
-$font-family-base: $dv-font-family;
-
-$font-size-base: $dv-font-size;
-$font-size-sm: $dv-font-size-sm;
-
-$line-height-base: $dv-line-height;
-
-$font-weight-normal: $dv-font-weight;
-$font-weight-light: $dv-font-weight-light;
-$font-weight-bold: $dv-font-weight-bold;
-
-// Links
-$link-color: $dv-link-color;
-$link-hover-color: $dv-link-hover-color;
-
-// Base
-@import 'bootstrap/scss/maps';
 @import 'bootstrap/scss/root';
-@import 'bootstrap/scss/reboot';
-@import 'bootstrap/scss/type';
 
 // Buttons and Dropdowns
 @import 'bootstrap/scss/buttons';
@@ -55,9 +16,6 @@ $link-hover-color: $dv-link-hover-color;
 // Badge
 @import 'bootstrap/scss/badge';
 
-// Forms
-$form-label-font-weight: $dv-font-weight-bold;
-
 @import 'bootstrap/scss/forms';
 
 // Table
@@ -70,13 +28,7 @@ $form-label-font-weight: $dv-font-weight-bold;
 @import 'bootstrap/scss/modal';
 @import 'bootstrap/scss/close';
 
-// Breadcrumb
-$breadcrumb-divider: '>';
-
 @import 'bootstrap/scss/breadcrumb';
-
-// QuestionMarkTooltip
-$tooltip-max-width: 500px;
 
 @import 'bootstrap/scss/tooltip';
 
@@ -98,11 +50,6 @@ $tooltip-max-width: 500px;
 // OffCanvas
 @import 'bootstrap/scss/offcanvas';
 
-// Navbar
-
-$navbar-light-brand-color: $dv-brand-color;
-$navbar-brand-font-size: $dv-brand-font-size;
-
 @import 'bootstrap/scss/nav';
 @import 'bootstrap/scss/navbar';
 @import 'bootstrap/scss/transitions';
@@ -122,10 +69,6 @@ $navbar-brand-font-size: $dv-brand-font-size;
 .dropdown-menu > .dropdown > .dropdown-toggle:hover {
   background-color: $dropdown-link-hover-bg;
   border-color: transparent;
-}
-
-th {
-  vertical-align: middle;
 }
 
 /* Start - Overrides to Fix Group Butttons with Buttons with Tooltips */

--- a/packages/design-system/src/lib/assets/styles/bootstrap-global.scss
+++ b/packages/design-system/src/lib/assets/styles/bootstrap-global.scss
@@ -1,0 +1,7 @@
+// Optional global Bootstrap baseline for applications that want Dataverse's
+// page-level normalization and typography. This is intentionally excluded from
+// the component stylesheet so embedding the design system does not restyle the
+// consumer's document.
+@import 'bootstrap-configuration';
+@import 'bootstrap/scss/reboot';
+@import 'bootstrap/scss/type';

--- a/packages/design-system/src/lib/components/table/Table.module.scss
+++ b/packages/design-system/src/lib/components/table/Table.module.scss
@@ -1,3 +1,7 @@
 .table > thead {
   text-align: center;
 }
+
+.table th {
+  vertical-align: middle;
+}

--- a/src/index.app.tsx
+++ b/src/index.app.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import App from './App'
 import './i18n'
 import { LoadingProvider } from './shared/contexts/loading/LoadingProvider'
+import '@iqss/dataverse-design-system/bootstrap-global.css'
 import { ThemeProvider } from '@iqss/dataverse-design-system'
 import { AppLoader } from './sections/shared/layout/app-loader/AppLoader'
 

--- a/src/sections/collection/collection-items-panel/items-list/ItemsList.module.scss
+++ b/src/sections/collection/collection-items-panel/items-list/ItemsList.module.scss
@@ -49,7 +49,7 @@
     z-index: 10;
     width: calc(100% + (var(--inline-padding) * 2));
     padding: 0.5rem var(--inline-padding);
-    background-color: var(--bs-white);
+    background-color: var(--dv-bs-white);
     box-shadow: 0 0 10px 0 rgba(0 0 0 / 30%);
     transform: translateX(calc(var(--inline-padding) * -1));
   }
@@ -85,7 +85,7 @@
     z-index: 10;
     width: calc(100% + (var(--inline-padding) * 2));
     padding: 1rem var(--inline-padding) 0.5rem;
-    background-color: var(--bs-white);
+    background-color: var(--dv-bs-white);
     box-shadow: 0 0 10px 0 rgba(0 0 0 / 30%);
     transform: translateX(calc(var(--inline-padding) * -1));
   }

--- a/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
+++ b/src/sections/dataset/dataset-files/DatasetFilesScrollable.module.scss
@@ -15,7 +15,7 @@
     left: 0;
     z-index: 2;
     padding: 0.25rem 0.5rem 1rem 0.25rem;
-    background: var(--bs-white);
+    background: var(--dv-bs-white);
   }
 
   table {

--- a/src/sections/dataset/dataset-files/files-table/FilesTable.module.scss
+++ b/src/sections/dataset/dataset-files/files-table/FilesTable.module.scss
@@ -1,7 +1,7 @@
 .table-sticky-header {
   position: sticky;
   z-index: 1;
-  background-color: var(--bs-white);
+  background-color: var(--dv-bs-white);
   transition: top 100ms ease-in-out;
 
   &::before {
@@ -10,7 +10,7 @@
     display: block;
     width: 100%;
     height: 1px;
-    background: var(--bs-border-color);
+    background: var(--dv-bs-border-color);
     content: '';
   }
 

--- a/src/sections/edit-dataset-terms/EditDatasetTerms.module.scss
+++ b/src/sections/edit-dataset-terms/EditDatasetTerms.module.scss
@@ -19,29 +19,29 @@
 
 .placeholder {
   padding: 2rem;
-  color: var(--bs-secondary);
+  color: var(--dv-bs-secondary);
   font-style: italic;
   text-align: center;
-  background-color: var(--bs-light);
-  border: 2px dashed var(--bs-border-color);
+  background-color: var(--dv-bs-light);
+  border: 2px dashed var(--dv-bs-border-color);
   border-radius: 0.375rem;
 }
 
 .section-title {
   margin-bottom: 0;
   margin-left: 0.5rem;
-  color: var(--bs-dark);
+  color: var(--dv-bs-dark);
   font-weight: 600;
   font-size: 1rem;
 }
 
 .section-description {
   margin-left: 1rem;
-  color: var(--bs-body-color);
+  color: var(--dv-bs-body-color);
   line-height: 1.6;
 
   a {
-    color: var(--bs-primary);
+    color: var(--dv-bs-primary);
     text-decoration: none;
 
     &:hover {

--- a/src/sections/edit-dataset-terms/edit-guestbook/EditGuestbook.module.scss
+++ b/src/sections/edit-dataset-terms/edit-guestbook/EditGuestbook.module.scss
@@ -5,7 +5,7 @@
 
   .guestbook-list {
     margin-top: 0.75rem;
-    border: 1px solid var(--bs-border-color);
+    border: 1px solid var(--dv-bs-border-color);
   }
 
   .guestbook-loading {
@@ -18,7 +18,7 @@
     align-items: center;
     gap: 1rem;
     padding: 0.75rem;
-    border-top: 1px solid var(--bs-border-color);
+    border-top: 1px solid var(--dv-bs-border-color);
   }
 
   .guestbook-option:first-child {
@@ -34,6 +34,6 @@
     gap: 1rem;
     margin-top: 2rem;
     padding-top: 2rem;
-    border-top: 1px solid var(--bs-border-color);
+    border-top: 1px solid var(--dv-bs-border-color);
   }
 }

--- a/src/sections/edit-dataset-terms/edit-license-and-terms/EditLicenseAndTerms.module.scss
+++ b/src/sections/edit-dataset-terms/edit-license-and-terms/EditLicenseAndTerms.module.scss
@@ -9,7 +9,7 @@
   gap: 1rem;
   margin-top: 2rem;
   padding-top: 2rem;
-  border-top: 1px solid var(--bs-border-color);
+  border-top: 1px solid var(--dv-bs-border-color);
 }
 
 .guestbook-option {
@@ -19,7 +19,7 @@
   margin: 0.5rem;
   margin-left: 0.5rem;
   padding: 0.5rem 0.75rem;
-  background-color: var(--bs-light);
+  background-color: var(--dv-bs-light);
   border-radius: 4px;
 }
 

--- a/src/sections/layout/header/Header.module.scss
+++ b/src/sections/layout/header/Header.module.scss
@@ -4,7 +4,7 @@
   box-shadow: 0 1px 5px rgba(0 0 0 / 10%);
 
   .login-btn {
-    color: var(--bs-nav-link-color);
+    color: var(--dv-bs-nav-link-color);
     text-decoration: none;
   }
 }

--- a/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/index.module.scss
+++ b/src/sections/shared/form/DatasetMetadataForm/MetadataForm/MetadataBlockFormFields/MetadataFormField/index.module.scss
@@ -79,7 +79,7 @@
 }
 
 .custom-instructions-content .custom-instructions-toggle:hover {
-  color: var(--bs-link-hover-color, #0a58ca);
+  color: var(--dv-bs-link-hover-color, #0a58ca);
 }
 
 .custom-instructions-editor {
@@ -103,11 +103,11 @@
   justify-content: center;
   width: 36px;
   height: 36px;
-  border: 1px solid var(--bs-border-color, #ced4da);
+  border: 1px solid var(--dv-bs-border-color, #ced4da);
   border-radius: 6px;
   cursor: pointer;
 }
 
 .custom-instructions-icon-button:hover {
-  background: var(--bs-tertiary-bg, #f8f9fa);
+  background: var(--dv-bs-tertiary-bg, #f8f9fa);
 }


### PR DESCRIPTION
## What this PR does / why we need it:
#1060 describes how reusing the Dataverse Design System leaked Bootstrap CSS into a consuming project. This PR is a proposal how this could be addressed:
- use `$prefix: dv-bs-` for Dataverse CSS
- stop bundling `bootstrap/scss/reboot` and `bootstrap/scss/type` into the default stylesheet, since they had major page-level effects
- introduce the optional `bootstrap-global.css` into the design-system dist, which does bundle `bootstrap/scss/reboot` and `bootstrap/scss/type`. It can be imported on demand, as an opt-in solution for those applications that want it.

## Which issue(s) this PR closes:

- Closes #1060

## Special notes for your reviewer:

## Suggestions on how to test this:
1) Side-by-side comparison of `modern/` pages with and without these changes. If this PR is working correctly there should be no differences.
2) Use this version of the Dataverse Design System in a non-Bootstrap React project, and check if its CSS has any unwanted side effects. In project seen in the above linked issue's screenshot, no such issues occur anymore.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No

## Is there a release notes or changelog update needed for this change?:
Users of the Dataverse Design System should be informed that importing the Bootstrap page-level styles is now opt-in (via `bootstrap-global.css`).

## Additional documentation:
