### PR TITLE
fix(#1003): fallback to draft version on dataset page when no version…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This changelog follows the principles of [Keep a Changelog](https://keepachangel
 
 ### Fixed
 
+- Dataset Page: show draft version if user has permission when no version param is provided (#1003)
+
 - Edit Dataset Terms: navigate to the draft version of the dataset after saving changes to the terms, instead of the latest published version.
 - After saving on either Edit Template tab (Metadata or Terms), the user is redirected to the templates listing with a success toast instead of staying on the edit page.
 - Edit Template breadcrumb on the Terms page no longer renders the dataset's "Terms and Guestbook" label (templates have no guestbook).

--- a/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
+++ b/src/dataset/infrastructure/repositories/DatasetJSDataverseRepository.ts
@@ -275,7 +275,18 @@ export class DatasetJSDataverseRepository implements DatasetRepository {
       })
       .catch((error: ReadError) => {
         console.error(error)
-        if (version === DatasetNonNumericVersion.LATEST_PUBLISHED) {
+        if (!requestedVersion && version === DatasetNonNumericVersion.LATEST_PUBLISHED) {
+          return this.getByPersistentId(
+            persistentId,
+            DatasetNonNumericVersion.DRAFT,
+            requestedVersion,
+            keepRawFields
+          )
+        }
+        if (
+          version === DatasetNonNumericVersion.LATEST_PUBLISHED ||
+          version === DatasetNonNumericVersion.DRAFT
+        ) {
           throw new Error(`Failed to get dataset by persistent ID: ${error.message}`)
         }
         return this.getByPersistentId(


### PR DESCRIPTION
## What this PR does / why we need it:
When accessing a dataset page without an explicit version query parameter, the repository defaults to fetching `:latest-published`. For draft-only datasets, this request returns a 404 error, preventing authorized users (such as creators accessing datasets from notifications) from viewing their draft dataset.

This PR updates `DatasetJSDataverseRepository.getByPersistentId`:
- When no `requestedVersion` is provided and the initial `:latest-published` request fails, it attempts a fallback to `:draft`.
- If the `:draft` request also fails (e.g. for unauthorized users lacking draft-view permissions), it throws the error normally.
- If an explicit version was requested, existing behavior remains unchanged.

## Which issue(s) this PR closes:

- Closes #1003

## Special notes for your reviewer:
- Handled at the repository layer (`DatasetJSDataverseRepository`) as discussed in the issue thread.
- Preserves existing fallback logic when explicit versions are supplied.

## Suggestions on how to test this:
1. Create a draft-only dataset.
2. Navigate to the dataset URL without a `version` query parameter (`/datasets?persistentId=<doi>`).
3. Verify that the draft version loads successfully for authorized users instead of throwing a 404 error.
4. Access the same URL as an anonymous/unauthorized user and verify that the request fails as expected.

## Does this PR introduce a user interface change? If mockups are available, please link/include them here:
No.

## Is there a release notes or changelog update needed for this change?:
Yes, updated `CHANGELOG.md` under `[Unreleased] -> ### Fixed`.

## Additional documentation:
None.