### PR TITLE
fix: localize dynamic values and controlled labels (#1063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Fixed
 
+- Format dates, file sizes, and counts using the active interface language; translate known file labels and search facets while preserving custom metadata and raw filter values. (#1063)
 - Edit Dataset Terms: navigate to the draft version of the dataset after saving changes to the terms, instead of the latest published version.
 - After saving on either Edit Template tab (Metadata or Terms), the user is redirected to the templates listing with a success toast instead of staying on the edit page.
 - Edit Template breadcrumb on the Terms page no longer renders the dataset's "Terms and Guestbook" label (templates have no guestbook).

--- a/public/locales/en/collection.json
+++ b/public/locales/en/collection.json
@@ -81,5 +81,34 @@
     "helper": "Choose which of your collections you would like to link this collection to.",
     "save": "Save Linked Collection",
     "success": "<wrapper>{{linkedCollectionName}} has been successfully linked to <a>{{linkingCollectionName}}</a></wrapper>"
+  },
+  "facets": {
+    "names": {
+      "subject": "Subject",
+      "authorName": "Author Name",
+      "authorAffiliation": "Author Affiliation"
+    },
+    "subjectValues": {
+      "agriculturalSciences": "Agricultural Sciences",
+      "artsAndHumanities": "Arts and Humanities",
+      "astronomyAndAstrophysics": "Astronomy and Astrophysics",
+      "businessAndManagement": "Business and Management",
+      "chemistry": "Chemistry",
+      "computerAndInformationScience": "Computer and Information Science",
+      "earthAndEnvironmentalSciences": "Earth and Environmental Sciences",
+      "engineering": "Engineering",
+      "law": "Law",
+      "mathematicalSciences": "Mathematical Sciences",
+      "medicineHealthAndLifeSciences": "Medicine, Health and Life Sciences",
+      "physics": "Physics",
+      "socialSciences": "Social Sciences",
+      "other": "Other"
+    }
+  },
+  "fileCard": {
+    "variables_one": "{{formattedCount}} variable",
+    "variables_other": "{{formattedCount}} variables",
+    "observations_one": "{{formattedCount}} observation",
+    "observations_other": "{{formattedCount}} observations"
   }
 }

--- a/public/locales/en/file.json
+++ b/public/locales/en/file.json
@@ -71,6 +71,14 @@
       "observations": "Observations",
       "directory": "File Path",
       "description": "Description"
+    },
+    "fileTypes": {
+      "tabDelimited": "Tab-Delimited"
+    },
+    "systemFileCategories": {
+      "documentation": "Documentation",
+      "data": "Data",
+      "code": "Code"
     }
   },
   "actionButtons": {

--- a/public/locales/es/collection.json
+++ b/public/locales/es/collection.json
@@ -81,5 +81,34 @@
     "helper": "Elige a cuál de tus colecciones te gustaría vincular esta colección.",
     "save": "Guardar colección vinculada",
     "success": "<wrapper>{{linkedCollectionName}} se ha vinculado correctamente a <a>{{linkingCollectionName}}</a></wrapper>"
+  },
+  "facets": {
+    "names": {
+      "subject": "Tema",
+      "authorName": "Nombre del autor",
+      "authorAffiliation": "Afiliación del autor"
+    },
+    "subjectValues": {
+      "agriculturalSciences": "Ciencias agrarias",
+      "artsAndHumanities": "Artes y humanidades",
+      "astronomyAndAstrophysics": "Astronomía y astrofísica",
+      "businessAndManagement": "Administración y empresas",
+      "chemistry": "Química",
+      "computerAndInformationScience": "Ciencias de la información y computación",
+      "earthAndEnvironmentalSciences": "Ciencias de la tierra y el medioambiente",
+      "engineering": "Ingeniería",
+      "law": "Derecho",
+      "mathematicalSciences": "Ciencias matemáticas",
+      "medicineHealthAndLifeSciences": "Ciencias médicas, de la salud y de la vida",
+      "physics": "Física",
+      "socialSciences": "Ciencias sociales",
+      "other": "Otra"
+    }
+  },
+  "fileCard": {
+    "variables_one": "{{formattedCount}} variable",
+    "variables_other": "{{formattedCount}} variables",
+    "observations_one": "{{formattedCount}} observación",
+    "observations_other": "{{formattedCount}} observaciones"
   }
 }

--- a/public/locales/es/file.json
+++ b/public/locales/es/file.json
@@ -71,6 +71,14 @@
       "observations": "Observaciones",
       "directory": "Ruta del archivo",
       "description": "Descripción"
+    },
+    "fileTypes": {
+      "tabDelimited": "Valores separados por tabuladores"
+    },
+    "systemFileCategories": {
+      "documentation": "Documentación",
+      "data": "Datos",
+      "code": "Código"
     }
   },
   "actionButtons": {

--- a/src/files/domain/models/FileMetadata.ts
+++ b/src/files/domain/models/FileMetadata.ts
@@ -23,9 +23,10 @@ export class FileSize {
     ;[this.value, this.unit] = FileSize.convertToLargestUnit(value, unit)
   }
 
-  toString(): string {
-    const formattedValue =
-      this.value % 1 === 0 ? this.value.toFixed(0) : (Math.round(this.value * 10) / 10).toString()
+  toString(locale?: string): string {
+    const formattedValue = new Intl.NumberFormat(locale, {
+      maximumFractionDigits: 1
+    }).format(this.value)
     return `${formattedValue} ${this.unit}`
   }
 

--- a/src/sections/collection/collection-items-panel/filter-panel/facets-filters/FacetFilterGroup.tsx
+++ b/src/sections/collection/collection-items-panel/filter-panel/facets-filters/FacetFilterGroup.tsx
@@ -9,6 +9,29 @@ import styles from './FacetsFilters.module.scss'
 
 const FACETS_PER_VIEW = 5
 
+const FACET_NAME_TRANSLATION_KEY_BY_NAME: Record<string, string> = {
+  subject_ss: 'facets.names.subject',
+  authorName_ss: 'facets.names.authorName',
+  authorAffiliation_ss: 'facets.names.authorAffiliation'
+}
+
+const SUBJECT_TRANSLATION_KEY_BY_VALUE: Record<string, string> = {
+  'Agricultural Sciences': 'facets.subjectValues.agriculturalSciences',
+  'Arts and Humanities': 'facets.subjectValues.artsAndHumanities',
+  'Astronomy and Astrophysics': 'facets.subjectValues.astronomyAndAstrophysics',
+  'Business and Management': 'facets.subjectValues.businessAndManagement',
+  Chemistry: 'facets.subjectValues.chemistry',
+  'Computer and Information Science': 'facets.subjectValues.computerAndInformationScience',
+  'Earth and Environmental Sciences': 'facets.subjectValues.earthAndEnvironmentalSciences',
+  Engineering: 'facets.subjectValues.engineering',
+  Law: 'facets.subjectValues.law',
+  'Mathematical Sciences': 'facets.subjectValues.mathematicalSciences',
+  'Medicine, Health and Life Sciences': 'facets.subjectValues.medicineHealthAndLifeSciences',
+  Physics: 'facets.subjectValues.physics',
+  'Social Sciences': 'facets.subjectValues.socialSciences',
+  Other: 'facets.subjectValues.other'
+}
+
 export enum RemoveAddFacetFilter {
   REMOVE = 'remove',
   ADD = 'add'
@@ -27,10 +50,17 @@ export const FacetFilterGroup = ({
   onFacetChange,
   isLoadingCollectionItems
 }: FacetFilterGroupProps) => {
-  const { t } = useTranslation('collection')
+  const { t, i18n } = useTranslation('collection')
   const { t: tShared } = useTranslation('shared')
 
   const [visibleCount, setVisibleCount] = useState(FACETS_PER_VIEW)
+  const facetNameTranslationKey = Object.hasOwn(FACET_NAME_TRANSLATION_KEY_BY_NAME, facet.name)
+    ? FACET_NAME_TRANSLATION_KEY_BY_NAME[facet.name]
+    : undefined
+  const facetDisplayName = facetNameTranslationKey
+    ? t(facetNameTranslationKey, { defaultValue: facet.friendlyName })
+    : facet.friendlyName
+  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language)
 
   const handleShowMore = () => {
     setVisibleCount((prev) => Math.min(prev + FACETS_PER_VIEW, facet.labels.length))
@@ -56,7 +86,7 @@ export const FacetFilterGroup = ({
 
   return (
     <li key={facet.name} className={styles['facet-filter-group']}>
-      <span className={styles['facet-name']}>{facet.friendlyName}</span>
+      <span className={styles['facet-name']}>{facetDisplayName}</span>
       <ul className={styles['labels-list']}>
         {[...facet.labels]
           .sort((a, b) =>
@@ -67,6 +97,14 @@ export const FacetFilterGroup = ({
           .slice(0, visibleCount)
           .map((label) => {
             const isFacetLabelSelected = Boolean(facetSelectedLabels?.includes(label.name))
+            const subjectTranslationKey =
+              facet.name === 'subject_ss' &&
+              Object.hasOwn(SUBJECT_TRANSLATION_KEY_BY_VALUE, label.name)
+                ? SUBJECT_TRANSLATION_KEY_BY_VALUE[label.name]
+                : undefined
+            const labelDisplayName = subjectTranslationKey
+              ? t(subjectTranslationKey, { defaultValue: label.name })
+              : label.name
 
             return (
               <li key={label.name}>
@@ -77,13 +115,13 @@ export const FacetFilterGroup = ({
                   })}
                   aria-label={
                     isFacetLabelSelected
-                      ? t('removeSelectedFacet', { labelName: label.name })
-                      : t('addFacetFilter', { labelName: label.name })
+                      ? t('removeSelectedFacet', { labelName: labelDisplayName })
+                      : t('addFacetFilter', { labelName: labelDisplayName })
                   }
                   disabled={isLoadingCollectionItems}
                   variant="link"
                   size="sm">
-                  <span>{`${label.name} (${label.count})`}</span>
+                  <span>{`${labelDisplayName} (${numberFormatter.format(label.count)})`}</span>
                   {isFacetLabelSelected && <CloseIcon size={22} />}
                 </Button>
               </li>

--- a/src/sections/collection/collection-items-panel/filter-panel/type-filters/TypeFilters.tsx
+++ b/src/sections/collection/collection-items-panel/filter-panel/type-filters/TypeFilters.tsx
@@ -23,7 +23,8 @@ export const TypeFilters = ({
   isLoadingCollectionItems,
   countPerObjectType
 }: TypeFiltersProps) => {
-  const { t } = useTranslation('collection')
+  const { t, i18n } = useTranslation('collection')
+  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language)
 
   const handleItemTypeChange = (type: CollectionItemType, checked: boolean) => {
     onItemTypesChange({ type, checked })
@@ -55,7 +56,7 @@ export const TypeFilters = ({
               {t('collectionFilterTypeLabel')}{' '}
               {countPerObjectType?.collections !== undefined &&
                 currentItemTypes?.includes(CollectionItemType.COLLECTION) && (
-                  <small>{`(${Intl.NumberFormat().format(countPerObjectType.collections)})`}</small>
+                  <small>{`(${numberFormatter.format(countPerObjectType.collections)})`}</small>
                 )}
             </span>
           </>
@@ -75,7 +76,7 @@ export const TypeFilters = ({
               {t('datasetFilterTypeLabel')}{' '}
               {countPerObjectType?.datasets !== undefined &&
                 currentItemTypes?.includes(CollectionItemType.DATASET) && (
-                  <small>{`(${Intl.NumberFormat().format(countPerObjectType.datasets)})`}</small>
+                  <small>{`(${numberFormatter.format(countPerObjectType.datasets)})`}</small>
                 )}
             </span>
           </>
@@ -95,7 +96,7 @@ export const TypeFilters = ({
               {t('fileFilterTypeLabel')}{' '}
               {countPerObjectType?.files !== undefined &&
                 currentItemTypes?.includes(CollectionItemType.FILE) && (
-                  <small>{`(${Intl.NumberFormat().format(countPerObjectType.files)})`}</small>
+                  <small>{`(${numberFormatter.format(countPerObjectType.files)})`}</small>
                 )}
             </span>
           </>

--- a/src/sections/collection/collection-items-panel/items-list/file-card/FileCardBody.tsx
+++ b/src/sections/collection/collection-items-panel/items-list/file-card/FileCardBody.tsx
@@ -10,15 +10,20 @@ import { DvObjectType } from '@/shared/hierarchy/domain/models/UpwardHierarchyNo
 import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus'
 import { CopyToClipboardButton } from '@/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/copy-to-clipboard-button/CopyToClipboardButton'
 import { FileLabels } from '@/sections/file/file-labels/FileLabels'
+import { FileTypeLabel } from '@/sections/file/file-type-label/FileTypeLabel'
+import { useTranslation } from 'react-i18next'
 
 interface FileCardBodyProps {
   filePreview: FileItemTypePreview
 }
 
 export const FileCardBody = ({ filePreview }: FileCardBodyProps) => {
-  const bytesFormatted = FileCardHelper.formatBytesToCompactNumber(filePreview.sizeInBytes)
-  const variables = filePreview.variables || 0
-  const observations = filePreview.observations || 0
+  const { t, i18n } = useTranslation('collection')
+  const locale = i18n.resolvedLanguage || i18n.language
+  const bytesFormatted = FileCardHelper.formatBytesToCompactNumber(filePreview.sizeInBytes, locale)
+  const variables = filePreview.variables ?? 0
+  const observations = filePreview.observations ?? 0
+  const numberFormatter = new Intl.NumberFormat(locale)
 
   return (
     <Stack direction="vertical" gap={2} className={styles['card-body-container']}>
@@ -45,10 +50,26 @@ export const FileCardBody = ({ filePreview }: FileCardBodyProps) => {
             </span>
           </Stack>
           <div className={styles.info}>
-            <span>{filePreview.fileType}</span>
+            <span>
+              <FileTypeLabel
+                mimeType={filePreview.fileContentType}
+                fallback={filePreview.fileType}
+              />
+            </span>
             <span>{`- ${bytesFormatted}`}</span>
-            {filePreview.fileType === 'Tab-Delimited' && (
-              <span>{`- ${variables} variables, ${observations} observations`}</span>
+            {filePreview.fileContentType === 'text/tab-separated-values' && (
+              <span>
+                {'- '}
+                {t('fileCard.variables', {
+                  count: variables,
+                  formattedCount: numberFormatter.format(variables)
+                })}
+                {', '}
+                {t('fileCard.observations', {
+                  count: observations,
+                  formattedCount: numberFormatter.format(observations)
+                })}
+              </span>
             )}
             {filePreview.checksum && (
               <Stack direction="horizontal" gap={0}>

--- a/src/sections/collection/collection-items-panel/items-list/file-card/FileCardHelper.ts
+++ b/src/sections/collection/collection-items-panel/items-list/file-card/FileCardHelper.ts
@@ -16,8 +16,8 @@ export class FileCardHelper {
     return params
   }
 
-  static formatBytesToCompactNumber(bytes: number): string {
-    const byteValueNumberFormatter = Intl.NumberFormat(undefined, {
+  static formatBytesToCompactNumber(bytes: number, locale?: string): string {
+    const byteValueNumberFormatter = Intl.NumberFormat(locale, {
       notation: 'compact',
       style: 'unit',
       unit: 'byte',

--- a/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
+++ b/src/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.tsx
@@ -137,7 +137,7 @@ const DatasetDownloadOptions = ({
   requiresTermsOrGuestbook,
   onDownloadWithGuestbook
 }: DatasetDownloadOptionsProps) => {
-  const { t } = useTranslation('dataset')
+  const { t, i18n } = useTranslation('dataset')
   const { t: tFiles } = useTranslation('files')
   const accessRepository = useAccessRepository()
 
@@ -173,7 +173,7 @@ const DatasetDownloadOptions = ({
 
   function getFormattedFileSize(mode: FileDownloadMode): string {
     const foundSize = fileDownloadSizes.find((size) => size.mode === mode)
-    return foundSize ? foundSize.toString() : ''
+    return foundSize ? foundSize.toString(i18n.resolvedLanguage || i18n.language) : ''
   }
 
   return hasOneTabularFileAtLeast ? (

--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDownloads.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDownloads.tsx
@@ -6,7 +6,7 @@ interface FileDownloadsProps {
   datasetPublishingStatus: DatasetPublishingStatus
 }
 export function FileDownloads({ downloadCount, datasetPublishingStatus }: FileDownloadsProps) {
-  const { t } = useTranslation('files')
+  const { t, i18n } = useTranslation('files')
   if (datasetPublishingStatus !== DatasetPublishingStatus.RELEASED) {
     return <></>
   }
@@ -14,7 +14,8 @@ export function FileDownloads({ downloadCount, datasetPublishingStatus }: FileDo
   return (
     <div>
       <span>
-        {downloadCount} {t('table.downloads')}
+        {new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language).format(downloadCount)}{' '}
+        {t('table.downloads')}
       </span>
     </div>
   )

--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileTabularData.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileTabularData.tsx
@@ -7,14 +7,16 @@ export function FileTabularData({
 }: {
   tabularData: FileTabularDataModel | undefined
 }) {
-  const { t } = useTranslation('files')
+  const { t, i18n } = useTranslation('files')
   if (!tabularData) {
     return <></>
   }
+  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language)
+
   return (
     <div>
-      {tabularData.variables} {t('table.tabularData.variables')}, {tabularData.observations}{' '}
-      {t('table.tabularData.observations')}{' '}
+      {numberFormatter.format(tabularData.variables)} {t('table.tabularData.variables')},{' '}
+      {numberFormatter.format(tabularData.observations)} {t('table.tabularData.observations')}{' '}
       {tabularData.unf && <CopyToClipboardButton text={tabularData.unf} />}
     </div>
   )

--- a/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileType.tsx
+++ b/src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileType.tsx
@@ -10,14 +10,14 @@ interface FileTypeProps {
 }
 
 export function FileType({ type, size }: FileTypeProps) {
-  const { t } = useTranslation('files')
+  const { t, i18n } = useTranslation('files')
   return (
     <div>
       <span>
         {type.value === 'text/tab-separated-values'
           ? t('table.tabularData.name')
           : type.toDisplayFormat()}{' '}
-        - {size.toString()}
+        - {size.toString(i18n.resolvedLanguage || i18n.language)}
       </span>
     </div>
   )

--- a/src/sections/edit-file-metadata/EditFileMetadata.tsx
+++ b/src/sections/edit-file-metadata/EditFileMetadata.tsx
@@ -28,7 +28,7 @@ export enum EditFileMetadataReferrer {
 
 export const EditFileMetadata = ({ fileId, fileRepository, referrer }: EditFileMetadataProps) => {
   const { t: tEditFileMetadata } = useTranslation('editFileMetadata')
-  const { t: tFiles } = useTranslation('files')
+  const { t: tFiles, i18n } = useTranslation('files')
   const { setIsLoading } = useLoading()
   const { file, isLoading } = useFile(fileRepository, fileId)
 
@@ -70,7 +70,10 @@ export const EditFileMetadata = ({ fileId, fileRepository, referrer }: EditFileM
             <div className={styles.tab_container}>
               <EditFilesList
                 fileRepository={fileRepository}
-                editFileMetadataFormData={createEditFileMetadataFormData(file)}
+                editFileMetadataFormData={createEditFileMetadataFormData(
+                  file,
+                  i18n.resolvedLanguage || i18n.language
+                )}
                 referrer={referrer}
                 datasetPersistentId={file.hierarchy.parent?.persistentId}
                 datasetLastUpdateTime={file.datasetVersion.lastUpdateTime}
@@ -82,14 +85,14 @@ export const EditFileMetadata = ({ fileId, fileRepository, referrer }: EditFileM
     </section>
   )
 }
-const createEditFileMetadataFormData = (file: File): EditFileMetadataFormData => {
+const createEditFileMetadataFormData = (file: File, locale?: string): EditFileMetadataFormData => {
   return {
     files: [
       {
         id: file.id,
         fileName: file.name,
         fileType: file.metadata.type.value,
-        fileSizeString: file.metadata.size.toString(),
+        fileSizeString: file.metadata.size.toString(locale),
         checksumValue: file.metadata.checksum?.value.toString(),
         checksumAlgorithm: file.metadata.checksum?.algorithm,
         description: file.metadata.description ?? '',

--- a/src/sections/file/file-labels/FileLabels.tsx
+++ b/src/sections/file/file-labels/FileLabels.tsx
@@ -1,18 +1,37 @@
 import { Badge } from '@iqss/dataverse-design-system'
 import { FileLabel, FileLabelType } from '../../../files/domain/models/FileMetadata'
 import styles from './FileLabels.module.scss'
+import { useTranslation } from 'react-i18next'
 
 const VARIANT_BY_LABEL_TYPE: Record<FileLabelType, 'secondary' | 'info'> = {
   [FileLabelType.CATEGORY]: 'secondary',
   [FileLabelType.TAG]: 'info'
 }
 
+const SYSTEM_CATEGORY_TRANSLATION_KEY_BY_VALUE: Record<string, string> = {
+  Documentation: 'metadata.systemFileCategories.documentation',
+  Data: 'metadata.systemFileCategories.data',
+  Code: 'metadata.systemFileCategories.code'
+}
+
 export function FileLabels({ labels }: { labels: FileLabel[] }) {
+  const { t } = useTranslation('file')
+
+  const getDisplayValue = (label: FileLabel): string => {
+    const translationKey =
+      label.type === FileLabelType.CATEGORY &&
+      Object.hasOwn(SYSTEM_CATEGORY_TRANSLATION_KEY_BY_VALUE, label.value)
+        ? SYSTEM_CATEGORY_TRANSLATION_KEY_BY_VALUE[label.value]
+        : undefined
+
+    return translationKey ? t(translationKey, { defaultValue: label.value }) : label.value
+  }
+
   return (
     <div className={styles.container} data-testid="file-labels">
       {labels.map((label, index) => (
         <Badge key={`${label.value}-${index}`} variant={VARIANT_BY_LABEL_TYPE[label.type]}>
-          {label.value}
+          {getDisplayValue(label)}
         </Badge>
       ))}
     </div>

--- a/src/sections/file/file-metadata/FileMetadata.tsx
+++ b/src/sections/file/file-metadata/FileMetadata.tsx
@@ -11,6 +11,7 @@ import { MarkdownComponent } from '@/sections/dataset/markdown/MarkdownComponent
 import { DataverseInfoRepository } from '@/info/domain/repositories/DataverseInfoRepository'
 import { ExportMetadataDropdown } from '@/sections/dataset/dataset-metadata/export-metadata-dropdown/ExportMetadataDropdown'
 import { File } from '@/files/domain/models/File'
+import { FileTypeLabel } from '@/sections/file/file-type-label/FileTypeLabel'
 import styles from './FileMetadata.module.scss'
 
 interface FileMetadataProps {
@@ -35,8 +36,9 @@ export function FileMetadata({
   datasetVersion,
   dataverseInfoRepository
 }: FileMetadataProps) {
-  const { t } = useTranslation('file')
+  const { t, i18n } = useTranslation('file')
   const appConfig = requireAppConfig()
+  const numberFormatter = new Intl.NumberFormat(i18n.resolvedLanguage || i18n.language)
 
   return (
     <>
@@ -173,13 +175,18 @@ export function FileMetadata({
               <Col sm={3}>
                 <strong>{t('metadata.fields.size')}</strong>
               </Col>
-              <Col>{metadata.size.toString()}</Col>
+              <Col>{metadata.size.toString(i18n.resolvedLanguage || i18n.language)}</Col>
             </Row>
             <Row className={styles.row}>
               <Col sm={3}>
                 <strong>{t('metadata.fields.type')}</strong>
               </Col>
-              <Col>{metadata.type.toDisplayFormat()}</Col>
+              <Col>
+                <FileTypeLabel
+                  mimeType={metadata.type.value}
+                  fallback={metadata.type.toDisplayFormat()}
+                />
+              </Col>
             </Row>
             {metadata.tabularData && (
               <>
@@ -187,13 +194,13 @@ export function FileMetadata({
                   <Col sm={3}>
                     <strong>{t('metadata.fields.variables')}</strong>
                   </Col>
-                  <Col>{metadata.tabularData.variables}</Col>
+                  <Col>{numberFormatter.format(metadata.tabularData.variables)}</Col>
                 </Row>
                 <Row className={styles.row}>
                   <Col sm={3}>
                     <strong>{t('metadata.fields.observations')}</strong>
                   </Col>
-                  <Col>{metadata.tabularData.observations}</Col>
+                  <Col>{numberFormatter.format(metadata.tabularData.observations)}</Col>
                 </Row>
               </>
             )}

--- a/src/sections/file/file-type-label/FileTypeLabel.tsx
+++ b/src/sections/file/file-type-label/FileTypeLabel.tsx
@@ -1,0 +1,18 @@
+import { useTranslation } from 'react-i18next'
+
+interface FileTypeLabelProps {
+  mimeType: string
+  fallback: string
+}
+
+export function FileTypeLabel({ mimeType, fallback }: FileTypeLabelProps) {
+  const { t } = useTranslation('file')
+
+  return (
+    <>
+      {mimeType === 'text/tab-separated-values'
+        ? t('metadata.fileTypes.tabDelimited', { defaultValue: fallback })
+        : fallback}
+    </>
+  )
+}

--- a/src/sections/shared/pagination/PaginationResultsInfo.tsx
+++ b/src/sections/shared/pagination/PaginationResultsInfo.tsx
@@ -11,7 +11,8 @@ interface PaginationResultsInfoProps {
 }
 
 export function PaginationResultsInfo({ paginationInfo, accumulated }: PaginationResultsInfoProps) {
-  const { t } = useTranslation('shared', { keyPrefix: 'pagination' })
+  const { t, i18n } = useTranslation('shared', { keyPrefix: 'pagination' })
+  const locale = i18n.resolvedLanguage || i18n.language
 
   const defineLocale = useCallback(
     (accumulated: number) =>
@@ -23,23 +24,24 @@ export function PaginationResultsInfo({ paginationInfo, accumulated }: Paginatio
     [paginationInfo.pageSize]
   )
 
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(locale), [locale])
   const formattedCount = useMemo(
-    () => new Intl.NumberFormat().format(paginationInfo.totalItems),
-    [paginationInfo.totalItems]
+    () => numberFormatter.format(paginationInfo.totalItems),
+    [numberFormatter, paginationInfo.totalItems]
   )
 
   return (
     <span className={styles.results}>
       {typeof accumulated === 'number'
         ? t(defineLocale(accumulated), {
-            accumulated: accumulated,
+            accumulated: numberFormatter.format(accumulated),
             count: paginationInfo.totalItems,
             formattedCount: formattedCount,
             item: paginationInfo.itemName
           })
         : t('results', {
-            start: paginationInfo.pageStartItem,
-            end: paginationInfo.pageEndItem,
+            start: numberFormatter.format(paginationInfo.pageStartItem),
+            end: numberFormatter.format(paginationInfo.pageEndItem),
             item: paginationInfo.itemName,
             count: paginationInfo.totalItems,
             formattedCount: formattedCount

--- a/src/shared/helpers/DateHelper.ts
+++ b/src/shared/helpers/DateHelper.ts
@@ -1,9 +1,11 @@
+import i18n from '@/i18n'
+
 export class DateHelper {
   static toDisplayFormat(date: Date): string {
     if (!date) {
       return ''
     }
-    return date.toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale, {
+    return date.toLocaleDateString(DateHelper.getActiveLocale(), {
       year: 'numeric',
       month: 'short',
       day: 'numeric'
@@ -13,8 +15,7 @@ export class DateHelper {
     if (!date) {
       return ''
     }
-    const locale = Intl.DateTimeFormat().resolvedOptions().locale
-    return date.toLocaleString(locale, {
+    return date.toLocaleString(DateHelper.getActiveLocale(), {
       year: 'numeric',
       month: 'short',
       day: 'numeric',
@@ -29,7 +30,7 @@ export class DateHelper {
     if (!date) {
       return ''
     }
-    return date.toLocaleDateString(Intl.DateTimeFormat().resolvedOptions().locale, {
+    return date.toLocaleDateString(DateHelper.getActiveLocale(), {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit'
@@ -38,5 +39,9 @@ export class DateHelper {
 
   static toISO8601Format(date: Date): string {
     return date.toISOString().split('T')[0]
+  }
+
+  private static getActiveLocale(): string | undefined {
+    return i18n.resolvedLanguage || i18n.languages[0]
   }
 }

--- a/tests/component/sections/collection/collection-items-panel/FacetsFilter.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/FacetsFilter.spec.tsx
@@ -1,10 +1,15 @@
 import { FacetsFilters } from '@/sections/collection/collection-items-panel/filter-panel/facets-filters/FacetsFilters'
 import { CollectionItemsMother } from '@tests/component/collection/domain/models/CollectionItemsMother'
 import styles from '@/sections/collection/collection-items-panel/filter-panel/facets-filters/FacetsFilters.module.scss'
+import { CollectionItemsFacet } from '@/collection/domain/models/CollectionItemSubset'
+import i18n from '@/i18n'
 
 const facets = CollectionItemsMother.createItemsFacets()
 
 describe('FacetsFilters', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('should render skeleton while loading collection items and no facets', () => {
     cy.customMount(
       <FacetsFilters facets={[]} onFacetChange={cy.stub()} isLoadingCollectionItems={true} />
@@ -66,6 +71,61 @@ describe('FacetsFilters', () => {
     cy.findByRole('button', { name: /Department/ }).click()
 
     cy.wrap(onFacetChange).should('be.calledWith', 'dvCategory:Department', 'remove')
+  })
+
+  it('localizes controlled facet labels and counts without changing filter values', () => {
+    const onFacetChange = cy.stub().as('onFacetChange')
+    const localizedFacets: CollectionItemsFacet[] = [
+      {
+        name: 'subject_ss',
+        friendlyName: 'Subject',
+        labels: [
+          { name: 'Social Sciences', count: 53_305 },
+          { name: 'toString', count: 4_940 }
+        ]
+      },
+      {
+        name: 'authorName_ss',
+        friendlyName: 'Author Name',
+        labels: [{ name: 'García, Elena', count: 4_940 }]
+      },
+      {
+        name: 'authorAffiliation_ss',
+        friendlyName: 'Author Affiliation',
+        labels: [{ name: 'Harvard University', count: 4_940 }]
+      },
+      {
+        name: 'constructor',
+        friendlyName: 'Custom facet',
+        labels: [{ name: 'Law', count: 1 }]
+      }
+    ]
+
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(
+        <FacetsFilters
+          facets={localizedFacets}
+          onFacetChange={onFacetChange}
+          isLoadingCollectionItems={false}
+        />
+      )
+    })
+
+    cy.findByText('Tema').should('exist')
+    cy.findByText('Nombre del autor').should('exist')
+    cy.findByText('Afiliación del autor').should('exist')
+    cy.findByRole('button', { name: /Ciencias sociales/ })
+      .should('contain.text', 'Ciencias sociales (53.305)')
+      .click()
+    cy.findByRole('button', { name: /toString/ }).should('contain.text', 'toString (4940)')
+    cy.findByRole('button', { name: /García, Elena/ }).should(
+      'contain.text',
+      'García, Elena (4940)'
+    )
+    cy.findByRole('button', { name: /Harvard University/ }).should('exist')
+    cy.findByText('Custom facet').should('exist')
+    cy.findByRole('button', { name: /Law/ }).should('contain.text', 'Law (1)')
+    cy.wrap(onFacetChange).should('be.calledWith', 'subject_ss:Social Sciences', 'add')
   })
 
   it('show more and less functionality', () => {

--- a/tests/component/sections/collection/collection-items-panel/TypeFilters.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/TypeFilters.spec.tsx
@@ -1,7 +1,11 @@
 import { TypeFilters } from '@/sections/collection/collection-items-panel/filter-panel/type-filters/TypeFilters'
 import { CollectionItemType } from '@/collection/domain/models/CollectionItemType'
+import i18n from '@/i18n'
 
 describe('TypeFilters', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('sets default selected checkboxes based on current item types prop', () => {
     const onItemTypesChange = cy.stub().as('onItemTypesChange')
     cy.customMount(
@@ -16,6 +20,22 @@ describe('TypeFilters', () => {
     cy.findByRole('checkbox', { name: /Collections/ }).should('be.checked')
     cy.findByRole('checkbox', { name: /Datasets/ }).should('not.be.checked')
     cy.findByRole('checkbox', { name: /Files/ }).should('be.checked')
+  })
+
+  it('formats type counts with the active language', () => {
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(
+        <TypeFilters
+          onItemTypesChange={cy.stub()}
+          isLoadingCollectionItems={false}
+          currentItemTypes={[CollectionItemType.COLLECTION, CollectionItemType.DATASET]}
+          countPerObjectType={{ collections: 53_305, datasets: 4_940, files: 1 }}
+        />
+      )
+    })
+
+    cy.findByRole('checkbox', { name: /Colecciones \(53\.305\)/ }).should('exist')
+    cy.findByRole('checkbox', { name: /Datasets \(4940\)/ }).should('exist')
   })
 
   it('if there is only one selected checkbox this one is disabled so user can not deselect all of them', () => {

--- a/tests/component/sections/collection/collection-items-panel/file-card/FileCard.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/file-card/FileCard.spec.tsx
@@ -3,8 +3,13 @@ import { FileItemTypePreviewMother } from '@tests/component/files/domain/models/
 import { DateHelper } from '@/shared/helpers/DateHelper'
 import { FileCardHelper } from '@/sections/collection/collection-items-panel/items-list/file-card/FileCardHelper'
 import { PublicationStatus } from '@/shared/core/domain/models/PublicationStatus'
+import { FileLabelType } from '@/files/domain/models/FileMetadata'
+import i18n from '@/i18n'
 
 describe('FileCard', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('should render the card', () => {
     const userRoles = ['Admin', 'Contributor']
     const filePreview = FileItemTypePreviewMother.create({ userRoles: userRoles })
@@ -29,7 +34,10 @@ describe('FileCard', () => {
   })
 
   it('should render the card if file is tabular', () => {
-    const filePreview = FileItemTypePreviewMother.create({ fileType: 'Tab-Delimited' })
+    const filePreview = FileItemTypePreviewMother.create({
+      fileType: 'Tab-Delimited',
+      fileContentType: 'text/tab-separated-values'
+    })
     cy.customMount(<FileCard filePreview={filePreview} />)
 
     cy.contains(DateHelper.toDisplayFormat(filePreview.releaseOrCreateDate)).should('exist')
@@ -42,8 +50,10 @@ describe('FileCard', () => {
       filePreview.tags.forEach((tag) => {
         cy.findByText(tag.value).should('exist')
       })
-    filePreview.variables && cy.contains(filePreview.variables).should('exist')
-    filePreview.observations && cy.contains(filePreview.observations).should('exist')
+    filePreview.variables &&
+      cy.contains(new Intl.NumberFormat('en').format(filePreview.variables)).should('exist')
+    filePreview.observations &&
+      cy.contains(new Intl.NumberFormat('en').format(filePreview.observations)).should('exist')
   })
 
   it('should render the card if dateset is draft version', () => {
@@ -75,9 +85,30 @@ describe('FileCard', () => {
     cy.findByTestId('file-labels').children().should('have.length', 0)
   })
 
+  it('localizes the date, file type, system label, and tabular counts in Spanish', () => {
+    const filePreview = FileItemTypePreviewMother.create({
+      releaseOrCreateDate: new Date(2026, 8, 2, 12),
+      fileType: 'Tab-Delimited',
+      fileContentType: 'text/tab-separated-values',
+      variables: 53_305,
+      observations: 4_940,
+      tags: [{ value: 'Data', type: FileLabelType.CATEGORY }]
+    })
+
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(<FileCard filePreview={filePreview} />)
+    })
+
+    cy.findByText(/2 sept 2026/).should('exist')
+    cy.findByText('Valores separados por tabuladores').should('exist')
+    cy.findByText(/53\.305 variables, 4940 observaciones/).should('exist')
+    cy.findByText('Datos').should('have.class', 'bg-secondary')
+  })
+
   it('should default to 0 variables and 0 observations if file is tabular and they are not present', () => {
     const filePreview = FileItemTypePreviewMother.create({
       fileType: 'Tab-Delimited',
+      fileContentType: 'text/tab-separated-values',
       variables: undefined,
       observations: undefined
     })

--- a/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
+++ b/tests/component/sections/dataset/dataset-action-buttons/access-dataset-menu/AccessDatasetMenu.spec.tsx
@@ -14,6 +14,7 @@ import { AccessRepositoryProvider } from '@/sections/access/AccessRepositoryProv
 import { Guestbook } from '@/guestbooks/domain/models/Guestbook'
 import { GuestbookRepository } from '@/guestbooks/domain/repositories/GuestbookRepository'
 import { WithRepositories } from '@tests/component/WithRepositories'
+import i18n from '@/i18n'
 
 const guestbook: Guestbook = {
   id: 10,
@@ -72,6 +73,38 @@ function withAccessRepository(
 }
 
 describe('AccessDatasetMenu', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
+  it('updates download sizes when the interface language changes', () => {
+    cy.customMount(
+      withAccessRepository(
+        <Suspense fallback="loading">
+          <TranslationPreloader>
+            <AccessDatasetMenu
+              fileDownloadSizes={[
+                DatasetFileDownloadSizeMother.createOriginal({
+                  value: 180.3,
+                  unit: FileSizeUnit.KILOBYTES
+                })
+              ]}
+              hasOneTabularFileAtLeast={false}
+              version={DatasetVersionMother.createReleased()}
+              permissions={DatasetPermissionsMother.createWithFilesDownloadAllowed()}
+              fileStore="s3"
+              persistentId="doi:10.5072/FK2/ABCDEFGH"
+            />
+          </TranslationPreloader>
+        </Suspense>
+      )
+    )
+
+    cy.findByRole('button', { name: 'Access Dataset' }).click()
+    cy.findByText(/180\.3 KB/).should('be.visible')
+    cy.then(() => i18n.changeLanguage('es'))
+    cy.findByText(/180,3 KB/).should('be.visible')
+  })
+
   it('renders the AccessDatasetMenu if the user has download files permissions and the dataset is not deaccessioned', () => {
     const version = DatasetVersionMother.createReleased()
     const permissions = DatasetPermissionsMother.createWithFilesDownloadAllowed()

--- a/tests/component/sections/dataset/dataset-files/files-table/files-info/file-info-cell/file-info-data/FileDownloads.spec.tsx
+++ b/tests/component/sections/dataset/dataset-files/files-table/files-info/file-info-cell/file-info-data/FileDownloads.spec.tsx
@@ -1,13 +1,30 @@
 import { DatasetPublishingStatus } from '../../../../../../../../../src/dataset/domain/models/Dataset'
 import { FileDownloads } from '../../../../../../../../../src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileDownloads'
+import i18n from '@/i18n'
 
 describe('FileDownloads', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('renders the number of downloads when file is RELEASED', () => {
     const downloads = 10
     const status = DatasetPublishingStatus.RELEASED
     cy.customMount(<FileDownloads downloadCount={downloads} datasetPublishingStatus={status} />)
 
     cy.findByText('10 Downloads').should('exist')
+  })
+
+  it('formats the download count with the active language', () => {
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(
+        <FileDownloads
+          downloadCount={53_305}
+          datasetPublishingStatus={DatasetPublishingStatus.RELEASED}
+        />
+      )
+    })
+
+    cy.findByText('53.305 Descargas').should('exist')
   })
 
   it('renders an empty fragment when file is not RELEASED', () => {

--- a/tests/component/sections/dataset/dataset-files/files-table/files-info/file-info-cell/file-info-data/FileTabularData.spec.tsx
+++ b/tests/component/sections/dataset/dataset-files/files-table/files-info/file-info-cell/file-info-data/FileTabularData.spec.tsx
@@ -1,7 +1,11 @@
 import { FileTabularData } from '../../../../../../../../../src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/file-info-data/FileTabularData'
 import styles from '../../../../../../../../../src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/FileInfoCell.module.scss'
+import i18n from '@/i18n'
 
 describe('FileTabularData', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('renders the tabular data and CopyToClipboardButton when tabularData is provided', () => {
     const tabularData = {
       variables: 10,
@@ -13,6 +17,16 @@ describe('FileTabularData', () => {
     cy.findByText(/10 Variables, 100 Observations/).should('exist')
     cy.findByText('UNF:6:xXw6...QZA==').should('exist')
     cy.findByRole('button', { name: /Copy to clipboard icon/ }).should('exist')
+  })
+
+  it('formats counts with the active language', () => {
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(
+        <FileTabularData tabularData={{ variables: 53_305, observations: 4_940, unf: undefined }} />
+      )
+    })
+
+    cy.findByText(/53\.305 Variables, 4940 Observaciones/).should('exist')
   })
 
   it('renders an empty fragment when tabularData is not provided', () => {

--- a/tests/component/sections/file/file-labels/FileLabels.spec.tsx
+++ b/tests/component/sections/file/file-labels/FileLabels.spec.tsx
@@ -1,8 +1,11 @@
 import { FileLabelType } from '../../../../../src/files/domain/models/FileMetadata'
 import { FileLabels } from '../../../../../src/sections/file/file-labels/FileLabels'
-import styles from '../../../../../src/sections/dataset/dataset-files/files-table/file-info/file-info-cell/FileInfoCell.module.scss'
+import i18n from '@/i18n'
 
 describe('FileLabels', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('renders labels with correct variants and values', () => {
     const labels = [
       { value: 'Category 1', type: FileLabelType.CATEGORY },
@@ -15,9 +18,21 @@ describe('FileLabels', () => {
     cy.findAllByText(/Tag/).should('have.class', 'bg-info')
   })
 
-  it('renders an empty fragment when no labels are provided', () => {
-    cy.customMount(<FileLabels labels={[]} />)
+  it('localizes system categories but preserves custom categories and tabular tags', () => {
+    const labels = [
+      { value: 'Data', type: FileLabelType.CATEGORY },
+      { value: 'Custom Category', type: FileLabelType.CATEGORY },
+      { value: 'constructor', type: FileLabelType.CATEGORY },
+      { value: 'Data', type: FileLabelType.TAG }
+    ]
 
-    cy.get(styles['labels-container']).should('not.exist')
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(<FileLabels labels={labels} />)
+    })
+
+    cy.findByText('Datos').should('have.class', 'bg-secondary')
+    cy.findByText('Custom Category').should('have.class', 'bg-secondary')
+    cy.findByText('constructor').should('have.class', 'bg-secondary')
+    cy.findByText('Data').should('have.class', 'bg-info')
   })
 })

--- a/tests/component/sections/file/file-metadata/FileMetadata.spec.tsx
+++ b/tests/component/sections/file/file-metadata/FileMetadata.spec.tsx
@@ -1,6 +1,6 @@
 import { FileMetadata as FileMetadataComponent } from '../../../../../src/sections/file/file-metadata/FileMetadata'
 import { FileMother } from '../../../files/domain/models/FileMother'
-import { FileSizeUnit } from '../../../../../src/files/domain/models/FileMetadata'
+import { FileLabelType, FileSizeUnit } from '../../../../../src/files/domain/models/FileMetadata'
 import {
   FileEmbargoMother,
   FileMetadataMother,
@@ -14,6 +14,7 @@ import { requireAppConfig } from '@/config'
 import { WithRepositories } from '@tests/component/WithRepositories'
 import { DatasetMockRepository } from '@/stories/dataset/DatasetMockRepository'
 import { type ComponentProps } from 'react'
+import i18n from '@/i18n'
 
 const appConfig = requireAppConfig()
 
@@ -25,6 +26,9 @@ const FileMetadata = (props: ComponentProps<typeof FileMetadataComponent>) => (
 )
 
 describe('FileMetadata', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   const mountFileMetadata = (props: Partial<ComponentProps<typeof FileMetadata>> = {}) => {
     cy.customMount(
       <FileMetadata
@@ -421,6 +425,25 @@ describe('FileMetadata', () => {
 
     cy.findByText('Size').should('exist')
     cy.findByText('123 B').should('exist')
+  })
+
+  it('formats file values using the active Spanish language', () => {
+    const metadata = FileMetadataMother.create({
+      size: FileSizeMother.create({ value: 180.3, unit: FileSizeUnit.KILOBYTES }),
+      type: FileTypeMother.createTabular(),
+      labels: [{ value: 'Data', type: FileLabelType.CATEGORY }],
+      tabularData: FileTabularDataMother.create({ variables: 53_305, observations: 4_940 })
+    })
+
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      mountFileMetadata({ metadata })
+    })
+
+    cy.findByText('180,3 KB').should('exist')
+    cy.findByText('Valores separados por tabuladores').should('exist')
+    cy.findByText('Datos').should('have.class', 'bg-secondary')
+    cy.findByText('53.305').should('exist')
+    cy.findByText('4940').should('exist')
   })
 
   it('renders the file type', () => {

--- a/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
+++ b/tests/component/sections/shared/pagination/PaginationResultsInfo.spec.tsx
@@ -2,8 +2,12 @@ import { FilePaginationInfo } from '../../../../../src/files/domain/models/FileP
 import { DatasetPaginationInfo } from '../../../../../src/dataset/domain/models/DatasetPaginationInfo'
 import { PaginationResultsInfo } from '../../../../../src/sections/shared/pagination/PaginationResultsInfo'
 import { PaginationInfo } from '../../../../../src/shared/pagination/domain/models/PaginationInfo'
+import i18n from '@/i18n'
 
 describe('PaginationResultsInfo', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
   it('shows the correct results info', () => {
     cy.customMount(
       <PaginationResultsInfo
@@ -12,6 +16,25 @@ describe('PaginationResultsInfo', () => {
     )
 
     cy.findByText('1 to 10 of 11 Items').should('exist')
+  })
+
+  it('formats result counts with the active language', () => {
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      cy.customMount(
+        <PaginationResultsInfo
+          paginationInfo={
+            new PaginationInfo<FilePaginationInfo | DatasetPaginationInfo>(
+              1,
+              10,
+              53_305,
+              'resultado'
+            )
+          }
+        />
+      )
+    })
+
+    cy.findByText('1 a 10 de 53.305 resultados').should('exist')
   })
 
   it('shows the correct results info when there is 1 item', () => {

--- a/tests/component/shared/helpers/DateHelper.spec.ts
+++ b/tests/component/shared/helpers/DateHelper.spec.ts
@@ -1,0 +1,21 @@
+import i18n from '@/i18n'
+import { DateHelper } from '@/shared/helpers/DateHelper'
+
+describe('DateHelper', () => {
+  beforeEach(() => cy.wrap(i18n.changeLanguage('en')))
+  afterEach(() => cy.wrap(i18n.changeLanguage('en')))
+
+  it('formats dates with the active i18next language instead of the browser locale', () => {
+    const date = new Date(2026, 8, 2, 12)
+
+    cy.wrap(i18n.changeLanguage('es')).then(() => {
+      expect(DateHelper.toDisplayFormat(date)).to.equal(
+        date.toLocaleDateString('es', {
+          year: 'numeric',
+          month: 'short',
+          day: 'numeric'
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
## What this PR does / why we need it:
- Format dates, file sizes, and counts using the active interface language.
- Localize known file types, system categories, facet headings, and Subject values.
- Preserve custom metadata, raw filter values, and dataset version identifiers.
- Prevent inherited object properties from being treated as translation keys.

## Which issue(s) this PR closes:
- Closes #1063

## Special notes for your reviewer:
Frontend-only changes; no backend API or dependency changes.

## Suggestions on how to test this:
- Switch between English and Spanish and verify dates, sizes, and counts.
- Add and remove translated facets.
- Verify custom values, including constructor and toString, remain unchanged.
- Verify download sizes update after changing the interface language.

Validation: 121 passing tests across 16 affected specs; Node 22 build,
scoped ESLint, Prettier, and browser component smoke checks passed.
Full backend E2E was not run.

## Does this PR introduce a user interface change?
Yes: localized display values and labels; no layout changes.

## Is there a release notes or changelog update needed?
Updated CHANGELOG.md under Unreleased / Fixed.

## Additional documentation:
None.
