### PR TITLE
fix(#894): display facet name alongside facet value in selected filter chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+﻿# Changelog
 
 All notable changes to **Dataverse Frontend** are documented here. We also maintain a separate [Design System Changelog](./packages/design-system/CHANGELOG.md) for component-specific changes.
 
@@ -27,6 +27,7 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Fixed
 
+- Display facet name alongside facet value in selected filter chips above search results (#894)
 - Edit Dataset Terms: navigate to the draft version of the dataset after saving changes to the terms, instead of the latest published version.
 - After saving on either Edit Template tab (Metadata or Terms), the user is redirected to the templates listing with a success toast instead of staying on the edit page.
 - Edit Template breadcrumb on the Terms page no longer renders the dataset's "Terms and Guestbook" label (templates have no guestbook).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-﻿# Changelog
+# Changelog
 
 All notable changes to **Dataverse Frontend** are documented here. We also maintain a separate [Design System Changelog](./packages/design-system/CHANGELOG.md) for component-specific changes.
 

--- a/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
+++ b/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+﻿import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { Stack } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'
@@ -371,6 +371,7 @@ export const CollectionItemsPanel = ({
         <Stack direction="vertical" gap={2}>
           {showSelectedFacets && facets.length > 0 && (
             <SelectedFacets
+              facets={facets}
               onRemoveFacet={(filterQuery: FilterQuery) =>
                 handleFacetChange(filterQuery, RemoveAddFacetFilter.REMOVE)
               }
@@ -408,3 +409,4 @@ export const CollectionItemsPanel = ({
     </section>
   )
 }
+

--- a/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
+++ b/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
@@ -1,4 +1,4 @@
-﻿import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
 import { Stack } from '@iqss/dataverse-design-system'
 import { useTranslation } from 'react-i18next'

--- a/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
+++ b/src/sections/collection/collection-items-panel/CollectionItemsPanel.tsx
@@ -409,4 +409,3 @@ export const CollectionItemsPanel = ({
     </section>
   )
 }
-

--- a/src/sections/collection/collection-items-panel/selected-facets/SelectedFacets.tsx
+++ b/src/sections/collection/collection-items-panel/selected-facets/SelectedFacets.tsx
@@ -1,29 +1,43 @@
-import { useTranslation } from 'react-i18next'
+﻿import { useTranslation } from 'react-i18next'
 import { Button } from '@iqss/dataverse-design-system'
 import { X as CloseIcon } from 'react-bootstrap-icons'
+import { CollectionItemsFacet } from '@/collection/domain/models/CollectionItemSubset'
 import { FilterQuery } from '@/collection/domain/models/CollectionSearchCriteria'
 import { CollectionHelper } from '../../CollectionHelper'
 import styles from './SelectedFacets.module.scss'
 
 interface SelectedFacetsProps {
+  facets?: CollectionItemsFacet[]
   selectedFilterQueries: FilterQuery[]
   onRemoveFacet: (filterQuery: FilterQuery) => void
   isLoadingCollectionItems: boolean
 }
 
 export const SelectedFacets = ({
+  facets = [],
   selectedFilterQueries,
   onRemoveFacet,
   isLoadingCollectionItems
 }: SelectedFacetsProps) => {
   const { t } = useTranslation('collection')
 
+  const getFacetLabel = (filterQuery: FilterQuery): string => {
+    const keyAndValue = CollectionHelper.splitFilterQueryKeyAndValue(filterQuery)
+    if (!keyAndValue) {
+      return 'Unknown'
+    }
+
+    const { filterQueryKey, filterQueryValue } = keyAndValue
+    const matchingFacet = facets.find((facet) => facet.name === filterQueryKey)
+    const facetName = matchingFacet ? matchingFacet.friendlyName : filterQueryKey
+
+    return `${facetName}: ${filterQueryValue}`
+  }
+
   return (
     <div className={styles['selected-facets-container']}>
       {selectedFilterQueries.map((filterQuery) => {
-        const keyAndValue = CollectionHelper.splitFilterQueryKeyAndValue(filterQuery)
-
-        const labelName = keyAndValue?.filterQueryValue || 'Unknown' // Fallback if split fails
+        const labelName = getFacetLabel(filterQuery)
 
         return (
           <Button

--- a/src/sections/collection/collection-items-panel/selected-facets/SelectedFacets.tsx
+++ b/src/sections/collection/collection-items-panel/selected-facets/SelectedFacets.tsx
@@ -1,4 +1,4 @@
-﻿import { useTranslation } from 'react-i18next'
+import { useTranslation } from 'react-i18next'
 import { Button } from '@iqss/dataverse-design-system'
 import { X as CloseIcon } from 'react-bootstrap-icons'
 import { CollectionItemsFacet } from '@/collection/domain/models/CollectionItemSubset'

--- a/tests/component/sections/collection/collection-items-panel/SelectedFacets.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/SelectedFacets.spec.tsx
@@ -1,4 +1,4 @@
-﻿import { CollectionItemsFacet } from '@/collection/domain/models/CollectionItemSubset'
+import { CollectionItemsFacet } from '@/collection/domain/models/CollectionItemSubset'
 import { FilterQuery } from '@/collection/domain/models/CollectionSearchCriteria'
 import { SelectedFacets } from '@/sections/collection/collection-items-panel/selected-facets/SelectedFacets'
 

--- a/tests/component/sections/collection/collection-items-panel/SelectedFacets.spec.tsx
+++ b/tests/component/sections/collection/collection-items-panel/SelectedFacets.spec.tsx
@@ -1,8 +1,37 @@
+﻿import { CollectionItemsFacet } from '@/collection/domain/models/CollectionItemSubset'
 import { FilterQuery } from '@/collection/domain/models/CollectionSearchCriteria'
 import { SelectedFacets } from '@/sections/collection/collection-items-panel/selected-facets/SelectedFacets'
 
+const mockFacets: CollectionItemsFacet[] = [
+  {
+    name: 'publicationDate',
+    friendlyName: 'Publication Year',
+    labels: [{ name: '2024', count: 10 }]
+  },
+  {
+    name: 'authorName',
+    friendlyName: 'Author',
+    labels: [{ name: 'Doe', count: 5 }]
+  }
+]
+
 describe('SelectedFacets', () => {
-  it('should render the correct selected facets', () => {
+  it('should render facet name and value correctly when matching facet exists', () => {
+    const onRemoveFacet = cy.stub().as('onRemoveFacet')
+
+    cy.customMount(
+      <SelectedFacets
+        facets={mockFacets}
+        selectedFilterQueries={['publicationDate:2024']}
+        onRemoveFacet={onRemoveFacet}
+        isLoadingCollectionItems={false}
+      />
+    )
+
+    cy.findByRole('button', { name: /Publication Year: 2024/ }).should('exist')
+  })
+
+  it('should fallback to filterQueryKey when no matching facet is found in facets prop', () => {
     const onRemoveFacet = cy.stub().as('onRemoveFacet')
 
     cy.customMount(
@@ -12,6 +41,9 @@ describe('SelectedFacets', () => {
         isLoadingCollectionItems={false}
       />
     )
+
+    cy.findByRole('button', { name: /Foo: Bar/ }).should('exist')
+    cy.findByRole('button', { name: /Foo2: Bar 2/ }).should('exist')
   })
 
   it('should call onRemoveFacet when clicking on a selected facet', () => {
@@ -19,19 +51,20 @@ describe('SelectedFacets', () => {
 
     cy.customMount(
       <SelectedFacets
-        selectedFilterQueries={['Foo:Bar', 'Foo:Doe']}
+        facets={mockFacets}
+        selectedFilterQueries={['publicationDate:2024', 'authorName:Doe']}
         onRemoveFacet={onRemoveFacet}
         isLoadingCollectionItems={false}
       />
     )
 
-    cy.findByRole('button', { name: /Bar/ }).click()
+    cy.findByRole('button', { name: /Publication Year: 2024/ }).click()
 
-    cy.wrap(onRemoveFacet).should('be.calledWith', 'Foo:Bar')
+    cy.wrap(onRemoveFacet).should('be.calledWith', 'publicationDate:2024')
 
-    cy.findByRole('button', { name: /Doe/ }).click()
+    cy.findByRole('button', { name: /Author: Doe/ }).click()
 
-    cy.wrap(onRemoveFacet).should('be.calledWith', 'Foo:Doe')
+    cy.wrap(onRemoveFacet).should('be.calledWith', 'authorName:Doe')
   })
 
   it('should disable the button when loading collection items', () => {
@@ -39,13 +72,14 @@ describe('SelectedFacets', () => {
 
     cy.customMount(
       <SelectedFacets
-        selectedFilterQueries={['Foo:Bar']}
+        facets={mockFacets}
+        selectedFilterQueries={['publicationDate:2024']}
         onRemoveFacet={onRemoveFacet}
         isLoadingCollectionItems={true}
       />
     )
 
-    cy.findByRole('button', { name: /Bar/ }).should('be.disabled')
+    cy.findByRole('button', { name: /Publication Year: 2024/ }).should('be.disabled')
   })
 
   it('should render "Unknown" when filter query split fails', () => {
@@ -53,7 +87,7 @@ describe('SelectedFacets', () => {
 
     cy.customMount(
       <SelectedFacets
-        selectedFilterQueries={['InvalidQuery'] as unknown as FilterQuery[]} // Casting to simulate a badly formatted filter query, should not happen but we want to test the fallback
+        selectedFilterQueries={['InvalidQuery'] as unknown as FilterQuery[]}
         onRemoveFacet={onRemoveFacet}
         isLoadingCollectionItems={false}
       />


### PR DESCRIPTION
## What this PR does / why we need it:
When selecting a facet filter in the collection items view, the filter chip above the results only displayed the facet value (e.g. `2024 ×`) instead of the facet name and value combined (e.g. `Publication Year: 2024 ×`). 

This PR:
- Passes the existing `facets` list from `CollectionItemsPanel` to `SelectedFacets`.
- Updates `SelectedFacets` to look up the facet's `friendlyName` by matching `filterQueryKey`, rendering `<Facet Name>: <Facet Value>`.
- Keeps a clean fallback to `filterQueryKey` if no matching facet object is found.
- Updates component specs to verify facet name rendering, click removal, and fallback handling.

## Which issue(s) this PR closes:

- Closes #894

## Special notes for your reviewer:
- **Backend check:** No backend or `js-dataverse` change is needed. The `CollectionItemsFacet` model already provides `name` and `friendlyName` in the frontend.
- Since local installation of the `@IQSS/dataverse-client-javascript` package requires GitHub registry authentication, I verified the logic and test cases via isolated execution. I look forward to CI checks on this PR.

## Suggestions on how to test this:
1. Navigate to a collection page with facets (e.g., Publication Year, Subject, etc.).
2. Select any facet value (for example, under **Publication Year**, select **2024**).
3. Observe the applied filter chip above the search results: it should display `Publication Year: 2024 ×` instead of just `2024 ×`.
4. Click the `×` button on the chip and verify the filter is removed as expected.
5. Run component tests:
   `cypress run --component --spec "tests/component/sections/collection/collection-items-panel/SelectedFacets.spec.tsx"`

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
Yes. Applied facet filter buttons above results now render `<Facet Name>: <Facet Value> ×` instead of only `<Facet Value> ×`.

## Is there a release notes or changelog update needed for this change?:
Yes, updated `CHANGELOG.md` under `[Unreleased] -> ### Fixed`.

## Additional documentation:
None.